### PR TITLE
add WMS support adding layers on the fly

### DIFF
--- a/client/app/components/add-layer/add-layer.directive.js
+++ b/client/app/components/add-layer/add-layer.directive.js
@@ -37,12 +37,14 @@
         var vm = this;
         vm.type = 'xyz';
         vm.layerURL = '';
+        vm.layerName = '';
         vm.isVisible = false;
         
          /**
          * Add layer
          * Supported types: 
          *  - XYZ
+         *  - WMS (tiled)
          * @param url
          */
         vm.addLayer = function(){
@@ -50,6 +52,9 @@
                 if (vm.type === 'xyz'){
                     // Use the type as the layer name
                     mapService.addXYZLayer(vm.type + ' (temporary)', vm.layerURL, true);
+                }
+                if (vm.type === 'wms'){
+                    mapService.addTiledWMSLayer(vm.type + ' (temporary)', vm.layerURL, vm.layerName, true);
                 }
             }
         };

--- a/client/app/components/add-layer/add-layer.html
+++ b/client/app/components/add-layer/add-layer.html
@@ -1,15 +1,22 @@
 <div class="add-layer-wrapper">
     <div class="form__input-group">
+        <label class="form__label">Map service type</label>
+        <select class="button button--achromic button--small pull-right" ng-model="addLayerCtrl.type">
+            <option value="xyz">XYZ (e.g. MapBox)</option>
+            <option value="wms">WMS (tiled)</option>
+        </select>
+    </div>
+    <div class="form__input-group">
         <label class="form__label">Map service URL</label>
         <input type="text" class="form__control form__control--small"
                placeholder="Map URL"
                ng-model="addLayerCtrl.layerURL">
     </div>
-    <div class="form__input-group">
-        <label class="form__label">Map service type</label>
-        <select class="button button--achromic button--small pull-right" ng-model="addLayerCtrl.type">
-            <option value="xyz">XYZ (e.g. MapBox)</option>
-        </select>
+    <div ng-show="addLayerCtrl.type === 'wms'" class="form__input-group">
+        <label class="form__label">Layer name</label>
+        <input type="text" class="form__control form__control--small"
+               placeholder="Layer name"
+               ng-model="addLayerCtrl.layerName">
     </div>
     <div class="form__input-group">
         <button type="submit"

--- a/client/app/components/add-layer/add-layer.html
+++ b/client/app/components/add-layer/add-layer.html
@@ -1,7 +1,7 @@
 <div class="add-layer-wrapper">
     <div class="form__input-group">
         <label class="form__label">Map service type</label>
-        <select class="button button--achromic button--small pull-right" ng-model="addLayerCtrl.type">
+        <select class="form__control form__control--small pull-right" ng-model="addLayerCtrl.type">
             <option value="xyz">XYZ (e.g. MapBox)</option>
             <option value="wms">WMS (tiled)</option>
         </select>

--- a/client/app/services/map.service.js
+++ b/client/app/services/map.service.js
@@ -17,6 +17,7 @@
             createOSMMap: createOSMMap,
             getOSMMap: getOSMMap,
             addXYZLayer: addXYZLayer,
+            addTiledWMSLayer: addTiledWMSLayer,
             addGeocoder: addGeocoder
         };
 
@@ -27,6 +28,7 @@
          * with additional layers. 
          * Supported additional layers:
          *    - XYZ
+         *    - WMS
          * @param targetElement
          */
         function createOSMMap(targetElement){
@@ -55,6 +57,9 @@
                 for (var i = 0; i < additionalLayers.length; i++) {
                     if (additionalLayers[i].type === 'XYZ') {
                         addXYZLayer(additionalLayers[i].name, additionalLayers[i].url);
+                    }
+                    if (additionalLayers[i].type === 'WMS'){
+                        addTiledWMSLayer(additionalLayers[i].name, additionalLayers[i].url, additionalLayers[i].layerName)
                     }
                 }
             }
@@ -99,6 +104,32 @@
                 })
             });
             map.addLayer(aerialLayer);
+        }
+
+        /**
+         * Add tiled WMS layer
+         * @param name
+         * @param url
+         * @param layer
+         * @param visible
+         */
+        function addTiledWMSLayer(name, url, layer, visible){
+            var visibility = false;
+            if (visible){
+                visibility = true;
+            }
+            var wmsLayer = new ol.layer.Tile({
+                visible: visibility,
+                title: name,
+                type: 'base',
+                source: new ol.source.TileWMS({
+                    url: url,
+                    params: {
+                        'LAYERS': layer
+                    }
+                })
+            });
+            map.addLayer(wmsLayer);
         }
         
         /**

--- a/client/taskingmanager.config.json
+++ b/client/taskingmanager.config.json
@@ -8,6 +8,13 @@
           "name": "MapBox Aerial",
           "url": "https://api.mapbox.com/v4/openstreetmap.map-inh7ifmo/{z}/{x}/{y}.png?access_token=pk.eyJ1Ijoib3BlbnN0cmVldG1hcCIsImEiOiJhNVlHd29ZIn0.ti6wATGDWOmCnCYen-Ip7Q",
           "type": "XYZ"
+        },
+        {
+          "id": "Population density WMS",
+          "name": "Population density",
+          "url": "http://sedac.ciesin.columbia.edu/geoserver/wms",
+          "layerName": "gpw-v3:gpw-v3-population-density-future-estimates_2005",
+          "type": "WMS"
         }
       ]
     }


### PR DESCRIPTION
Add WMS support for adding layers on the fly. Also for adding them as default layers for the layer switcher, I've added a WMS in the config file for DEV for demo purposes.

To test:
WMS url: http://sedac.ciesin.columbia.edu/geoserver/wms
Layer name: gpw-v3:gpw-v3-population-density-future-estimates_2005