### PR TITLE
include missing maps profile link

### DIFF
--- a/client/app/profile/profile.html
+++ b/client/app/profile/profile.html
@@ -70,6 +70,11 @@
                                     </a>
                                    </p>
                                 <p>
+                                    <a href="http://www.missingmaps.org/users/#/{{ profileCtrl.username }}/history" target="_blank" rel="noopener">
+                                        {{ 'Missing Maps Badges' | translate }}
+                                    </a>
+                                    </p>
+                                <p>
                                     <a href="http://www.openstreetmap.org/user/{{ profileCtrl.username }}/history" target="_blank" rel="noopener">
                                         {{ 'OSM edit history' | translate }}
                                     </a>


### PR DESCRIPTION
This allows uses to see the badges they earn in a link.