### PR TITLE
localhost to numeric

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -26,7 +26,14 @@ class StagingConfig(EnvironmentConfig):
 
 
 class DevConfig(EnvironmentConfig):
-    APP_BASE_URL = 'http://localhost:5000'
-    API_DOCS_URL = f'{APP_BASE_URL}/api-docs/swagger-ui/index.html?url=http://localhost:5000/api/docs'
+    APP_BASE_URL = 'http://127.0.0.1:5000'
+    API_DOCS_URL = f'{APP_BASE_URL}/api-docs/swagger-ui/index.html?url=http://127.0.0.1:5000/api/docs'
+    LOG_DIR = 'logs'
+    LOG_LEVEL = logging.DEBUG
+
+
+class DevIPv6Config(EnvironmentConfig):
+    APP_BASE_URL = 'http://[::1]:5000'
+    API_DOCS_URL = f'{APP_BASE_URL}/api-docs/swagger-ui/index.html?url=http://[::1]:5000/api/docs'
     LOG_DIR = 'logs'
     LOG_LEVEL = logging.DEBUG


### PR DESCRIPTION
When using DevConfig for the Flask server, OAuth does not like a `localhost` callback. Changing the app base url to `127.0.0.1` fixes this problem. 

I've also added a config for those running only IPv6 locally and cannot use `127.0.0.1`, but was not personally able to verify that works properly.