### PR TITLE
refactor, new geospatial service, ability to add temp layer

### DIFF
--- a/client/app/admin/create-project/create-project.controller.js
+++ b/client/app/admin/create-project/create-project.controller.js
@@ -340,18 +340,6 @@
          };
 
         /**
-         * Add layer
-         * Supported types: 
-         *  - XYZ
-         * @param url
-         */
-        vm.addLayer = function(url){
-            if (url) {
-                mapService.addXYZLayer('temporary', url);
-            }
-        };
-
-        /**
          * Create a new project with a project name
          */
         vm.createProject = function(){

--- a/client/app/admin/create-project/create-project.html
+++ b/client/app/admin/create-project/create-project.html
@@ -185,6 +185,9 @@
                 </div>
             </div>
             <div id="map" class="map-container">
+                <div class="add-layer-control">
+                    <add-layer></add-layer>
+                </div>
             </div>
         </div>
     </section>

--- a/client/app/admin/create-project/create-project.html
+++ b/client/app/admin/create-project/create-project.html
@@ -185,8 +185,14 @@
                 </div>
             </div>
             <div id="map" class="map-container">
-                <div class="add-layer-control">
-                    <add-layer></add-layer>
+                <div class="add-layer-control ol-control">
+                    <button type="button" class="button"
+                            ng-click="createProjectCtrl.isVisible = !createProjectCtrl.isVisible">
+                        <i class="oam-ds-icon-hamburger-menu"></i>
+                    </button>
+                </div>
+                <div class="add-layer-panel">
+                    <add-layer ng-show="createProjectCtrl.isVisible"></add-layer>
                 </div>
             </div>
         </div>

--- a/client/app/components/add-layer/add-layer.directive.js
+++ b/client/app/components/add-layer/add-layer.directive.js
@@ -1,0 +1,56 @@
+(function () {
+
+    'use strict';
+
+    /**
+     * @fileoverview This file provides a add layer directive. 
+     * Users can provide a URL and choose a type of layer/source which will then get added to the map
+     * It depends on the mapService which provides the functionality to actually add the layer to the map
+     */
+
+    angular
+        .module('taskingManager')
+        .controller('addLayerController', ['mapService', addLayerController])
+        .directive('addLayer', addLayerDirective);
+
+    /**
+     * Creates add-layer directive
+     * Example:
+     *
+     * <add-layer></add-layer>
+     */
+    function addLayerDirective() {
+
+        var directive = {
+            restrict: 'EA',
+            templateUrl: 'app/components/add-layer/add-layer.html',
+            controller: 'addLayerController',
+            controllerAs: 'addLayerCtrl',
+            bindToController: true // because the scope is isolated
+        };
+
+        return directive;
+    }
+
+    function addLayerController(mapService) {
+
+        var vm = this;
+        vm.type = 'xyz';
+        vm.layerURL = '';
+        
+         /**
+         * Add layer
+         * Supported types: 
+         *  - XYZ
+         * @param url
+         */
+        vm.addLayer = function(){
+            if (vm.layerURL) {
+                if (vm.type === 'xyz'){
+                    // Use the type as the layer name
+                    mapService.addXYZLayer(vm.type + ' (temporary)', vm.layerURL, true);
+                }
+            }
+        };
+    }
+})();

--- a/client/app/components/add-layer/add-layer.directive.js
+++ b/client/app/components/add-layer/add-layer.directive.js
@@ -37,6 +37,7 @@
         var vm = this;
         vm.type = 'xyz';
         vm.layerURL = '';
+        vm.isVisible = false;
         
          /**
          * Add layer
@@ -52,5 +53,9 @@
                 }
             }
         };
+
+        vm.toggleVisibility = function(){
+            vm.isVisible = !vm.isVisible;
+        }
     }
 })();

--- a/client/app/components/add-layer/add-layer.html
+++ b/client/app/components/add-layer/add-layer.html
@@ -1,0 +1,19 @@
+<div class="form__group">
+    <span>
+        <div class="form__input-group">
+        <input type="text" class="form__control form__control--small"
+             placeholder="Map URL"
+             ng-model="addLayerCtrl.layerURL">
+          <span class="form__input-group-button">
+               <select class="button button--achromic button--small" ng-model="addLayerCtrl.type">
+                   <option value="xyz">XYZ</option>
+                </select>
+              <button type="submit"
+                      ng-click="addLayerCtrl.addLayer()"
+                      class="button button--secondary button--small">
+                Add layer
+              </button>
+          </span>
+        </div>
+    </span>
+</div>

--- a/client/app/components/add-layer/add-layer.html
+++ b/client/app/components/add-layer/add-layer.html
@@ -1,19 +1,21 @@
-<div class="form__group">
-    <span>
-        <div class="form__input-group">
+<div class="add-layer-wrapper">
+    <div class="form__input-group">
+        <label class="form__label">Map service URL</label>
         <input type="text" class="form__control form__control--small"
-             placeholder="Map URL"
-             ng-model="addLayerCtrl.layerURL">
-          <span class="form__input-group-button">
-               <select class="button button--achromic button--small" ng-model="addLayerCtrl.type">
-                   <option value="xyz">XYZ</option>
-                </select>
-              <button type="submit"
-                      ng-click="addLayerCtrl.addLayer()"
-                      class="button button--secondary button--small">
-                Add layer
-              </button>
-          </span>
-        </div>
-    </span>
+               placeholder="Map URL"
+               ng-model="addLayerCtrl.layerURL">
+    </div>
+    <div class="form__input-group">
+        <label class="form__label">Map service type</label>
+        <select class="button button--achromic button--small pull-right" ng-model="addLayerCtrl.type">
+            <option value="xyz">XYZ (e.g. MapBox)</option>
+        </select>
+    </div>
+    <div class="form__input-group">
+        <button type="submit"
+                ng-click="addLayerCtrl.addLayer()"
+                class="button button--secondary button--small pull-right">
+            Add layer
+        </button>
+    </div>
 </div>

--- a/client/app/services/draw.service.js
+++ b/client/app/services/draw.service.js
@@ -80,6 +80,8 @@
             var vector = new ol.layer.Vector({
                 source: source
             });
+            // Use a high Z index to ensure it draws on top of other layers
+            vector.setZIndex(100);
             map.addLayer(vector);
         }
 

--- a/client/app/services/geospatial.service.js
+++ b/client/app/services/geospatial.service.js
@@ -1,0 +1,117 @@
+(function () {
+    'use strict';
+    /**
+     * @fileoverview This file provides a geospatial helper service using OpenLayers
+     */
+
+    angular
+        .module('taskingManager')
+        .service('geospatialService', [geospatialService]);
+
+    function geospatialService() {
+        
+        // Target projection for Turf.js / TM API
+        var DATA_PROJECTION = 'EPSG:4326';
+
+        // Map projection in OpenLayers
+        var MAP_PROJECTION = 'EPSG:3857';
+
+        var service = {
+            getFeaturesFromGeoJSON: getFeaturesFromGeoJSON,
+            getFeaturesFromKML: getFeaturesFromKML,
+            getGeoJSONFromFeature: getGeoJSONFromFeature,
+            getGeoJSONObjectFromFeature: getGeoJSONObjectFromFeature,
+            getGeoJSONFromFeatures: getGeoJSONFromFeatures,
+            getGeoJSONObjectFromFeatures: getGeoJSONObjectFromFeatures
+        };
+
+        return service;
+
+        /**
+         * Get OL features from GeoJSON
+         * @param {string} geojson
+         * @returns {Array.<ol.Feature>}
+         */
+        function getFeaturesFromGeoJSON(geojson){
+            var format = new ol.format.GeoJSON();
+            var features = format.readFeatures(geojson, {
+                dataProjection: DATA_PROJECTION,
+                featureProjection: MAP_PROJECTION
+            });
+            return features;
+        }
+
+        /**
+         * Get OL features from GeoJSON
+         * @param {string} kml
+         * @returns {Array.<ol.Feature>}
+         */
+        function getFeaturesFromKML(kml){
+            var format = new ol.format.KML({
+                extractStyles: false,
+                showPointNames: false
+            });
+            var features = format.readFeatures(kml, {
+                dataProjection: DATA_PROJECTION,
+                featureProjection: MAP_PROJECTION
+            });
+            return features;
+        }
+
+        /**
+         * Get GeoJSON string from an OL Feature
+         * @param ol.Feature
+         * @returns {string} geojson
+         */
+        function getGeoJSONFromFeature(feature){
+            var format = new ol.format.GeoJSON();
+            var geojson = format.writeFeature(feature, {
+                dataProjection: DATA_PROJECTION,
+                featureProjection: MAP_PROJECTION
+            });
+            return geojson;
+        }
+
+        /**
+         * Get GeoJSON object from an OL Feature
+         * @param ol.Feature
+         * @returns {object} geojson
+         */
+        function getGeoJSONObjectFromFeature(feature){
+            var format = new ol.format.GeoJSON();
+            var geojsonObject = format.writeFeatureObject(feature, {
+                dataProjection: DATA_PROJECTION,
+                featureProjection: MAP_PROJECTION
+            });
+            return geojsonObject;
+        }
+
+        /**
+         * Get GeoJSON string from OL Features
+         * @param features
+         * @returns {string} geojson
+         */
+        function getGeoJSONFromFeatures(features){
+            var format = new ol.format.GeoJSON();
+            var geojson = format.writeFeatures(features, {
+                dataProjection: DATA_PROJECTION,
+                featureProjection: MAP_PROJECTION
+            });
+            return geojson;
+        }
+
+        /**
+         * Get GeoJSON object from OL Features
+         * @param features
+         * @returns {object} geojson
+         */
+        function getGeoJSONObjectFromFeatures(features){
+            var format = new ol.format.GeoJSON();
+            var geojsonObject = format.writeFeaturesObject(features, {
+                dataProjection: DATA_PROJECTION,
+                featureProjection: MAP_PROJECTION
+            });
+            return geojsonObject;
+        }
+    }
+})();

--- a/client/app/services/map.service.js
+++ b/client/app/services/map.service.js
@@ -16,7 +16,8 @@
         var service = {
             createOSMMap: createOSMMap,
             getOSMMap: getOSMMap,
-            addXYZLayer: addXYZLayer
+            addXYZLayer: addXYZLayer,
+            addGeocoder: addGeocoder
         };
 
         return service;
@@ -83,9 +84,13 @@
         /**
          * Adds a XYZ layer to the map
          */
-        function addXYZLayer(name, url){
+        function addXYZLayer(name, url, visible){
+            var visibility = false;
+            if (visible){
+                visibility = true;
+            }
             var aerialLayer = new ol.layer.Tile({
-                visible: false,
+                visible: visibility,
                 preload: Infinity,
                 title: name,
                 type: 'base',
@@ -94,6 +99,35 @@
                 })
             });
             map.addLayer(aerialLayer);
+        }
+        
+        /**
+         * Adds a geocoder control to the map
+         * It is using an OpenLayers plugin control
+         * For more info and options, please see https://github.com/jonataswalker/ol3-geocoder
+         * @private
+         */
+        function addGeocoder(){
+
+            // Initialise the geocoder
+            var geocoder = new Geocoder('nominatim', {
+                provider: 'osm',
+                lang: 'en',
+                placeholder: 'Search for ...',
+                targetType: 'glass-button',
+                limit: 5,
+                keepOpen: true,
+                preventDefault: true
+            });
+            map.addControl(geocoder);
+
+            // By setting the preventDefault to false when initialising the Geocoder, you can add your own event
+            // handler which has been done here.
+            geocoder.on('addresschosen', function(evt){
+                map.getView().setCenter(evt.coordinate);
+                // It is assumed that most people will search for cities. Zoom level 12 seems most appropriate
+                map.getView().setZoom(12);
+            });
         }
     }
 })();

--- a/client/app/services/project.service.js
+++ b/client/app/services/project.service.js
@@ -65,6 +65,8 @@
             var vector = new ol.layer.Vector({
                 source: taskGridSource
             });
+            // Use a high Z index to ensure it draws on top of other layers
+            vector.setZIndex(100);
             map.addLayer(vector);
         }
 

--- a/client/app/services/project.service.js
+++ b/client/app/services/project.service.js
@@ -3,7 +3,7 @@
 
     angular
         .module('taskingManager')
-        .service('projectService', ['$http', '$q', 'mapService','configService', projectService]);
+        .service('projectService', ['$http', '$q', 'mapService','configService', 'geospatialService', projectService]);
 
     /**
      * @fileoverview This file provides a project service.
@@ -11,19 +11,13 @@
      * The task grid matches up with OSM's grid.
      * Code is similar to Tasking Manager 2 (where this was written server side in Python)
      */
-    function projectService($http, $q, mapService, configService) {
+    function projectService($http, $q, mapService, configService, geospatialService) {
 
         // Maximum resolution of OSM
         var MAXRESOLUTION = 156543.0339;
 
         // X/Y axis offset
         var AXIS_OFFSET = MAXRESOLUTION * 256 / 2;
-
-        // Target projection for Turf.js
-        var TARGETPROJECTION = 'EPSG:4326';
-
-        // Map projection in OpenLayers
-        var MAPPROJECTION = 'EPSG:3857';
 
         var map = null;
         var taskGrid = null;
@@ -83,16 +77,8 @@
         function createTaskGrid(areaOfInterest, zoomLevel) {
 
             var zoomLevel = zoomLevel;
-
             var extent = areaOfInterest.getGeometry().getExtent();
-
-            var format = new ol.format.GeoJSON();
-
-            // Convert feature to GeoJSON for Turf.js to process
-            var areaOfInterestGeoJSON = format.writeFeature(areaOfInterest, {
-                dataProjection: TARGETPROJECTION,
-                featureProjection: MAPPROJECTION
-            });
+            var areaOfInterestGeoJSON = geospatialService.getGeoJSONFromFeature(areaOfInterest);
 
             var xmin = Math.ceil(extent[0]);
             var ymin = Math.ceil(extent[1]);
@@ -113,11 +99,7 @@
             for (var x = xminstep; x < xmaxstep; x++) {
                 for (var y = yminstep; y < ymaxstep; y++) {
                     var taskFeature = createTaskFeature_(step, x, y);
-                    // Write the feature as GeoJSON and transform to the projection Turf.js needs
-                    var taskFeatureGeoJSON = format.writeFeature(taskFeature, {
-                        dataProjection: TARGETPROJECTION,
-                        featureProjection: MAPPROJECTION
-                    });
+                    var taskFeatureGeoJSON = geospatialService.getGeoJSONFromFeature(taskFeature);
                     // Check if the generated task feature intersects with the area of interest
                     var intersection = turf.intersect(JSON.parse(taskFeatureGeoJSON), JSON.parse(areaOfInterestGeoJSON));
                     // Add the task feature to the array if it intersects
@@ -166,12 +148,7 @@
          * @returns {number} the size of the task
          */
         function getTaskSize(){
-            // Write the feature as GeoJSON and transform to the projection Turf.js needs
-            var format = new ol.format.GeoJSON();
-            var taskGeoJSON = format.writeFeature(taskGrid[0], {
-                dataProjection: TARGETPROJECTION,
-                featureProjection: MAPPROJECTION
-            });
+            var taskGeoJSON = geospatialService.getGeoJSONFromFeature(taskGrid[0]);
             return turf.area(JSON.parse(taskGeoJSON)) / 1000000;
         }
 
@@ -305,21 +282,11 @@
          */
         function splitTasks(drawnPolygon){
 
-            var format = new ol.format.GeoJSON();
-
-            // Write the polygon as GeoJSON and transform to the projection Turf.js needs
-            var drawnPolygonGeoJSON = format.writeFeatureObject(drawnPolygon, {
-                dataProjection: TARGETPROJECTION,
-                featureProjection: MAPPROJECTION
-            });
+            var drawnPolygonGeoJSON = geospatialService.getGeoJSONObjectFromFeature(drawnPolygon);
             
             var newTaskGrid = [];
             for (var i = 0; i < taskGrid.length; i++){
-                // Write the feature as GeoJSON and transform to the projection Turf.js needs
-                var taskGeoJSON = format.writeFeatureObject(taskGrid[i], {
-                    dataProjection: TARGETPROJECTION,
-                    featureProjection: MAPPROJECTION
-                });
+                var taskGeoJSON = geospatialService.getGeoJSONObjectFromFeature(taskGrid[i]);
                 // Check if the task intersects with the drawn polygon
                 var intersection = turf.intersect(drawnPolygonGeoJSON, taskGeoJSON);
                 // If the task doesn't intersect with the drawn polygon, copy the existing task into the new task grid
@@ -358,39 +325,24 @@
          * @param feature - has to be a Polygon
          * @returns {boolean}
          */
-        function checkFeatureSelfIntersections_(feature){
-            var format = new ol.format.GeoJSON();
-            var hasSelfIntersections = false;
-            var feature_as_gj = format.writeFeatureObject(feature, {
-                dataProjection: TARGETPROJECTION,
-                featureProjection: MAPPROJECTION
-            });
-            if (turf.kinks(feature_as_gj).features.length > 0) {
-                hasSelfIntersections = true;
-            }
-            return hasSelfIntersections;
-        }
+         function checkFeatureSelfIntersections_(feature) {
+             var hasSelfIntersections = false;
+             var featureAsGeoJSON = geospatialService.getGeoJSONObjectFromFeature(feature);
+             if (turf.kinks(featureAsGeoJSON).features.length > 0) {
+                 hasSelfIntersections = true;
+             }
+             return hasSelfIntersections;
+         }
 
         /**
          * Creates a project by calling the API with the AOI, a task grid and a project name
          * @returns {*|!jQuery.jqXHR|!jQuery.Promise|!jQuery.deferred}
          */
         function createProject(projectName){
+
+            var areaOfInterestGeoJSON = geospatialService.getGeoJSONObjectFromFeatures(aoi);
+            var taskGridGeoJSON = geospatialService.getGeoJSONObjectFromFeatures(taskGrid);
             
-            var format = new ol.format.GeoJSON();
-
-            // Write the feature as a GeoJSON object and transform to the projection the API needs
-            var areaOfInterestGeoJSON = format.writeFeaturesObject(aoi, {
-                dataProjection: TARGETPROJECTION,
-                featureProjection: MAPPROJECTION
-            });
-
-            // Write the features as a GeoJSON object and transform to the projection the API needs
-            var taskGridGeoJSON = format.writeFeaturesObject(taskGrid, {
-                dataProjection: TARGETPROJECTION,
-                featureProjection: MAPPROJECTION
-            });
-
             // Get the geometry of the area of interest. It should only have one feature.
             var newProject = {
                 areaOfInterest: areaOfInterestGeoJSON.features[0].geometry,

--- a/client/assets/styles/sass/_admin.scss
+++ b/client/assets/styles/sass/_admin.scss
@@ -39,6 +39,7 @@
   .map-container {
     float: left;
     height: inherit;
+    position: relative;
     @include span(7/12);
 
     @include media(medium-up) {

--- a/client/assets/styles/sass/_map.scss
+++ b/client/assets/styles/sass/_map.scss
@@ -20,3 +20,10 @@
   bottom: 3em;
   top: auto;
 }
+
+.add-layer-control {
+  right: 0.5em;
+  position: absolute;
+  width: 300px;
+  z-index: 1000;
+}

--- a/client/assets/styles/sass/_map.scss
+++ b/client/assets/styles/sass/_map.scss
@@ -21,9 +21,26 @@
   top: auto;
 }
 
-.add-layer-control {
-  right: 0.5em;
+/** Add layer control **/
+.add-layer-control{
+  top: 0.5rem;
+  right: 0.5rem;
   position: absolute;
-  width: 300px;
   z-index: 1000;
+}
+
+.add-layer-panel {
+  top: 3rem;
+  right: 0.5rem;
+  position: absolute;
+  z-index: 1000;
+}
+
+.add-layer-wrapper {
+    background:rgba(255,255,255, 0.9);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    select {
+      width: 100%;
+    }
 }

--- a/client/index.html
+++ b/client/index.html
@@ -144,6 +144,8 @@
 <script src="app/services/style.service.js"></script>
 <script src="app/services/draw.service.js"></script>
 <script src="app/services/task.service.js"></script>
+<script src="app/services/geospatial.service.js"></script>
+<script src="app/components/add-layer/add-layer.directive.js"></script>
 <!-- /build -->
 
 </body>

--- a/tests/client/unit/app/components/test.add-layer.directive.js
+++ b/tests/client/unit/app/components/test.add-layer.directive.js
@@ -1,0 +1,20 @@
+'use strict';
+
+describe('add-layer.directive', function () {
+    var addLayerController, mapService = null;
+
+    beforeEach(function () {
+        module('taskingManager');
+
+
+         inject(function ($controller, _mapService_) {
+            _mapService_.createOSMMap();
+             mapService = _mapService_;
+             addLayerController = $controller('addLayerController', {mapService: _mapService_});
+         });
+    });
+
+    it('should be created successfully', function () {
+        expect(addLayerController).toBeDefined()
+    });
+});


### PR DESCRIPTION
- Added ability to add 'temporary' layer on the fly during project creation. At the moment it only supports XYZ layers such as MapBox. To test, use this URL: https://api.mapbox.com/v4/openstreetmap.map-inh7ifmo/{z}/{x}/{y}.png?access_token=pk.eyJ1Ijoib3BlbnN0cmVldG1hcCIsImEiOiJhNVlHd29ZIn0.ti6wATGDWOmCnCYen-Ip7Q
The layer is then also added to the layer switcher and can be switched off.
- Refactor of conversion between GeoJSON and ol features. A new geospatial service handles these conversions.
