### PR TITLE
Incorrect null check, should check for empty list. 

### DIFF
--- a/server/models/postgis/task.py
+++ b/server/models/postgis/task.py
@@ -111,8 +111,8 @@ class TaskHistory(db.Model):
                     TaskHistory.action == TaskAction.STATE_CHANGE.name) \
             .order_by(TaskHistory.action_date.desc()).all()
 
-        if result is None:
-            return TaskStatus.READY
+        if not result:
+            return TaskStatus.READY  # No result so default to ready status
 
         if len(result) == 1 and for_undo:
             # We're looking for the previous status, however, there isn't any so we'll return Ready


### PR DESCRIPTION
This should fix error #668 when attempting to stop mapping.

@bgirardot note that any tasks you previously attempted to stop mapping on will now contain a data error that will need to be cleaned up with a database fix.  To fix these you will need to run the following Update on the DB

update task_history
   set action_text = NULL
 where id in (select th.id
                from tasks t,
                     task_history th
               where t.id = th.task_id
                 and t.project_id = th.project_id
                 and t.locked_by = th.user_id
                 and t.locked_by is not null
                 and th.action_text is not null
                 and t.mapped_by is null
                 and th.action = 'LOCKED_FOR_MAPPING');

