### PR TITLE
Auth mappers validators part2

### DIFF
--- a/client/app/login/login.controller.js
+++ b/client/app/login/login.controller.js
@@ -23,7 +23,7 @@
             // Set the session in the authentication service
             authService.setSession(vm.sessionToken, vm.userName);
             // Return to the URL where the user came from
-            var redirectURL = $location.search().redirect;
+            var redirectURL = $location.search().redirect_to;
             if (redirectURL){
                 $location.path(redirectURL);
             }

--- a/client/app/login/login.controller.js
+++ b/client/app/login/login.controller.js
@@ -34,7 +34,7 @@
             // Clear the URL parameters
             $location.search('username', null);
             $location.search('session_token', null);
-            $location.search('redirect', null);
+            $location.search('redirect_to', null);
             $location.search('ng', null);
         }
     }

--- a/client/app/profile/profile.controller.js
+++ b/client/app/profile/profile.controller.js
@@ -7,9 +7,9 @@
      */
     angular
         .module('taskingManager')
-        .controller('profileController', ['$routeParams', 'accountService', profileController]);
+        .controller('profileController', ['$routeParams', '$location', 'accountService', profileController]);
 
-    function profileController($routeParams, accountService) {
+    function profileController($routeParams, $location, accountService) {
         var vm = this;
         vm.username = '';
         vm.currentlyLoggedInUser = null;
@@ -30,6 +30,9 @@
                 if (account){
                     vm.currentlyLoggedInUser = account;
                 }
+            }, function () {
+                // Could not find the user, redirect to the homepage
+                $location.path('/');
             });
         }
     }

--- a/client/app/project/project.controller.js
+++ b/client/app/project/project.controller.js
@@ -7,13 +7,14 @@
      */
     angular
         .module('taskingManager')
-        .controller('projectController', ['$scope', '$routeParams', '$window', 'mapService', 'projectService', 'styleService', 'taskService', 'geospatialService','editorService', projectController]);
+        .controller('projectController', ['$scope', '$routeParams', '$window', 'mapService', 'projectService', 'styleService', 'taskService', 'geospatialService','editorService','authService','accountService', projectController]);
 
-    function projectController($scope, $routeParams, $window, mapService, projectService, styleService, taskService, geospatialService, editorService) {
+    function projectController($scope, $routeParams, $window, mapService, projectService, styleService, taskService, geospatialService, editorService, authService, accountService) {
         var vm = this;
         vm.projectData = null;
         vm.taskVectorLayer = null;
         vm.map = null;
+        vm.user = {};
 
         // tab and view control
         vm.currentTab = '';
@@ -48,6 +49,16 @@
         activate();
 
         function activate() {
+
+             // Check the user's role
+            var session = authService.getSession();
+            if (session){
+                var resultsPromise = accountService.getUser(session.username);
+                resultsPromise.then(function (user) {
+                    vm.user = user;
+                });
+            }
+
             vm.currentTab = 'description';
             vm.mappingStep = 'selecting';
             vm.validatingStep = 'selecting';
@@ -303,7 +314,7 @@
                     refreshCurrentSelection(data);
                 }
             }, function () {
-                // could not unlock lock task, very unlikey to happen but
+                // could not unlock lock task, very unlikely to happen but
                 // most likely because task was unlocked or status changed on server
                 // refresh map and selected task.  UI will react to new state if task
                 refreshProject(projectId);

--- a/client/app/project/project.controller.js
+++ b/client/app/project/project.controller.js
@@ -319,7 +319,7 @@
                     refreshCurrentSelection(data);
                 }
             }, function (error) {
-                onLockError(projectId, taskId, error);
+                onLockUnLockError(projectId, taskId, error);
             });
         };
 
@@ -344,7 +344,7 @@
                 vm.taskLockError = false;
                 vm.clearCurrentSelection();
             }, function (error) {
-                onLockError(projectId, taskId, error);
+                onLockUnLockError(projectId, taskId, error);
             });
         };
 
@@ -370,7 +370,7 @@
                 vm.taskLockError = false;
                 vm.lockedTaskData = data;
             }, function (error) {
-                onLockError(projectId, taskId, error);
+                onLockUnLockError(projectId, taskId, error);
             });
         };
 
@@ -395,7 +395,7 @@
                 vm.taskLockError = false;
                 vm.lockedTaskData = tasks[0];
             }, function (error) {
-                onLockError(projectId, taskId, error);
+                onLockUnLockError(projectId, taskId, error);
             });
         };
 
@@ -485,7 +485,7 @@
          * @param taskId
          * @param error
          */
-        function onLockError(projectId, taskId, error) {
+        function onLockUnLockError(projectId, taskId, error) {
             // Could not unlock/lock task
             // Refresh the map and selected task.
             refreshProject(projectId);

--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -87,7 +87,7 @@
                                             you
                                          </span>
                                          <span ng-show="projectCtrl.selectedTaskData.lockHolder !== projectCtrl.user.username">
-                                            {{ projectCtrl.lockedTaskData.lockHolder }}
+                                            {{ projectCtrl.selectedTaskData.lockHolder }}
                                          </span>
                                     </span>
                                     <span ng-hide="projectCtrl.selectedTaskData.taskLocked"> {{ projectCtrl.selectedTaskData.taskStatus }} </span>
@@ -100,9 +100,14 @@
                                 </div>
                                 <!-- task error alerts -->
                                 <div>
-                                    <div ng-show="projectCtrl.taskLockError">
+                                    <div ng-show="projectCtrl.taskLockError && projectCtrl.isAuthorized">
                                         <div class="alert alert--danger" role="alert">
                                             <p>The task could not be locked for mapping.</p>
+                                        </div>
+                                    </div>
+                                     <div ng-show="projectCtrl.taskLockError && !projectCtrl.isAuthorized">
+                                        <div class="alert alert--danger" role="alert">
+                                            <p>Please login first.</p>
                                         </div>
                                     </div>
                                     <div ng-show="projectCtrl.taskError === 'task-not-mappable'"
@@ -126,7 +131,6 @@
                                 </div>
                                 <!-- task action buttons -->
                                 <div>
-
                                     <div class="pull-center">
                                         <button ng-show="projectCtrl.isSelectTaskMappable"
                                                 class="button button--secondary button--large"
@@ -222,7 +226,7 @@
                                             you
                                         </span>
                                         <span ng-show="projectCtrl.selectedTaskData.lockHolder !== projectCtrl.user.username">
-                                            {{ projectCtrl.lockedTaskData.lockHolder }}
+                                            {{ projectCtrl.selectedTaskData.lockHolder }}
                                         </span>
                                     </span>
                                     <span ng-hide="projectCtrl.selectedTaskData.taskLocked"> {{ projectCtrl.selectedTaskData.taskStatus }} </span>
@@ -235,9 +239,14 @@
                                 </div>
                                 <!-- task error alerts -->
                                 <div>
-                                    <div ng-show="projectCtrl.taskLockError">
+                                    <div ng-show="projectCtrl.taskLockError && projectCtrl.isAuthorized">
                                         <div class="alert alert--danger" role="alert">
                                             <p>The task could not be locked for validation.</p>
+                                        </div>
+                                    </div>
+                                    <div ng-show="projectCtrl.taskLockError && !projectCtrl.isAuthorized">
+                                        <div class="alert alert--danger" role="alert">
+                                            <p>Please login first.</p>
                                         </div>
                                     </div>
                                     <div ng-show="projectCtrl.taskErrorValidation === 'task-not-validatable'"

--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -82,7 +82,14 @@
                                 <h2>Mapping</h2>
                                 <h3>Task
                                     #{{ projectCtrl.selectedTaskData.taskId }} is
-                                    <span ng-show="projectCtrl.selectedTaskData.taskLocked">LOCKED</span>
+                                    <span ng-show="projectCtrl.selectedTaskData.taskLocked">LOCKED by
+                                         <span ng-show="projectCtrl.selectedTaskData.lockHolder === projectCtrl.user.username">
+                                            you
+                                         </span>
+                                         <span ng-show="projectCtrl.selectedTaskData.lockHolder !== projectCtrl.user.username">
+                                            {{ projectCtrl.lockedTaskData.lockHolder }}
+                                         </span>
+                                    </span>
                                     <span ng-hide="projectCtrl.selectedTaskData.taskLocked"> {{ projectCtrl.selectedTaskData.taskStatus }} </span>
                                 </h3>
                                 <div ng-show="projectCtrl.selectedTaskData">
@@ -142,13 +149,18 @@
                                             </button>
                                         </div>
                                     </div>
-
                                 </div>
                             </div>
                             <!-- task locked UI -->
                             <div ng-show="projectCtrl.mappingStep === 'locked'"><!-- task mapping UI -->
                                 <h3>Task
-                                    #{{ projectCtrl.lockedTaskData.taskId }} is LOCKED by you
+                                    #{{ projectCtrl.lockedTaskData.taskId }} is LOCKED by
+                                    <span ng-show="projectCtrl.lockedTaskData.lockHolder === projectCtrl.user.username">
+                                        you
+                                    </span>
+                                    <span ng-show="projectCtrl.lockedTaskData.lockHolder !== projectCtrl.user.username">
+                                        {{ projectCtrl.lockedTaskData.lockHolder }}
+                                    </span>
                                 </h3>
                                 <p></p>
                                 <div class="form__group">
@@ -205,8 +217,15 @@
                                 <h2>Validation</h2>
                                 <h3>Task
                                     #{{ projectCtrl.selectedTaskData.taskId }} is
-                                    <span ng-show="projectCtrl.selectedTaskData.taskLocked">LOCKED</span><span
-                                            ng-hide="projectCtrl.selectedTaskData.taskLocked"> {{ projectCtrl.selectedTaskData.taskStatus }} </span>
+                                    <span ng-show="projectCtrl.selectedTaskData.taskLocked">LOCKED by
+                                        <span ng-show="projectCtrl.selectedTaskData.lockHolder === projectCtrl.user.username">
+                                            you
+                                        </span>
+                                        <span ng-show="projectCtrl.selectedTaskData.lockHolder !== projectCtrl.user.username">
+                                            {{ projectCtrl.lockedTaskData.lockHolder }}
+                                        </span>
+                                    </span>
+                                    <span ng-hide="projectCtrl.selectedTaskData.taskLocked"> {{ projectCtrl.selectedTaskData.taskStatus }} </span>
                                 </h3>
                                 <div ng-show="projectCtrl.selectedTaskData">
                                     <div ng-show="projectCtrl.isSelectTaskValidatable" class="alert alert--success"
@@ -241,10 +260,7 @@
                                     </div>
                                 </div>
                                 <!-- task action buttons -->
-
-
                                 <div>
-
                                     <div class="pull-center">
                                         <button ng-show="projectCtrl.isSelectTaskValidatable"
                                                 class="button button--secondary button--large"
@@ -272,7 +288,13 @@
                             <!-- task locked UI -->
                             <div ng-show="projectCtrl.validatingStep === 'locked'"><!-- task mapping UI -->
                                 <h3>Task
-                                    #{{ projectCtrl.lockedTaskData.taskId }} is LOCKED by you (TODO)
+                                    #{{ projectCtrl.lockedTaskData.taskId }} is LOCKED by
+                                    <span ng-show="projectCtrl.selectedTaskData.lockHolder === projectCtrl.user.username">
+                                        you
+                                    </span>
+                                    <span ng-show="projectCtrl.selectedTaskData.lockHolder !== projectCtrl.user.username">
+                                        {{ projectCtrl.lockedTaskData.lockHolder }}
+                                    </span>
                                 </h3>
                                 <p></p>
                                 <div class="form__group">
@@ -348,12 +370,12 @@
                                          ng-repeat="item in projectCtrl.selectedTaskData.taskHistory | orderBy: '-actionDate' track by $index"
                                          ng-class-odd="'odd'" ng-class-even="'even'">
                                         <div>
-                                            <span ng-show="item.action === 'COMMENT'">Comment left by TODO</span>
-                                            <span ng-show="item.action === 'LOCKED'">Locked by TODO</span>
-                                            <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'BADIMAGERY'">Marked as bad imagery by TODO</span>
-                                            <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'DONE'">Marked done by TODO</span>
-                                            <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'VALIDATED'">Validated by TODO</span>
-                                            <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'INVALIDATED'">Invalidated by TODO</span>
+                                            <span ng-show="item.action === 'COMMENT'">Comment left by <a href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
+                                            <span ng-show="item.action === 'LOCKED'">Locked by <a href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
+                                            <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'BADIMAGERY'">Marked as bad imagery by <a href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
+                                            <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'DONE'">Marked done by <a href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
+                                            <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'VALIDATED'">Validated by <a href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
+                                            <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'INVALIDATED'">Invalidated by <a href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
                                         </div>
                                         <div>
                                             <span ng-show="item.action === 'COMMENT'">{{ item.actionText }}</span>
@@ -390,7 +412,7 @@
                     </h2>
                 </div>
                 <div>
-                    <div class="edit-project-button">
+                    <div ng-show="projectCtrl.user.role === 'PROJECT_MANAGER' || projectCtrl.user.role === 'ADMIN'" class="edit-project-button">
                         <a href="/admin/edit-project/{{ projectCtrl.projectData.projectId }}" class="button button--secondary">Edit project</a>
                     </div>
                 </div>

--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -405,6 +405,11 @@
                                             ng-click="projectCtrl.viewOSMChangesets()">
                                         View OSM changesets
                                     </button>
+                                    <button class="button button--achromic"
+                                            title="See the changesets in Overpass turbo for this area"
+                                            ng-click="projectCtrl.viewOverpassTurbo()">
+                                        View in Overpass Turbo
+                                    </button>
                                 </div>
                             </div>
                         </div>

--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -125,7 +125,7 @@
                                             <button class="alert__button-dismiss" title="Dismiss alert"
                                                     ng-click="projectCtrl.clearCurrentSelection()"><span>Dismiss</span>
                                             </button>
-                                            <p>there was an error retrieving the task from the server.</p>
+                                            <p>There was an error retrieving the task from the server.</p>
                                         </div>
                                     </div>
                                 </div>

--- a/client/app/services/auth.service.js
+++ b/client/app/services/auth.service.js
@@ -31,7 +31,7 @@
         function login(){
             // Get the current page the user is on and remember it so we can go back to it
             var urlBeforeLoggingIn = $location.path();
-            $window.location.href = configService.tmAPI + '/auth/login?redirect=' + urlBeforeLoggingIn;
+            $window.location.href = configService.tmAPI + '/auth/login?redirect_to=' + urlBeforeLoggingIn;
         }
         
         /**

--- a/client/app/services/task.service.js
+++ b/client/app/services/task.service.js
@@ -94,10 +94,10 @@
                 // this callback will be called asynchronously
                 // when the response is available
                 return (response.data);
-            }, function errorCallback() {
+            }, function errorCallback(error) {
                 // called asynchronously if an error occurs
                 // or server returns response with an error status.
-                return $q.reject("error");
+                return $q.reject(error);
             });
         }
 
@@ -122,10 +122,10 @@
                 // this callback will be called asynchronously
                 // when the response is available
                 return (response.data.tasks);
-            }, function errorCallback() {
+            }, function errorCallback(error) {
                 // called asynchronously if an error occurs
                 // or server returns response with an error status.
-                return $q.reject("error");
+                return $q.reject(error);
             });
         }
 
@@ -148,10 +148,10 @@
                 // this callback will be called asynchronously
                 // when the response is available
                 return (response.data.tasks);
-            }, function errorCallback() {
+            }, function errorCallback(error) {
                 // called asynchronously if an error occurs
                 // or server returns response with an error status.
-                return $q.reject("error");
+                return $q.reject(error);
             });
         }
 

--- a/client/app/services/task.service.js
+++ b/client/app/services/task.service.js
@@ -71,10 +71,10 @@
                 // this callback will be called asynchronously
                 // when the response is available
                 return (response.data);
-            }, function errorCallback() {
+            }, function errorCallback(error) {
                 // called asynchronously if an error occurs
                 // or server returns response with an error status.
-                return $q.reject("error");
+                return $q.reject(error);
             });
         }
 


### PR DESCRIPTION
- Show error when user needs to login when locking for mapping/validating
- Overpass Turbo link (it shows a no data available message in Overpass which is the same when opening a task in Overpass in TM2 when no edits have been made). Need to test this fully once we can launch the editors.
- Redirect parameter on logging in which brings the user back to where they came from when logging in
- show history user names
- shows who has locked the task (and 'you' if it was the logged in user). Users can map/validate their own locked task (API still needs to deal with this, so shows error at the moment)