### PR TITLE
Get consumer key from env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,17 +60,20 @@ As the project is open source we have to keep secrets out of the repo.  You will
 
 * **TM_DB** - This is the for the PostGIS connection string.  If you can't access an existing DB refer to DevOps page to [set up a local DB in Docker](https://github.com/hotosm/tasking-manager/wiki/Dev-Ops#creating-a-local-postgis-database-with-docker)
 * **TM_SECRET** - This is secret key for the TM app used by itsdangerous and flask-oauthlib for entropy
+* **TM_CONSUMER_KEY** - This is the OAUTH Consumer Key used for authenticating the Tasking Manager App in OSM
 * **TM_CONSUMER_SECRET** - This is the OAUTH Consumer Secret used for authenticating the Tasking Manager App in OSM
 
 * Linux/Mac
     * (It is strongly recommended to set these within your .bash_profile so they are available to all processes )
     * ```export TM_DB=postgresql://USER:PASSWORD@HOST/DATABASE```
     * ```export TM_SECRET=secret-key-here```
-    * ```export TM_CONSUMER_SECRET=outh-consumer-secret-key-goes-here```
+    * ```export TM_CONSUMER_KEY=oauth-consumer-key-goes-here```
+    * ```export TM_CONSUMER_SECRET=oauth-consumer-secret-key-goes-here```
 * Windows:
     * ```setx TM_DB "postgresql://USER:PASSWORD@HOST/DATABASE"```
     * ```setx TM_SECRET "secret-key-here"```
-    * ```setx TM_CONSUMER_SECRET "outh-consumer-secret-key-goes-here"```
+    * ```setx TM_CONSUMER_KEY "oauth-consumer-key-goes-here"```
+    * ```setx TM_CONSUMER_SECRET "oauth-consumer-secret-key-goes-here"```
 
 ### Creating the DB
 We use [Flask-Migrate](https://flask-migrate.readthedocs.io/en/latest/) to create the database from the migrations directory.  If you can't access an existing DB refer to DevOps page to [set up a local DB in Docker](https://github.com/hotosm/tasking-manager/wiki/Dev-Ops#creating-a-local-postgis-database-with-docker) Create the database as follows:

--- a/server/config.py
+++ b/server/config.py
@@ -11,7 +11,7 @@ class EnvironmentConfig:
     # TODO recreate for go-live.
     OSM_OAUTH_SETTINGS = {
         'base_url': 'https://www.openstreetmap.org/api/0.6/',
-        'consumer_key': '4I5YXs4VQkXTTrMgau11rmE5tuTVoAIWsQXE5HnW',
+        'consumer_key': os.getenv('TM_CONSUMER_KEY', None),
         'consumer_secret': os.getenv('TM_CONSUMER_SECRET', None),
         'request_token_url': 'https://www.openstreetmap.org/oauth/request_token',
         'access_token_url': 'https://www.openstreetmap.org/oauth/access_token',


### PR DESCRIPTION
This lets people create and use their own oauth key.
By the way, since I don't have the `consumer_secret` for the currently provided key, I'm not able to login in my locally installed instance. Did I miss something?