### PR TITLE
revert legend translation

### DIFF
--- a/client/app/contribute/contribute.html
+++ b/client/app/contribute/contribute.html
@@ -253,30 +253,30 @@
                     <div>
                         <div id="map" class="map-container"></div>
                         <div id="legend-container" class="ol-control legend-control">
-                            <h3>{{ 'Legend' | translate }}</h3>
+                            <h3>Legend</h3>
                             <div>
                                 <svg height="25" width="25">
                                     <circle cx="15" cy="15" r="8" stroke="black" stroke-width="1" fill="red" fill-opacity="0.5" />
                                 </svg>
-                                {{ 'Urgent' | translate }}
+                                Urgent
                             </div>
                             <div>
                                 <svg height="25" width="25">
                                     <circle cx="15" cy="15" r="8" stroke="black" stroke-width="1" fill="orange" fill-opacity="0.5" />
                                 </svg>
-                                {{ 'High' | translate }}
+                                High
                             </div>
                             <div>
                                 <svg height="25" width="25">
                                     <circle cx="15" cy="15" r="8" stroke="black" stroke-width="1" fill="yellow" fill-opacity="0.5" />
                                 </svg>
-                                {{ 'Medium' | translate }}
+                                Medium
                             </div>
                             <div>
                                 <svg height="25" width="25">
                                     <circle cx="15" cy="15" r="8" stroke="black" stroke-width="1" fill="blue" fill-opacity="0.5" />
                                 </svg>
-                                {{ 'Low' | translate }}
+                                Low
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
@bgirardot the legend on the contribute page did not translate well and was generating Angular errors. I have reverted to non translatable strings for now. We'll probably have the same issue on the project page legend. I'll have a look at what is causing it when I get a moment.