### PR TITLE
Add project AOI json endpoint

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -96,7 +96,8 @@ def init_flask_restful_routes(app):
     from server.api.messaging.project_chat_apis import ProjectChatAPI
     from server.api.project_admin_api import ProjectAdminAPI, ProjectCommentsAPI, ProjectInvalidateAll,\
         ProjectValidateAll, ProjectsForAdminAPI
-    from server.api.project_apis import ProjectAPI, ProjectSearchAPI, HasUserTaskOnProject, HasUserTaskOnProjectDetails, ProjectSearchBBoxAPI, ProjectSummaryAPI
+    from server.api.project_apis import ProjectAPI, ProjectAOIAPI, ProjectSearchAPI, HasUserTaskOnProject,\
+        HasUserTaskOnProjectDetails, ProjectSearchBBoxAPI, ProjectSummaryAPI
     from server.api.swagger_docs_api import SwaggerDocsAPI
     from server.api.stats_api import StatsContributionsAPI, StatsActivityAPI, StatsProjectAPI
     from server.api.tags_apis import CampaignsTagsAPI, OrganisationTagsAPI
@@ -130,6 +131,7 @@ def init_flask_restful_routes(app):
     api.add_resource(ProjectSearchAPI,              '/api/v1/project/search')
     api.add_resource(ProjectSearchBBoxAPI,          '/api/v1/projects/within-bounding-box')
     api.add_resource(ProjectAPI,                    '/api/v1/project/<int:project_id>')
+    api.add_resource(ProjectAOIAPI,                 '/api/v1/project/<int:project_id>/aoi')
     api.add_resource(ProjectChatAPI,                '/api/v1/project/<int:project_id>/chat')
     api.add_resource(HasUserTaskOnProject,          '/api/v1/project/<int:project_id>/has-user-locked-tasks')
     api.add_resource(HasUserTaskOnProjectDetails,   '/api/v1/project/<int:project_id>/has-user-locked-tasks/details')

--- a/server/api/project_apis.py
+++ b/server/api/project_apis.py
@@ -1,3 +1,5 @@
+import geojson, io
+from flask import send_file
 from flask_restful import Resource, current_app, request
 from schematics.exceptions import DataError
 from distutils.util import strtobool
@@ -57,6 +59,57 @@ class ProjectAPI(Resource):
                 ProjectService.auto_unlock_tasks(project_id)
             except Exception as e:
                 current_app.logger.critical(str(e))
+
+
+class ProjectAOIAPI(Resource):
+    def get(self, project_id):
+        """
+        Get AOI of Project
+        ---
+        tags:
+            - mapping
+        produces:
+            - application/json
+        parameters:
+            - name: project_id
+              in: path
+              description: The unique project ID
+              required: true
+              type: integer
+              default: 1
+            - in: query
+              name: as_file
+              type: boolean
+              description: Set to false if file download not preferred
+              default: True
+        responses:
+            200:
+                description: Project found
+            403:
+                description: Forbidden
+            404:
+                description: Project not found
+            500:
+                description: Internal Server Error
+        """
+        try:
+            as_file = strtobool(request.args.get('as_file')) if request.args.get('as_file') else True
+
+            project_aoi = ProjectService.get_project_aoi(project_id)
+
+            if as_file:
+                return send_file(io.BytesIO(geojson.dumps(project_aoi).encode('utf-8')), mimetype='application/json',
+                                 as_attachment=True, attachment_filename=f'project.geoJSON')
+
+            return project_aoi, 200
+        except NotFound:
+            return {"Error": "Project Not Found"}, 404
+        except ProjectServiceError as e:
+            return {"Error": str(e)}, 403
+        except Exception as e:
+            error_msg = f'Project GET - unhandled error: {str(e)}'
+            current_app.logger.critical(error_msg)
+            return {"Error": error_msg}, 500
 
 
 class ProjectSearchBBoxAPI(Resource):

--- a/server/api/project_apis.py
+++ b/server/api/project_apis.py
@@ -99,7 +99,7 @@ class ProjectAOIAPI(Resource):
 
             if as_file:
                 return send_file(io.BytesIO(geojson.dumps(project_aoi).encode('utf-8')), mimetype='application/json',
-                                 as_attachment=True, attachment_filename=f'project.geoJSON')
+                                 as_attachment=True, attachment_filename=f'{str(project_id)}.geoJSON')
 
             return project_aoi, 200
         except NotFound:

--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -46,6 +46,11 @@ class ProjectService:
         return project.as_dto_for_mapping(locale)
 
     @staticmethod
+    def get_project_aoi(project_id):
+        project = ProjectService.get_project_by_id(project_id)
+        return project.get_aoi_geometry_as_geojson()
+
+    @staticmethod
     def get_task_for_logged_in_user(project_id: int, user_id: int):
         """ if the user is working on a task in the project return it """
         project = ProjectService.get_project_by_id(project_id)


### PR DESCRIPTION
First half of #789: provide an API endpoint to access only the area of interest of a project as a JSON file.

Specific url endpoint is `/api/v1/project/#####/aoi`.

@bgirardot this doesn't completely match the url from TM2, but mostly follows naming scheme of other API endpoints. Please comment on yes/no for that.

Default behavior. Accessing the url as listed above will prompt download for a file, or if accessed via API GUI, a link to download the file will show up. File downloaded is named `project.json`:
![When download as a file is not set or set to yes](https://user-images.githubusercontent.com/8998918/30245571-c40bb2e2-95a3-11e7-8e0c-b24d8b609689.PNG)


By specifying ?as_file=false, the user can load the data in browser:
![When download as a file is set to no](https://user-images.githubusercontent.com/8998918/30245556-fb72fe44-95a2-11e7-9a99-e0dba4b09d4c.PNG)

