### PR TITLE
Project dashboard admin

### DIFF
--- a/client/app/admin/dashboard/dashboard.controller.js
+++ b/client/app/admin/dashboard/dashboard.controller.js
@@ -7,47 +7,11 @@
      */
     angular
         .module('taskingManager')
-        .controller('dashboardController', ['mapService', 'projectMapService', 'projectService', dashboardController]);
+        .controller('dashboardController', ['$filter', 'mapService', 'projectMapService', 'projectService', dashboardController]);
 
-    function dashboardController(mapService, projectMapService, projectService) {
+    function dashboardController($filter, mapService, projectMapService, projectService) {
         var vm = this;
-
-        // TODO: get projects + mapper level stats from the API.
-        vm.projects = [
-            {
-                id: 186,
-                name: 'Hardcoded project name',
-                portfolio: 'Name of portfolio',
-                percentageMapped: '45',
-                percentageValidated: '33',
-                createdBy: 'LindaA1',
-                aoiCentroid: {
-                    coordinates: [34.3433748084466, 31.003454415691]
-                }
-            },
-            {
-                id: 236,
-                name: 'Hardcoded project name 2',
-                portfolio: 'Name of portfolio',
-                percentageMapped: '66',
-                percentageValidated: '11',
-                createdBy: 'IF',
-                aoiCentroid: {
-                    coordinates: [-51.3464801406698, -11.5096335806906]
-                }
-            },
-            {
-                id: 159,
-                name: 'Hardcoded project name 3',
-                portfolio: 'Name of portfolio',
-                percentageMapped: '66',
-                percentageValidated: '11',
-                createdBy: 'IF',
-                aoiCentroid: {
-                    coordinates: [-51.3464801406698, -11.5096335806906]
-                }
-            }
-        ];
+        vm.projects = {};
 
         // Stats
         vm.selectedProject = {};
@@ -60,11 +24,16 @@
         vm.projectComments = [];
 
         // Filter
-        vm.searchText = {};
+        vm.searchText = '';
        
         // Order
         vm.propertyName = 'id';
         vm.reverse = true;
+
+        // Show lists
+        vm.showActive = true;
+        vm.showDraft = false;
+        vm.showArchived = false;
 
         activate();
 
@@ -72,34 +41,10 @@
             mapService.createOSMMap('map');
             vm.map = mapService.getOSMMap();
             //TODO: get projects from API
-            if (vm.projects) {
-                var lastProjectIndex = vm.projects.length - 1;
-                // TODO: look at ordering and which one to select by default
-                setGraphVariables(lastProjectIndex);
-                projectMapService.initialise(vm.map);
-                projectMapService.showProjectsOnMap(vm.projects);
-                projectMapService.highlightProjectOnMap(vm.projects, vm.projects[lastProjectIndex].id);
-            }
+            //TODO: look at ordering
+            projectMapService.initialise(vm.map);
+            getProjects();
         }
-
-        /**
-         * Select a project, show graphs and highlight on map
-         * @param projectId
-         */
-        vm.selectProject = function(projectId){
-            vm.projectComments = [];
-            var index = -1;
-            for (var i = 0; i < vm.projects.length; i++){
-                if (vm.projects[i].id == projectId){
-                    index = i;
-                }
-            }
-            if (index != -1){
-                setGraphVariables(index);
-                setComments(projectId);
-                projectMapService.highlightProjectOnMap(vm.projects, projectId);
-            }
-        };
 
         /**
          * Sorts the table by property name
@@ -111,30 +56,55 @@
         };
 
         /**
-         * Set the graph variables for a project by providing the index of the project in the projects array
-         * @param index
+         * Toggle active
          */
-        function setGraphVariables(index){
-            vm.selectedProject = vm.projects[index];
-            // Tasks mapped
-            vm.mappedData = [vm.selectedProject.percentageMapped, 100 - vm.selectedProject.percentageMapped];
-            vm.mappedLabels = ['Mapped', 'Not mapped'];
-            // Tasks validated
-            vm.validatedData = [vm.selectedProject.percentageValidated, 100 - vm.selectedProject.percentageValidated];
-            vm.validatedLabels = ['Validated', 'Not validated'];
+        vm.toggleActive = function(){
+            vm.showActive = !vm.showActive;
+        };
+
+        /**
+         * Toggle completed
+         */
+        vm.toggleDraft = function(){
+            vm.showDraft = !vm.showDraft;
+        };
+
+        /**
+         * Toggle archived
+         */
+        vm.toggleArchived = function(){
+            vm.showArchived = !vm.showArchived;
+        };
+
+        /**
+         * Get the projects for the logged in user
+         */
+        function getProjects(){
+            var resultsPromise = projectService.getMyProjects();
+            resultsPromise.then(function (data) {
+                // Return the projects successfully
+                vm.projects = data;
+                showOnMap(vm.projects);
+            }, function(){
+                // an error occurred
+                vm.projects = {};
+            });
         }
 
         /**
-         * Set the project's comments
-         * @param projectId
+         * Show projects on map
+         * @param projects
          */
-        function setComments(projectId){
-            var resultsPromise = projectService.getCommentsForProject(projectId);
-            resultsPromise.then(function (data) {
-                vm.projectComments = data.comments;
-            }, function(){
-               // TODO
-            });
+        function showOnMap(projects){
+            if (projects.activeProjects) {
+                projectMapService.showProjectsOnMap(projects.activeProjects, "active", false);
+            }
+            if (projects.draftProjects) {
+                projectMapService.showProjectsOnMap(projects.draftProjects, "draft", true);
+            }
+            if (projects.archivedProjects) {
+                projectMapService.showProjectsOnMap(projects.archivedProjects, "archived", true);
+            }
         }
     }
 })();

--- a/client/app/admin/dashboard/dashboard.controller.js
+++ b/client/app/admin/dashboard/dashboard.controller.js
@@ -7,9 +7,9 @@
      */
     angular
         .module('taskingManager')
-        .controller('dashboardController', ['$filter', 'mapService', 'projectMapService', 'projectService', dashboardController]);
+        .controller('dashboardController', ['mapService', 'projectMapService', 'projectService', dashboardController]);
 
-    function dashboardController($filter, mapService, projectMapService, projectService) {
+    function dashboardController(mapService, projectMapService, projectService) {
         var vm = this;
         vm.projects = {};
 
@@ -40,8 +40,6 @@
         function activate(){
             mapService.createOSMMap('map');
             vm.map = mapService.getOSMMap();
-            //TODO: get projects from API
-            //TODO: look at ordering
             projectMapService.initialise(vm.map);
             getProjects();
         }

--- a/client/app/admin/dashboard/dashboard.html
+++ b/client/app/admin/dashboard/dashboard.html
@@ -3,7 +3,7 @@
         <header class="section__header">
             <div class="inner">
                 <h1 class="section__title">
-                    Dashboard - projects (TODO)
+                    Dashboard - your projects
                 </h1>
             </div>
         </header>
@@ -11,70 +11,203 @@
             <div class="section__body">
                 <div class="inner">
                      <div class="dashboard-container">
-                         <div class="filter">
-                             <h2>Filter projects</h2>
+                         <div>
+                             <h3>Filter</h3>
                              <form class="form">
                                  <div class="form__group">
-                                     <label class="form__label" for="form-name">ID</label>
                                      <input type="text" class="form__control form__control--medium"
-                                            placeholder="Filter on ID" ng-model="dashboardCtrl.searchText.id"/>
-                                 </div>
-                                 <div class="form__group">
-                                     <label class="form__label" for="form-name">Name</label>
-                                     <input type="text" class="form__control form__control--medium"
-                                            placeholder="Filter on name" ng-model="dashboardCtrl.searchText.name"/>
-                                 </div>
-                                 <div class="form__group">
-                                     <label class="form__label" for="form-name">Portfolio</label>
-                                     <input type="text" class="form__control form__control--medium"
-                                            placeholder="Filter on portfolio" ng-model="dashboardCtrl.searchText.portfolio"/>
-                                 </div>
-                                 <div class="form__group">
-                                     <label class="form__label" for="form-name">Created by</label>
-                                     <input type="text" class="form__control form__control--medium"
-                                            placeholder="Filter on created by" ng-model="dashboardCtrl.searchText.createdBy"/>
+                                            size="500"
+                                            placeholder="Filter projects (on name, campaign, ...)" ng-model="dashboardCtrl.searchText"/>
                                  </div>
                              </form>
                          </div>
-                         <div class="results">
-                             <table class="table table-project-dashboard">
-                                <thead>
-                                <tr>
-                                    <th ng-click="dashboardCtrl.sortBy('id')">
-                                        <a class="table__sort table__sort--none" title="Sort column"><span>#</span></a>
-                                    </th>
-                                    <th ng-click="dashboardCtrl.sortBy('name')">
-                                        <a class="table__sort table__sort--none" title="Sort column"><span>Name</span></a>
-                                    </th>
-                                    <th ng-click="dashboardCtrl.sortBy('portfolio')">
-                                        <a class="table__sort table__sort--none" title="Sort column"><span>Portfolio</span></a>
-                                    </th>
-                                    <th ng-click="dashboardCtrl.sortBy('percentageMapped')">
-                                        <a class="table__sort table__sort--none" title="Sort column"><span>% mapped</span></a>
-                                    </th>
-                                    <th ng-click="dashboardCtrl.sortBy('percentageValidated')">
-                                        <a class="table__sort table__sort--none" title="Sort column"><span>% validated</span></a>
-                                    </th>
-                                    <th ng-click="dashboardCtrl.sortBy('createdBy')">
-                                        <a class="table__sort table__sort--none" title="Sort column"><span>Created by</span></a>
-                                    </th>
-                                </tr>
-                                </thead>
-                                <tbody>
-                                    <tr class="pointer"
-                                        ng-repeat="project in dashboardCtrl.projects | filter:dashboardCtrl.searchText | orderBy:dashboardCtrl.propertyName:dashboardCtrl.reverse"
-                                        ng-class="project === dashboardCtrl.selectedProject ? 'selected' : ''"
-                                        ng-click="dashboardCtrl.selectProject(project.id)">
-                                        <td>{{ project.id }}</td>
-                                        <td>{{ project.name }}</td>
-                                        <td>{{ project.portfolio }}</td>
-                                        <td>{{ project.percentageMapped }}</td>
-                                        <td>{{ project.percentageValidated }}</td>
-                                        <td>{{ project.createdBy }}</td>
-                                    </tr>
-                                </tbody>
-                            </table>
+                         <hr>
+                         <!-- active projects -->
+                         <h3 class="pointer" ng-click="dashboardCtrl.toggleActive()">
+                             <span ng-show="!dashboardCtrl.showActive">+</span>
+                             <span ng-show="dashboardCtrl.showActive">-</span>
+                             Active
+                         </h3>
+                         <div ng-show="dashboardCtrl.showActive">
+                             <p ng-show="!dashboardCtrl.projects.activeProjects">No active projects.</p>
+                             <div class="dashboard-my-projects" ng-show="dashboardCtrl.projects.activeProjects">
+                                 <table ng-show="dashboardCtrl.projects.activeProjects" class="table">
+                                 <thead>
+                                 <tr>
+                                     <th ng-click="dashboardCtrl.sortBy('projectId')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>#</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('name')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>Name</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('campaignTag')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>Campaign</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('percentMapped')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>% mapped</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('percentValidated')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>% validated</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('created')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>Created</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('lastUpdated')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>Last updated</span></a>
+                                     </th>
+                                     <th></th>
+                                 </tr>
+                                 </thead>
+                                 <tbody>
+                                 <tr ng-repeat="project in dashboardCtrl.projects.activeProjects | filter:dashboardCtrl.searchText | orderBy:dashboardCtrl.propertyName:dashboardCtrl.reverse">
+                                     <td>{{ project.projectId }}</td>
+                                     <td>
+                                         <a ng-href="/project/{{ project.projectId }}">{{ project.name }}</a>
+                                     </td>
+                                     <td>{{ project.campaignTag }}</td>
+                                     <td>{{ project.percentMapped }}</td>
+                                     <td>{{ project.percentValidated }}</td>
+                                     <td>
+                                         <span am-time-ago="project.created | amUtc | amLocal"></span>
+                                     </td>
+                                     <td>
+                                         <span am-time-ago="project.lastUpdated | amUtc | amLocal"></span>
+                                     </td>
+                                     <td>
+                                         <a class="button button--primary button--small"
+                                            ng-href="/project/{{ project.projectId }}/dashboard">dashboard
+                                         </a>
+                                     </td>
+                                 </tr>
+                                 </tbody>
+                             </table>
+                             </div>
                          </div>
+                         <!-- active projects -->
+                         <!-- draft projects -->
+                         <h3 class="pointer" ng-click="dashboardCtrl.toggleDraft()">
+                             <span ng-show="!dashboardCtrl.showDraft">+</span>
+                             <span ng-show="dashboardCtrl.showDraft">-</span>
+                             Draft
+                         </h3>
+                         <div ng-show="dashboardCtrl.showDraft">
+                             <p ng-show="!dashboardCtrl.projects.draftProjects">No draft projects.</p>
+                             <div class="dashboard-my-projects" ng-show="dashboardCtrl.projects.draftProjects">
+                                <table class="table">
+                                 <thead>
+                                 <tr>
+                                     <th ng-click="dashboardCtrl.sortBy('projectId')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>#</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('name')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>Name</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('campaignTag')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>Campaign</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('percentMapped')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>% mapped</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('percentValidated')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>% validated</span></a>
+                                     </th>
+                                      <th ng-click="dashboardCtrl.sortBy('created')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>Created</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('lastUpdated')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>Last updated</span></a>
+                                     </th>
+                                     <th></th>
+                                 </tr>
+                                 </thead>
+                                 <tbody>
+                                 <tr ng-repeat="project in dashboardCtrl.projects.draftProjects | filter:dashboardCtrl.searchText | orderBy:dashboardCtrl.propertyName:dashboardCtrl.reverse">
+                                     <td>{{ project.projectId }}</td>
+                                     <td>
+                                         <a ng-href="/admin/edit-project/{{ project.projectId }}">{{ project.name }}</a>
+                                     </td>
+                                     <td>{{ project.campaignTag }}</td>
+                                     <td>{{ project.percentMapped }}</td>
+                                     <td>{{ project.percentValidated }}</td>
+                                     <td>
+                                         <span am-time-ago="project.created | amUtc | amLocal"></span>
+                                     </td>
+                                     <td>
+                                         <span am-time-ago="project.lastUpdated | amUtc | amLocal"></span>
+                                     </td>
+                                     <td>
+                                         <a class="button button--primary button--small"
+                                            ng-href="/project/{{ project.projectId }}/dashboard">dashboard
+                                         </a>
+                                     </td>
+                                 </tr>
+                                 </tbody>
+                             </table>
+                             </div>
+                         </div>
+                          <!-- draft projects -->
+                          <!-- archived projects -->
+                         <h3 class="pointer" ng-click="dashboardCtrl.toggleArchived()">
+                             <span ng-show="!dashboardCtrl.showArchived">+</span>
+                             <span ng-show="dashboardCtrl.showArchived">-</span>
+                             Archived
+                         </h3>
+                           <div ng-show="dashboardCtrl.showArchived">
+                             <p ng-show="!dashboardCtrl.projects.archivedProjects">No active projects.</p>
+                             <div class="dashboard-my-projects" ng-show="dashboardCtrl.projects.archivedProjects">
+                                 <table ng-show="dashboardCtrl.projects.archivedProjects" class="table">
+                                 <thead>
+                                 <tr>
+                                     <th ng-click="dashboardCtrl.sortBy('projectId')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>#</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('name')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>Name</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('campaignTag')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>Campaign</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('percentMapped')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>% mapped</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('percentValidated')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>% validated</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('created')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>Created</span></a>
+                                     </th>
+                                     <th ng-click="dashboardCtrl.sortBy('lastUpdated')">
+                                         <a class="table__sort table__sort--none" title="Sort column"><span>Last updated</span></a>
+                                     </th>
+                                     <th></th>
+                                 </tr>
+                                 </thead>
+                                 <tbody>
+                                 <tr ng-repeat="project in dashboardCtrl.projects.archivedProjects | filter:dashboardCtrl.searchText | orderBy:dashboardCtrl.propertyName:dashboardCtrl.reverse">
+                                     <td>{{ project.projectId }}</td>
+                                     <td>
+                                         <a ng-href="/admin/edit-project/{{ project.projectId }}">{{ project.name }}</a>
+                                     </td>
+                                     <td>{{ project.campaignTag }}</td>
+                                     <td>{{ project.percentMapped }}</td>
+                                     <td>{{ project.percentValidated }}</td>
+                                     <td>
+                                         <span am-time-ago="project.created | amUtc | amLocal"></span>
+                                     </td>
+                                     <td>
+                                         <span am-time-ago="project.lastUpdated | amUtc | amLocal"></span>
+                                     </td>
+                                     <td>
+                                         <a class="button button--primary button--small"
+                                            ng-href="/project/{{ project.projectId }}/dashboard">dashboard
+                                         </a>
+                                     </td>
+                                 </tr>
+                                 </tbody>
+                             </table>
+                             </div>
+                         </div>
+                         <!-- archived projects -->
                      </div>
                 </div>
             </div>
@@ -82,62 +215,7 @@
         <div class="section-container">
             <div class="section__body">
                 <div class="inner">
-                    <div>
-                        <h2>Stats</h2>
-                        <h6 class="heading-alt">{{ dashboardCtrl.selectedProject.name }}</h6>
-                        <div class="section__project-dashboard--stats">
-                            <div class="stats__card">
-                                <h3>Tasks mapped</h3>
-                                <canvas class="chart chart-pie"
-                                        chart-data="dashboardCtrl.mappedData" chart-labels="dashboardCtrl.mappedLabels"
-                                        chart-options="{legend: {display: true, position: 'bottom'}}">
-                                </canvas>
-                            </div>
-                            <div class="stats__card">
-                                <h3>Tasks validated</h3>
-                                <canvas class="chart chart-pie"
-                                        chart-data="dashboardCtrl.validatedData" chart-labels="dashboardCtrl.validatedLabels"
-                                        chart-options="{legend: {display: true, position: 'bottom'}}">
-                                </canvas>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="section-container">
-            <div class="section__body">
-                <div class="inner">
                     <div id="map" class="map-container"></div>
-                </div>
-            </div>
-        </div>
-        <div class="section-container">
-            <div class="section__body">
-                <div class="inner">
-                    <h2>Comments by users</h2>
-                      <h6 class="heading-alt">{{ dashboardCtrl.selectedProject.name }}</h6>
-                    <div ng-show="dashboardCtrl.projectComments.length < 1">
-                        No comments for this project.
-                    </div>
-                    <div ng-show="dashboardCtrl.projectComments.length > 0">
-                        <table class="table">
-                            <thead>
-                                <tr>
-                                    <th>Comment</th>
-                                    <th>When</th>
-                                    <th>By</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr ng-repeat="comment in dashboardCtrl.projectComments | orderBy: '-commentDate'">
-                                    <td>{{ comment.comment }}</td>
-                                    <td><span am-time-ago="comment.commentDate | amUtc | amLocal"></span></td>
-                                    <td><a href="/user/{{ comment.userName }}" target="_blank">{{ comment.userName }}</a></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
                 </div>
             </div>
         </div>

--- a/client/app/admin/dashboard/dashboard.html
+++ b/client/app/admin/dashboard/dashboard.html
@@ -3,7 +3,7 @@
         <header class="section__header">
             <div class="inner">
                 <h1 class="section__title">
-                    Dashboard - your projects
+                    Project dashboard
                 </h1>
             </div>
         </header>
@@ -11,6 +11,7 @@
             <div class="section__body">
                 <div class="inner">
                      <div class="dashboard-container">
+                         <p>View the projects that you have created</p>
                          <div>
                              <h3>Filter</h3>
                              <form class="form">
@@ -75,7 +76,7 @@
                                      </td>
                                      <td>
                                          <a class="button button--primary button--small"
-                                            ng-href="/project/{{ project.projectId }}/dashboard">dashboard
+                                            ng-href="/project/{{ project.projectId }}/dashboard">Activity and Stats
                                          </a>
                                      </td>
                                  </tr>
@@ -137,7 +138,7 @@
                                      </td>
                                      <td>
                                          <a class="button button--primary button--small"
-                                            ng-href="/project/{{ project.projectId }}/dashboard">dashboard
+                                            ng-href="/project/{{ project.projectId }}/dashboard">Activity and Stats
                                          </a>
                                      </td>
                                  </tr>
@@ -199,7 +200,7 @@
                                      </td>
                                      <td>
                                          <a class="button button--primary button--small"
-                                            ng-href="/project/{{ project.projectId }}/dashboard">dashboard
+                                            ng-href="/project/{{ project.projectId }}/dashboard">Activity and Stats
                                          </a>
                                      </td>
                                  </tr>

--- a/client/app/project/project-dashboard.controller.js
+++ b/client/app/project/project-dashboard.controller.js
@@ -1,0 +1,76 @@
+(function () {
+
+    'use strict';
+
+    /**
+     * Dashboard controller which manages the dashboard page
+     */
+    angular
+        .module('taskingManager')
+        .controller('projectDashboardController', ['mapService', 'projectMapService', 'projectService', projectDashboardController]);
+
+    function projectDashboardController(mapService, projectMapService, projectService) {
+        var vm = this;
+
+        // TODO: get projects + mapper level stats from the API.
+        vm.project = {
+            id: 236,
+            name: 'Hardcoded project name',
+            portfolio: 'Name of portfolio',
+            percentageMapped: '45',
+            percentageValidated: '33',
+            createdBy: 'LindaA1',
+            aoiCentroid: {
+                coordinates: [34.3433748084466, 31.003454415691]
+            }
+        };
+
+        // Stats
+        vm.mappedData = [];
+        vm.mappedLabels = [];
+        vm.validatedData = [];
+        vm.validatedLabels = [];
+
+        // Comments
+        vm.projectComments = [];
+
+        activate();
+
+        function activate(){
+            mapService.createOSMMap('map');
+            vm.map = mapService.getOSMMap();
+            //TODO: get projects from API
+            if (vm.project) {
+                setGraphVariables();
+                setComments(vm.project.id);
+                projectMapService.initialise(vm.map);
+                projectMapService.showProjectOnMap(vm.project);
+            }
+        }
+
+        /**
+         * Set the graph variables for a project by providing the index of the project in the projects array
+         */
+        function setGraphVariables(){
+            // Tasks mapped
+            vm.mappedData = [vm.project.percentageMapped, 100 - vm.project.percentageMapped];
+            vm.mappedLabels = ['Mapped', 'Not mapped'];
+            // Tasks validated
+            vm.validatedData = [vm.project.percentageValidated, 100 - vm.project.percentageValidated];
+            vm.validatedLabels = ['Validated', 'Not validated'];
+        }
+
+        /**
+         * Set the project's comments
+         * @param projectId
+         */
+        function setComments(projectId){
+            var resultsPromise = projectService.getCommentsForProject(projectId);
+            resultsPromise.then(function (data) {
+                vm.projectComments = data.comments;
+            }, function(data){
+               // TODO
+            });
+        }
+    }
+})();

--- a/client/app/project/project-dashboard.html
+++ b/client/app/project/project-dashboard.html
@@ -3,7 +3,7 @@
         <header class="section__header">
             <div class="inner">
                 <h1 class="section__title">
-                    Dashboard (TODO)
+                    Activity and Stats (TODO)
                 </h1>
                 <a ng-href="/project/{{ projectDashboardCtrl.project.id }}"
                    class="heading-alt">{{ projectDashboardCtrl.project.name }}

--- a/client/app/project/project-dashboard.html
+++ b/client/app/project/project-dashboard.html
@@ -3,7 +3,7 @@
         <header class="section__header">
             <div class="inner">
                 <h1 class="section__title">
-                    Dashboard
+                    Dashboard (TODO)
                 </h1>
                 <a ng-href="/project/{{ projectDashboardCtrl.project.id }}"
                    class="heading-alt">{{ projectDashboardCtrl.project.name }}

--- a/client/app/project/project-dashboard.html
+++ b/client/app/project/project-dashboard.html
@@ -1,0 +1,75 @@
+<div class="inner">
+    <section class="section section--asided">
+        <header class="section__header">
+            <div class="inner">
+                <h1 class="section__title">
+                    Dashboard
+                </h1>
+                <a ng-href="/project/{{ projectDashboardCtrl.project.id }}"
+                   class="heading-alt">{{ projectDashboardCtrl.project.name }}
+                </a>
+            </div>
+        </header>
+        <div class="section-container">
+            <div class="section__body">
+                <div class="inner">
+                    <div class="dashboard-container">
+                        <h2>Stats</h2>
+                        <div class="left">
+                            <div class="section__project-dashboard--stats">
+                                <div class="stats__card">
+                                    <h3>Tasks mapped</h3>
+                                    <canvas class="chart chart-pie"
+                                            chart-data="projectDashboardCtrl.mappedData"
+                                            chart-labels="projectDashboardCtrl.mappedLabels"
+                                            chart-options="{legend: {display: true, position: 'bottom'}}">
+                                    </canvas>
+                                </div>
+                                <div class="stats__card">
+                                    <h3>Tasks validated</h3>
+                                    <canvas class="chart chart-pie"
+                                            chart-data="projectDashboardCtrl.validatedData"
+                                            chart-labels="projectDashboardCtrl.validatedLabels"
+                                            chart-options="{legend: {display: true, position: 'bottom'}}">
+                                    </canvas>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="right">
+                            <div id="map" class="map-container"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="section-container">
+            <div class="section__body">
+                <div class="inner">
+                    <h2>Comments by users</h2>
+                      <h6 class="heading-alt">{{ projectDashboardCtrl.selectedProject.name }}</h6>
+                    <div ng-show="projectDashboardCtrl.projectComments.length < 1">
+                        No comments for this project.
+                    </div>
+                    <div ng-show="projectDashboardCtrl.projectComments.length > 0">
+                        <table class="table table-dashboard-comments">
+                            <thead>
+                                <tr>
+                                    <th>Comment</th>
+                                    <th>When</th>
+                                    <th>By</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ng-repeat="comment in projectDashboardCtrl.projectComments | orderBy: '-commentDate'">
+                                    <td>{{ comment.comment }}</td>
+                                    <td><span am-time-ago="comment.commentDate | amUtc | amLocal"></span></td>
+                                    <td><a href="/user/{{ comment.userName }}" target="_blank">{{ comment.userName }}</a></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/client/app/services/project.service.js
+++ b/client/app/services/project.service.js
@@ -47,7 +47,8 @@
             deleteProject: deleteProject,
             invalidateAllTasks: invalidateAllTasks,
             validateAllTasks: validateAllTasks,
-            getCommentsForProject: getCommentsForProject
+            getCommentsForProject: getCommentsForProject,
+            getMyProjects: getMyProjects
         };
 
         return service;
@@ -524,6 +525,27 @@
             return $http({
                 method: 'GET',
                 url: configService.tmAPI + '/admin/project/' + id + '/comments',
+                headers: authService.getAuthenticatedHeader()
+            }).then(function successCallback(response) {
+                // this callback will be called asynchronously
+                // when the response is available
+                return response.data;
+            }, function errorCallback() {
+                // called asynchronously if an error occurs
+                // or server returns response with an error status.
+                return $q.reject("error");
+            });
+        }
+
+        /**
+         * Get my projects
+         * @returns {*|!jQuery.jqXHR|!jQuery.deferred|!jQuery.Promise}
+         */
+        function getMyProjects(){
+            // Returns a promise
+            return $http({
+                method: 'GET',
+                url: configService.tmAPI + '/admin/my-projects',
                 headers: authService.getAuthenticatedHeader()
             }).then(function successCallback(response) {
                 // this callback will be called asynchronously

--- a/client/app/services/projectMap.service.js
+++ b/client/app/services/projectMap.service.js
@@ -17,6 +17,7 @@
         var service = {
             initialise: initialise,
             showProjectsOnMap: showProjectsOnMap,
+            showProjectOnMap: showProjectOnMap,
             highlightProjectOnMap: highlightProjectOnMap,
             removeHighlightOnMap: removeHighlightOnMap
         };
@@ -38,11 +39,9 @@
          * @private
          */
         function addProjectsVectorLayer_(){
-            var style = styleService.getProjectStyle();
             projectVectorSource = new ol.source.Vector();
             var vectorLayer = new ol.layer.Vector({
-                source: projectVectorSource,
-                style: style
+                source: projectVectorSource
             });
             map.addLayer(vectorLayer);
         }
@@ -64,20 +63,38 @@
         
         /**
          * Show the projects on the map
+         * @param projects
+         * @param type - for styling purposes, optional
+         * @param dontClear - optional
          */
-        function showProjectsOnMap(projects){
-
-            projectVectorSource.clear();
+        function showProjectsOnMap(projects, type, dontClear){
+            var typeOfProject = '';
+            if (type){
+                typeOfProject = type;
+            }
+            if (!dontClear) {
+                projectVectorSource.clear();
+            }
 
             // iterate over the projects and add the center of the project as a point on the map
             for (var i = 0; i < projects.length; i++){
-                var projectCenter = ol.proj.transform(projects[i].aoiCentroid.coordinates, 'EPSG:4326', 'EPSG:3857');
-                var feature = new ol.Feature({
-                    geometry: new ol.geom.Point(projectCenter)
-                });
-                if (projectVectorSource) {
-                    projectVectorSource.addFeature(feature);
-                }
+                showProjectOnMap(projects[i], typeOfProject);
+            }
+        }
+
+        /**
+         * Show project on map
+         * @param project
+         * @param type - optional
+         */
+        function showProjectOnMap(project, type) {
+            var projectCenter = ol.proj.transform(project.aoiCentroid.coordinates, 'EPSG:4326', 'EPSG:3857');
+            var feature = new ol.Feature({
+                geometry: new ol.geom.Point(projectCenter)
+            });
+            if (projectVectorSource) {
+                projectVectorSource.addFeature(feature);
+                feature.setStyle(styleService.getProjectStyle(type));
             }
         }
         

--- a/client/app/services/style.service.js
+++ b/client/app/services/style.service.js
@@ -155,13 +155,29 @@
          * OpenLayers style function for showing a project (point) on the map
          * @returns {ol.style.Style}
          */
-        function getProjectStyle() {
+        function getProjectStyle(typeOfProject) {
+            var fillColour = [255, 0, 0, 0.5]; // red
+            var strokeColour = [255, 0, 0, 1]; // red
+            if (typeOfProject){
+                if (typeOfProject === 'active'){
+                    fillColour = [255, 0, 0, 0.5]; // red
+                    strokeColour = [255, 0, 0, 1]; // red
+                }
+                if (typeOfProject === 'draft'){
+                    fillColour = [0, 0, 255, 0.5]; // blue
+                    strokeColour = [0, 0, 255, 1]; // blue
+                }
+                if (typeOfProject === 'archived'){
+                    fillColour = [0, 0, 0, 0.5]; // black
+                    strokeColour = [0, 0, 0, 1]; // black
+                }
+            }
             var fill = new ol.style.Fill({
-                color: [255, 0, 0, 0.5], // red
+                color: fillColour,
                 width: 1
             });
             var stroke = new ol.style.Stroke({
-                color: [255, 0, 0, 1], // red
+                color: strokeColour,
                 width: 1
             });
             var style = new ol.style.Style({

--- a/client/app/taskingmanager.app.js
+++ b/client/app/taskingmanager.app.js
@@ -36,7 +36,7 @@
             $httpProvider.defaults.headers.get['If-Modified-Since'] = '0';
 
             ChartJsProvider.setOptions({
-                chartColors: ['#D73F3F', '#DCDCDC', '#7A7A7A', '#595959']
+                chartColors: ['#AC3232', '#DCDCDC', '#7A7A7A', '#595959']
             });
 
             $routeProvider
@@ -111,6 +111,12 @@
                     templateUrl: 'app/admin/dashboard/dashboard.html',
                     controller: 'dashboardController',
                     controllerAs: 'dashboardCtrl'
+                })
+                
+                .when('/project/:id/dashboard', {
+                    templateUrl: 'app/project/project-dashboard.html',
+                    controller: 'projectDashboardController',
+                    controllerAs: 'projectDashboardCtrl'
                 })
    
                 .when('/admin/users', {

--- a/client/assets/styles/sass/_dashboard.scss
+++ b/client/assets/styles/sass/_dashboard.scss
@@ -1,27 +1,20 @@
 .dashboard-container {
   @include column(12/12);
 
-  .filter {
+  .left {
     @include column(12/12);
     @include media(medium-up) {
-      @include column(4/12);
+      @include column(6/12);
     }
   }
 
-  .results {
+  .right {
     @include column(12/12);
     @include media(medium-up) {
-      @include column(8/12);
+      @include column(6/12);
     }
     max-height: 500px;
     overflow-y: auto;
-  }
-}
-
-.table-project-dashboard {
-  font-size: small;
-  .selected {
-    background-color: rgba($base-color, 0.1);
   }
 }
 
@@ -36,7 +29,7 @@
 
   .stats__card {
     display: inline-block;
-    width: 25%;
+    width: 40%;
   }
 
   .stats__card--amount {
@@ -49,4 +42,22 @@
     opacity: .7;
     line-height: 18px;
   }
+}
+
+/* ==========================================================================
+   Dashboard comments
+   ========================================================================== */
+.table-dashboard-comments {
+  table-layout: fixed;
+  .td {
+    word-wrap: break-word;
+  }
+}
+
+/* ==========================================================================
+   Admin - my projects dashboard
+   ========================================================================== */
+.dashboard-my-projects {
+  max-height: 350px;
+  overflow-y: auto;
 }

--- a/client/assets/styles/sass/_structure.scss
+++ b/client/assets/styles/sass/_structure.scss
@@ -84,11 +84,11 @@
       right: $global-spacing * 1.5;
     }
 
-    @include media(medium-up) {
+    /*@include media(medium-up) {
       top: 1.5rem;
-    }
+    }*/
 
-    @include media(large-up) {
+    @include media(medium-up) {
       display: none;
     }
   }
@@ -121,7 +121,7 @@
     padding: $global-spacing ($global-spacing * 2);
   }
 
-  @include media(large-up) {
+  @include media(medium-up) {
     position: initial;
     float: left;
     width: auto;

--- a/client/assets/styles/sass/_structure.scss
+++ b/client/assets/styles/sass/_structure.scss
@@ -84,10 +84,6 @@
       right: $global-spacing * 1.5;
     }
 
-    /*@include media(medium-up) {
-      top: 1.5rem;
-    }*/
-
     @include media(medium-up) {
       display: none;
     }

--- a/client/index.html
+++ b/client/index.html
@@ -176,6 +176,7 @@
 <script src="app/about/about.controller.js"></script>
 <script src="app/admin/dashboard/dashboard.controller.js"></script>
 <script src="app/admin/users/users.controller.js"></script>
+<script src="app/project/project-dashboard.controller.js"></script>
 
 <script src="app/services/map.service.js"></script>
 <script src="app/services/project.service.js"></script>

--- a/tests/client/unit/app/project/test.project-dashboard.controller.js
+++ b/tests/client/unit/app/project/test.project-dashboard.controller.js
@@ -1,0 +1,18 @@
+'use strict';
+
+describe('projectDashboard.controller', function () {
+    var projectDashboardController = null, scope = null;
+
+    beforeEach(function () {
+        module('taskingManager');
+
+        inject(function ($controller, $rootScope) {
+            scope = $rootScope.$new();
+            projectDashboardController = $controller('projectDashboardController', {$scope: scope});
+        });
+    });
+
+    it('should be created successfully', function () {
+        expect(projectDashboardController).toBeDefined()
+    });
+});


### PR DESCRIPTION
Project dashboard - work in progress

- project**s** dashboard for admins (/admin/dashboard) where users can see the projects that they have created. Data comes from the API. The lastUpdated date is hardcoded in the API still.
- individual project dashboard with stats on the project (project/528/dashboard). Data is mocked except the comments.  We could potentially use this page to display what is in the activity tab now? And link to it from the project page so any user can see this page? Just an idea.