### PR TITLE
Refresh mapper level helper

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -5,6 +5,7 @@ from flask_script import Manager
 
 from server import create_app
 from server.services.users.authentication_service import AuthenticationService
+from server.services.users.user_service import UserService
 
 # Initialise the flask app object
 application = create_app()
@@ -21,6 +22,13 @@ def gen_token(user_id):
     print(f'Raw token is: {token}')
     b64_token = base64.b64encode(token.encode())
     print(f'Your base64 encoded session token: {b64_token}')
+
+
+@manager.command
+def refresh_levels():
+    print('Started updating mapper levels...')
+    users_updated = UserService.refresh_mapper_level()
+    print(f'Updated {users_updated} user mapper levels')
 
 
 if __name__ == '__main__':

--- a/server/models/postgis/user.py
+++ b/server/models/postgis/user.py
@@ -91,6 +91,11 @@ class User(db.Model):
         return dto
 
     @staticmethod
+    def get_all_users_not_pagainated():
+        return db.session.query(User.id).all()
+
+
+    @staticmethod
     def filter_users(user_filter: str, page: int) -> UserFilterDTO:
         """ Finds users that matches first characters, for auto-complete """
         results = db.session.query(User.username).filter(User.username.ilike(user_filter.lower() + '%')) \

--- a/server/models/postgis/user.py
+++ b/server/models/postgis/user.py
@@ -92,6 +92,7 @@ class User(db.Model):
 
     @staticmethod
     def get_all_users_not_pagainated():
+        """ Get all users in DB"""
         return db.session.query(User.id).all()
 
 

--- a/server/services/users/user_service.py
+++ b/server/services/users/user_service.py
@@ -228,3 +228,20 @@ class UserService:
 
         user.save()
         return user
+
+    @staticmethod
+    def refresh_mapper_level() -> int:
+        """ Helper function to run thru all users in the DB and update their mapper level """
+        users = User.get_all_users_not_pagainated()
+        users_updated = 1
+        total_users = len(users)
+
+        for user in users:
+            UserService.check_and_update_mapper_level(user.id)
+
+            if users_updated % 50 == 0:
+                print(f'{users_updated} users updated of {total_users}')
+
+            users_updated += 1
+
+        return users_updated


### PR DESCRIPTION
Helper for #706   To allow us to set the mapper level for all users, I've added a wee helper that will initialise the level for all users in the db.  You will need to have an environment that can be connected to the live DB to run it.

Once updated the levels are recalculated everytime a users submits mapping so it should be fine.  You can run it from the solution as follows:

python manage.py refresh_levels

It will probably take an hour to run, but it will print out progress as it goes.  I seem to remember I had a clever hack to do this really fast previously, but I can't remember it.

@pgiraud @david-hotosm @bgirardot let me know if you have any questions