### PR TITLE
Bugfix - Correct counters when invalidating

### DIFF
--- a/server/services/mapping_service.py
+++ b/server/services/mapping_service.py
@@ -75,9 +75,10 @@ class MappingService:
         if new_state not in [TaskStatus.MAPPED, TaskStatus.BADIMAGERY, TaskStatus.READY]:
             raise MappingServiceError('Can only set status to MAPPED, BADIMAGERY, READY after mapping')
 
-        task.unlock_task(mapped_task.user_id, new_state, mapped_task.comment)
         StatsService.update_stats_after_task_state_change(mapped_task.project_id, mapped_task.user_id, new_state,
-                                                          current_state)
+                                                          mapped_task.task_id)
+        task.unlock_task(mapped_task.user_id, new_state, mapped_task.comment)
+
         return task.as_dto()
 
     @staticmethod

--- a/server/services/stats_service.py
+++ b/server/services/stats_service.py
@@ -31,8 +31,8 @@ class StatsService:
 
         UserService.upsert_mapped_projects(user_id, project_id)
         project.last_updated = timestamp()
-        #project.save()  # Will also save user changes, as using same session
 
+        # Transaction will be saved when task is saved
         return project, user
 
     @staticmethod

--- a/server/services/validator_service.py
+++ b/server/services/validator_service.py
@@ -82,9 +82,10 @@ class ValidatorService:
         dtos = []
         for task_to_unlock in tasks_to_unlock:
             task = task_to_unlock['task']
-            task.unlock_task(validated_dto.user_id, task_to_unlock['new_state'], task_to_unlock['comment'])
             StatsService.update_stats_after_task_state_change(validated_dto.project_id, validated_dto.user_id,
-                                                              task_to_unlock['new_state'], current_state)
+                                                              task_to_unlock['new_state'], task.id)
+            task.unlock_task(validated_dto.user_id, task_to_unlock['new_state'], task_to_unlock['comment'])
+
             dtos.append(task.as_dto())
 
         task_dtos = TaskDTOs()


### PR DESCRIPTION
Counters were not being correctly decremented when a task was invalidated.  This has been resolved.