### PR TITLE
Validate that we have all fields on default locale info

### DIFF
--- a/server/api/project_admin_api.py
+++ b/server/api/project_admin_api.py
@@ -1,7 +1,7 @@
 from flask_restful import Resource, request, current_app
 from schematics.exceptions import DataError
 from server.models.dtos.project_dto import DraftProjectDTO, ProjectDTO
-from server.services.project_service import ProjectService, InvalidGeoJson, InvalidData
+from server.services.project_admin_service import ProjectAdminService, InvalidGeoJson, InvalidData
 
 
 class ProjectAdminAPI(Resource):
@@ -57,7 +57,7 @@ class ProjectAdminAPI(Resource):
             return str(e), 400
 
         try:
-            project_service = ProjectService()
+            project_service = ProjectAdminService()
             draft_project_id = project_service.create_draft_project(draft_project_dto)
             return {"projectId": draft_project_id}, 201
         except (InvalidGeoJson, InvalidData) as e:
@@ -91,7 +91,7 @@ class ProjectAdminAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            project_service = ProjectService()
+            project_service = ProjectAdminService()
             project_dto = project_service.get_project_dto_for_admin(project_id)
 
             if project_dto is None:
@@ -157,7 +157,7 @@ class ProjectAdminAPI(Resource):
             return str(e), 400
 
         try:
-            project_service = ProjectService()
+            project_service = ProjectAdminService()
             project = project_service.update_project(project_dto)
 
             if project is None:

--- a/server/api/project_admin_api.py
+++ b/server/api/project_admin_api.py
@@ -1,7 +1,7 @@
 from flask_restful import Resource, request, current_app
 from schematics.exceptions import DataError
 from server.models.dtos.project_dto import DraftProjectDTO, ProjectDTO
-from server.services.project_admin_service import ProjectAdminService, InvalidGeoJson, InvalidData
+from server.services.project_admin_service import ProjectAdminService, InvalidGeoJson, InvalidData, ProjectAdminServiceError
 
 
 class ProjectAdminAPI(Resource):
@@ -164,6 +164,8 @@ class ProjectAdminAPI(Resource):
                 return {"Error": "Project Not Found"}, 404
 
             return {"Status": "Updated"}, 200
+        except ProjectAdminServiceError as e:
+            return {"error": str(e)}, 400
         except Exception as e:
             error_msg = f'Project GET - unhandled error: {str(e)}'
             current_app.logger.critical(error_msg)

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -166,12 +166,19 @@ class Project(db.Model):
         self.status = ProjectStatus.DRAFT.value
 
     def create(self):
-        """
-        Creates and saves the current model to the DB
-        """
+        """ Creates and saves the current model to the DB """
         # TODO going to need some validation and logic re Draft, Published etc
         db.session.add(self)
         db.session.commit()
+
+    @staticmethod
+    def get(project_id: int):
+        """
+        Gets specified project
+        :param project_id: project ID in scope
+        :return: Project if found otherwise None
+        """
+        return Project.query.get(project_id)
 
     def update(self, project_dto: ProjectDTO):
         """ Updates project from DTO """

--- a/server/services/project_admin_service.py
+++ b/server/services/project_admin_service.py
@@ -88,7 +88,13 @@ class ProjectAdminService:
             task_id += 1
 
     def _validate_default_locale(self, default_locale, project_info_locales):
-
+        """
+        Validates that all fields for the default project info locale have been completed
+        :param default_locale: Admin supplied default locale
+        :param project_info_locales: All locales supplied by admin
+        :raises ProjectAdminServiceError
+        :return: True if valid
+        """
         default_info = None
         for info in project_info_locales:
             if info.locale.lower() == default_locale.lower():
@@ -101,3 +107,5 @@ class ProjectAdminService:
         for attr, value in default_info.items():
             if not value:
                 raise(ProjectAdminServiceError(f'{attr} not provided for Default Locale'))
+
+        return True  # Indicates valid default locale for unit testing

--- a/server/services/project_admin_service.py
+++ b/server/services/project_admin_service.py
@@ -19,7 +19,7 @@ class ProjectStoreError(Exception):
             current_app.logger.error(message)
 
 
-class ProjectService:
+class ProjectAdminService:
 
     def create_draft_project(self, draft_project_dto: DraftProjectDTO) -> int:
         """
@@ -44,8 +44,7 @@ class ProjectService:
         draft_project.create()
         return draft_project.id
 
-
-    def get_project_dto_for_admin(self, project_id: int):
+    def get_project_dto_for_admin(self, project_id: int) -> ProjectDTO:
         """ Get the project as DTO for project managers """
         project = Project()
         return project.as_dto_for_admin(project_id)

--- a/server/services/project_admin_service.py
+++ b/server/services/project_admin_service.py
@@ -50,7 +50,7 @@ class ProjectAdminService:
         return project.as_dto_for_admin(project_id)
 
     def update_project(self, project_dto: ProjectDTO):
-        project = Project.query.get(project_dto.project_id)
+        project = Project.get(project_dto.project_id)
 
         if project is None:
             return None

--- a/tests/server/unit/services/test_mapping_service.py
+++ b/tests/server/unit/services/test_mapping_service.py
@@ -25,7 +25,6 @@ class TestProject(unittest.TestCase):
     def test_get_project_dto_for_mapping_returns_none_if_project_not_found(self, mock_project):
         # Arrange
         mock_project.return_value = None
-        test_project = 'test'
 
         # Act
         test_project = MappingService().get_project_dto_for_mapper(1, 'en')
@@ -42,7 +41,7 @@ class TestProject(unittest.TestCase):
 
         # Act
         with self.assertRaises(MappingServiceError):
-            test_project = MappingService().get_project_dto_for_mapper(1, 'en')
+            MappingService().get_project_dto_for_mapper(1, 'en')
 
     @patch.object(Task, 'get')
     def test_lock_task_for_mapping_returns_none_if_task_not_found(self, mock_task):

--- a/tests/server/unit/services/test_project_admin_service.py
+++ b/tests/server/unit/services/test_project_admin_service.py
@@ -1,16 +1,16 @@
 import json
 import unittest
 from unittest.mock import MagicMock
-from server.services.project_service import ProjectService, InvalidGeoJson, Project
+from server.services.project_admin_service import ProjectAdminService, InvalidGeoJson, Project
 
 
-class TestProject(unittest.TestCase):
+class TestProjectAdminService(unittest.TestCase):
 
     def test_cant_add_tasks_if_geojson_not_feature_collection(self):
         # Arrange
         invalid_feature = '{"coordinates": [[[[-4.0237, 56.0904], [-3.9111, 56.1715], [-3.8122, 56.098],' \
             '[-4.0237, 56.0904]]]], "type": "MultiPolygon"}'
-        test_project_service = ProjectService()
+        test_project_service = ProjectAdminService()
 
         # Act
         with self.assertRaises(InvalidGeoJson):
@@ -23,7 +23,7 @@ class TestProject(unittest.TestCase):
                                               '"MultiPolygon"}, "properties": {"x": 2402, "y": 1736, "zoom": 12}, "type":'
                                               '"Feature"}], "type": "FeatureCollection"}')
 
-        test_project_service = ProjectService()
+        test_project_service = ProjectAdminService()
         test_project = Project()
         test_project.create_draft_project('Test', MagicMock())
 

--- a/tests/server/unit/services/test_project_admin_service.py
+++ b/tests/server/unit/services/test_project_admin_service.py
@@ -1,7 +1,8 @@
 import json
 import unittest
 from unittest.mock import MagicMock, patch
-from server.services.project_admin_service import ProjectAdminService, InvalidGeoJson, Project, ProjectDTO
+from server.services.project_admin_service import ProjectAdminService, InvalidGeoJson, Project, ProjectAdminServiceError
+from server.models.dtos.project_dto import ProjectInfoDTO
 
 
 class TestProjectAdminService(unittest.TestCase):
@@ -43,3 +44,27 @@ class TestProjectAdminService(unittest.TestCase):
 
         # Assert
         self.assertIsNone(test_project)
+
+    def test_no_project_info_for_default_locale_raises_error(self):
+        # Arrange
+        locales = []
+        info = ProjectInfoDTO()
+        info.locale = 'en'
+        info.name = 'Test'
+        locales.append(info)
+
+        # Act / Assert
+        with self.assertRaises(ProjectAdminServiceError):
+            ProjectAdminService()._validate_default_locale('it', locales)
+
+    def test_incomplete_default_locale_raises_error(self):
+        # Arrange
+        locales = []
+        info = ProjectInfoDTO()
+        info.locale = 'en'
+        info.name = 'Test'
+        locales.append(info)
+
+        # Act / Assert
+        with self.assertRaises(ProjectAdminServiceError):
+            ProjectAdminService()._validate_default_locale('en', locales)

--- a/tests/server/unit/services/test_project_admin_service.py
+++ b/tests/server/unit/services/test_project_admin_service.py
@@ -68,3 +68,20 @@ class TestProjectAdminService(unittest.TestCase):
         # Act / Assert
         with self.assertRaises(ProjectAdminServiceError):
             ProjectAdminService()._validate_default_locale('en', locales)
+
+    def test_complete_default_locale_raises_is_valid(self):
+        # Arrange
+        locales = []
+        info = ProjectInfoDTO()
+        info.locale = 'en'
+        info.name = 'Test'
+        info.description = 'Test Desc'
+        info.short_description = 'Short Desc'
+        info.instructions = 'Instruct'
+        locales.append(info)
+
+        # Act
+        is_valid = ProjectAdminService()._validate_default_locale('en', locales)
+
+        # Assert
+        self.assertTrue(is_valid, 'Complete default locale should be valid')

--- a/tests/server/unit/services/test_project_admin_service.py
+++ b/tests/server/unit/services/test_project_admin_service.py
@@ -1,7 +1,7 @@
 import json
 import unittest
-from unittest.mock import MagicMock
-from server.services.project_admin_service import ProjectAdminService, InvalidGeoJson, Project
+from unittest.mock import MagicMock, patch
+from server.services.project_admin_service import ProjectAdminService, InvalidGeoJson, Project, ProjectDTO
 
 
 class TestProjectAdminService(unittest.TestCase):
@@ -32,3 +32,14 @@ class TestProjectAdminService(unittest.TestCase):
 
         # Assert
         self.assertEqual(1, len(test_project.tasks), 'One task should have been attached to project')
+
+    @patch.object(Project, 'get')
+    def test_get_project_for_update_returns_none_if_project_not_found(self, mock_project):
+        # Arrange
+        mock_project.return_value = None
+
+        # Act
+        test_project = ProjectAdminService().update_project(MagicMock())
+
+        # Assert
+        self.assertIsNone(test_project)


### PR DESCRIPTION
System will enforce that all fields of project info for the default locale are complete prior to publication.