### PR TITLE
Fix bug double counting mapped tasks

### DIFF
--- a/server/models/dtos/validator_dto.py
+++ b/server/models/dtos/validator_dto.py
@@ -45,6 +45,7 @@ class MappedTasksByUser(Model):
     mapped_task_count = IntType(required=True, serialized_name='mappedTaskCount')
     tasks_mapped = ListType(IntType, required=True, serialized_name='tasksMapped')
     last_seen = DateTimeType(required=True, serialized_name='lastSeen')
+    mapping_level = StringType(required=True, serialized_name='mappingLevel')
 
 
 class MappedTasks(Model):


### PR DESCRIPTION
If user locks/unlocks a task multiple times API was counting each action.  Code now only counts distinct task ids.