### PR TITLE
add faq page, update what is new page

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,45 +1,59 @@
-machine:
-  python:
-    version: 3.6.1
-
-dependencies:
-  cache_directories:
-    # relative to the build directory
-    - "client/node_modules"
-    - "env"
-  pre:
-    - |
-      # Install latest LTS node
-      sudo apt-get update
-      curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
-      sudo apt-get install nodejs libgeos-c1 libgeos-dev # Required for shapely
-      node --version
-  override:
-    - |
-      # Install NPM packages and build client from gulpfile
-      cd client
-      npm install
-      ./node_modules/.bin/gulp build
-      cd ..
-      # Install Python dependencies
-      virtualenv env
-      env/bin/pip install --upgrade pip
-      env/bin/pip install -r requirements.txt
-
-test:
-  override:
-    - |
-      # JS Unit Tests
-      cd tests/client
-      ../../client/node_modules/.bin/karma start ./karma.conf.js \
-        --single-run --browsers PhantomJS --reporters junit
-    - |
-      # Run Python tests
-      env/bin/nosetests ./tests/server --with-xunit \
-        --xunit-file $CIRCLE_TEST_REPORTS/unitresults.xml \
-        --with-coverage --cover-erase --cover-package=./server
-      env/bin/coverage xml -o $CIRCLE_TEST_REPORTS/coverage.xml
-  post:
-    - |
-      chmod +x ./devops/ci/circleci_deploy.sh
-      ./devops/ci/circleci_deploy.sh
+version: 2
+jobs:
+  build:
+    working_directory: /app
+    docker:
+      - image: python:3.6
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Install dependencies
+          command: |
+              # Install latest LTS node
+              apt-get update
+              curl -sL https://deb.nodesource.com/setup_6.x | bash -
+              apt-get install -y nodejs libgeos-c1 libgeos-dev # Required for shapely
+              node --version
+      - restore_cache:
+          keys:
+            - cached-directories
+          paths:
+            - /app/client/node_modules
+            - /app/env
+      - run:
+          name: Install requirements
+          command: |
+            # Install NPM packages and build client from gulpfile
+            cd /app/client
+            npm install
+            ./node_modules/.bin/gulp build
+            cd /app
+            # Install Python dependencies
+            pip install virtualenv
+            virtualenv env
+            /app/env/bin/pip install --upgrade pip
+            /app/env/bin/pip install -r requirements.txt
+      - run:
+          name: Run tests
+          command: |
+            # JS Unit Tests
+            cd /app/tests/client
+            ../../client/node_modules/.bin/karma start ./karma.conf.js \
+              --single-run --browsers PhantomJS --reporters junit
+            # Run Python tests
+            cd /app
+            env/bin/nosetests ./tests/server --with-xunit \
+              --xunit-file $CIRCLE_TEST_REPORTS/unitresults.xml \
+              --with-coverage --cover-erase --cover-package=./server
+            env/bin/coverage xml -o $CIRCLE_TEST_REPORTS/coverage.xml
+      - save_cache:
+          key: cached-directories
+          paths:
+            - /app/client/node_modules
+            - /app/env
+      - deploy:
+          name: Deploy application
+          command: |
+            chmod +x /app/devops/ci/circleci_deploy.sh
+            /app/devops/ci/circleci_deploy.sh

--- a/client/app/about/faq.html
+++ b/client/app/about/faq.html
@@ -1,0 +1,60 @@
+<div class="inner">
+    <section class="section section--asided">
+        <header class="section__header">
+            <div class="inner">
+                <h1 class="section__title">
+                    {{ "Frequently Asked Questions" | translate }}
+                </h1>
+                <p>
+                    Have questions about the new Tasking Manager? Read more below for answers to some of the most frequently asked questions by the community. If you want to know more about the new improvements to the Tasking Manger, <a href="/what-is-new">read more in the what is new section.</a>
+                </p>
+            </div>
+        </header>
+        <div class="section-container">
+            <div class="section__body section__body--secondary">
+                <div class="inner">
+                    <h3>What is Tasking Manager 3 (TM3)?</h3>
+                    <p>
+                        A new and improved version of the Tasking Manager was developed by HOT with support by USAID and DFAT during 2017. More information about what’s new in TM3 can be found here: <a href="http://tm3.hotosm.org/what-is-new">http://tm3.hotosm.org/what-is-new</a>.
+                    </p>
+                    <h3>When will TM3 be launched?</h3>
+                    <p>
+                        HOT originally planned to launch TM3 at the beginning of September, but because of several disaster response activations, the launch was delayed in order to avoid any potential issue with switching to a new platform for thousands of HOT mappers. We are now planning to launch TM3 during the week of October 16-20.
+                    </p>
+                    <h3>How will the switch from the current Tasking Manager (TM2) to TM3 happen?</h3>
+                    <p>
+                        TM3 introduces an enhanced backend which supports many new features, but doesn’t allow to run TM2 from the same database. Therefore the switch from TM2 to TM3 will involve a “hard cutover”, meaning that once TM3 is activated at tasks.hotosm.org, the TM2 platform will be turned off and become inaccessible. All projects from TM2 will automatically be ported to TM3 and mappers will be able to continue mapping in TM3 from where they left in TM2.
+                    </p>
+                    <h3>Will there be any downtime during the transition?</h3>
+                    <p>
+                        Yes, there might be up to one hour when both TM2 and TM3 will not be accessible. This will happen during late afternoon Pacific time / night European time, hoping to minimize any potential disruption.
+                    </p>
+                    <h3>What happens to my TM2 projects? Will they be available in TM3?</h3>
+                    <p>
+                        Yes, all projects created in TM2 will automatically be transferred to TM3, including all data and current progress on each task.
+                    </p>
+                    <h3>Where can I learn more about how TM3 works?</h3>
+                    <p>
+                        Detailed user documentation is available on LearnOSM: http://learnosm.org/en/coordination/tasking-manager3/ Videos have also been created: https://youtu.be/tWbaxdQrZSo (What’s new for mappers), https://youtu.be/yLTubyUePG8 (What’s new for validators).
+                    </p>
+                    <h3>When should project manager stop creating new projects in TM2?</h3>
+                    <p>
+                        Projects can be created until right before the switch to TM3 happens. A project that was just created in TM2, but hasn’t been published, will automatically be available in TM3 as a draft right after the switch.
+                    </p>
+                    <h3>What happens to projects that I created on the test TM3 instance (http://tm3.hotosm.org/)?</h3>
+                    <p>
+                        All projects that were created during the test phase at http://tm3.hotosm.org/ will be deleted right before launch. All data will be replaced with existing TM2 projects as soon as the switch happens.
+                    </p>
+                    <h3>How can I get some help if something doesn’t work after the switch?</h3>
+                    <p>
+                        You can report any issue at <a href="https://github.com/hotosm/tasking-manager/issues">https://github.com/hotosm/tasking-manager/issues</a> or join us on the <a href="https://slack.hotosm.org/">Slack #tasking_manager_3 channel</a> with any question.
+                    </p>
+                    <h3>What if I run my own TM2?</h3>
+                    <p>The code and community around Tasking Manager v2 will still exist. If you have questions about the older version, reach out via the <a href="https://github.com/hotosm/osm-tasking-manager2/issues">GitHub issues page</a>. If you want to upgrade to TM3, <a href="https://github.com/hotosm/tasking-manager/blob/develop/README.md">get started with the README</a>.</p>
+                </div>
+                <div class="inner">
+                </div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/client/app/about/what-is-new.html
+++ b/client/app/about/what-is-new.html
@@ -5,12 +5,17 @@
                 <h1 class="section__title">
                     {{ "What is New in the Tasking Manager 3" | translate }}
                 </h1>
+                <p>
+                    The Tasking Manager 3 has new features and functionality that are meant to improve the experience of everyone that uses it. Most of the individual improvements bring benefits to each group of users, mappers, validators and project managers. But the improvements can be divided into three broad categories: Improvements for Mappers, improvements for validators and improvements for mapping project managers.
+                </p>
+                <p>
+                    Read more below about the major improvements for mappers and validators. Have some immediate questions? <a href="/faq">Jump over to read the FAQs.</a>
+                </p>
             </div>
         </header>
         <div class="section-container">
             <div class="section__body section__body--secondary">
                 <div class="inner">
-                    <p>The Tasking Manager 3 has new features and functionality that are meant to improve the experience of everyone that uses it. Most of the individual improvements bring benefits to each group of users, mappers, validators and project managers. But the improvements can be divided into three broad categories: Improvements for Mappers, improvements for validators and improvements for mapping project managers.</p>
                     <h3>Improvements for Mappers</h3>
                     <ul>
                         <li><p>Expanded User Profile and Contact information - Please make the first thing you do in the new Tasking Manager visiting your <a title="{{ 'user profile' | translate }}" ng-click="accountNavCtrl.goToProfile()">{{ 'user profile' | translate }}</a>. There you will see your mapper experience level and most importantly, can fill in your user contact information so you can get feedback on your mapping delivered to your email in-box.</p></li>

--- a/client/app/taskingmanager.app.js
+++ b/client/app/taskingmanager.app.js
@@ -90,8 +90,12 @@
                     templateUrl: 'app/learn/learn.html'
                 })
 
-                .when('/whatisnew', {
-                    templateUrl: 'app/about/whatisnew.html'
+                .when('/what-is-new', {
+                    templateUrl: 'app/about/what-is-new.html'
+                })
+
+                .when('/faq', {
+                    templateUrl: 'app/about/faq.html'
                 })
 
                 .when('/contribute', {

--- a/client/index.html
+++ b/client/index.html
@@ -88,8 +88,8 @@
                         </a>
                     </li>
                     <li>
-                        <a href="/whatisnew" title="{{ 'New features in the Tasking Manager' | translate }}" class="global-menu-item">
-                            <span>{{ 'What is New' | translate }}</span>
+                        <a href="/what-is-new" title="{{ 'New features in the Tasking Manager' | translate }}" class="global-menu-item">
+                            <span>{{ 'What is New?' | translate }}</span>
                         </a>
                     </li>
                 </ul>


### PR DESCRIPTION
* Adds a FAQ page at `/faq`
* Rearranges the text on the what is new page
* Proposing a cosmetic change to the What is New Page --- move from `/whatisnew` to `/what-is-new`. It's a bit easier to read. 