### PR TITLE
display task errors only for mapping or validation as appropriate whe…

### DIFF
--- a/client/app/project/project.controller.js
+++ b/client/app/project/project.controller.js
@@ -107,11 +107,12 @@
             else {
                 vm.selectedTaskData = null;
                 vm.isSelectTaskMappable = false;
+                vm.isSelectTaskValidatable = false;
                 vm.taskError = 'none-available';
                 vm.taskErrorValidation = 'none-available';
                 vm.taskLockError = false;
-                vm.mappingStep = 'viewing';
-                vm.validatingStep = 'viewing';
+                vm.mappingStep = vm.currentTab === 'mapping' ? 'viewing' : 'selecting';
+                vm.validatingStep = vm.currentTab === 'validation' ? 'viewing' : 'selecting';
             }
         };
 

--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -79,9 +79,10 @@
                             <!-- task viewing UI -->
                             <div ng-show="projectCtrl.mappingStep === 'viewing' ">
                                 <!-- task information -->
+                                <h2>Mapping</h2>
                                 <h3>Task
                                     #{{ projectCtrl.selectedTaskData.taskId }} is
-                                    <span ng-show="projectCtrl.selectedTaskData.taskLocked">being worked on</span>
+                                    <span ng-show="projectCtrl.selectedTaskData.taskLocked">LOCKED</span>
                                     <span ng-hide="projectCtrl.selectedTaskData.taskLocked"> {{ projectCtrl.selectedTaskData.taskStatus }} </span>
                                 </h3>
                                 <div ng-show="projectCtrl.selectedTaskData">
@@ -201,6 +202,7 @@
                             <!-- task viewing UI -->
                             <div ng-show="projectCtrl.validatingStep === 'viewing' ">
                                 <!-- task information -->
+                                <h2>Validation</h2>
                                 <h3>Task
                                     #{{ projectCtrl.selectedTaskData.taskId }} is
                                     <span ng-show="projectCtrl.selectedTaskData.taskLocked">LOCKED</span><span


### PR DESCRIPTION
If selecting a random task for mapping or validation only display errors on the current tab, heep the other tab in selecting mode