### PR TITLE
Fix Go to project link behavior

### DIFF
--- a/client/app/admin/edit-project/edit-project.html
+++ b/client/app/admin/edit-project/edit-project.html
@@ -499,10 +499,10 @@
                                     <button class="button button--primary" type="button"
                                             ng-click="editProjectCtrl.saveEdits()">{{ 'Save changes' | translate }}
                                     </button>
-                                    <button class="button button--achromic button--secondary" role="button"
+                                    <a class="button button--achromic button--secondary"
                                        href="/project/{{ editProjectCtrl.project.projectId }}">
                                         {{ 'Go to project' | translate }}
-                                    </button>
+                                    </a>
                                 </div>
                                 <div class="button-group">
                                     <div>


### PR DESCRIPTION
Fixes #729
This issue may have happened elsewhere when the big 164f58cb commit was merged.
Note: it's not possible to change an `<a href="...">`to a `<button href="...">`.