### PR TITLE
Add bing imagery to layer switcher

### DIFF
--- a/client/app/services/map.service.js
+++ b/client/app/services/map.service.js
@@ -18,6 +18,7 @@
             getOSMMap: getOSMMap,
             addXYZLayer: addXYZLayer,
             addTiledWMSLayer: addTiledWMSLayer,
+            addBingLayer: addBingLayer,
             addGeocoder: addGeocoder,
             addOverviewMap: addOverviewMap
         };
@@ -30,6 +31,7 @@
          * Supported additional layers:
          *    - XYZ
          *    - WMS
+         *    - Bing
          * @param targetElement
          * @param disableScroll - optional - defaults to false
          */
@@ -78,6 +80,9 @@
                     }
                     if (additionalLayers[i].type === 'WMS'){
                         addTiledWMSLayer(additionalLayers[i].name, additionalLayers[i].url, additionalLayers[i].layerName, additionalLayers[i].attribution)
+                    }
+                    if (additionalLayers[i].type === 'bing'){
+                        addBingLayer(additionalLayers[i].name, additionalLayers[i].key, additionalLayers[i].imagerySet, additionalLayers[i].attribution)
                     }
                 }
             }
@@ -147,6 +152,7 @@
          * @param name
          * @param url
          * @param layer
+         * @param attribution
          * @param visible
          */
         function addTiledWMSLayer(name, url, layer, attribution, visible){
@@ -170,6 +176,37 @@
                 source: source
             });
             map.addLayer(wmsLayer);
+        }
+        
+        
+        /**
+         * Add bing WMS layer
+         * @param name
+         * @param key
+         * @param imagerySet
+         * @param attribution
+         * @param visible
+         */
+        function addBingLayer(name, key, imagerySet, attribution, visible){
+            var visibility = false;
+            if (visible){
+                visibility = true;
+            }
+            var source = new ol.source.BingMaps({
+              key: key,
+              imagerySet: imagerySet,
+            })
+            if (attribution){
+                source.setAttributions(attribution);
+            }
+            var bingLayer = new ol.layer.Tile({
+                preload: Infinity,
+                visible: visibility,
+                title: name,
+                type: 'base',
+                source: source
+            });
+            map.addLayer(bingLayer);
         }
         
         /**

--- a/client/taskingmanager.config.json
+++ b/client/taskingmanager.config.json
@@ -17,6 +17,13 @@
           "layerName": "gpw-v3:gpw-v3-population-density-future-estimates_2005",
           "type": "WMS",
           "attribution": "test"
+        },
+        {
+          "id": "bing",
+          "name": "Bing Imagery",
+          "type": "bing",
+          "key": "AioPAglzP9Qw32KN17dOkKYRdSlzj7W5kIQY6zct_UCmGc0WRxAh-QeiRBpRUgrv",
+          "imagerySet": "Aerial"
         }
       ]
     }


### PR DESCRIPTION
Add bing imagery as a configureable layer option, enabled by default to appear
in the layer switcher

fixes: https://github.com/hotosm/tasking-manager/issues/793

Looks like this:
![screen shot 2017-10-17 at 01 00 49](https://user-images.githubusercontent.com/227525/31640502-cf6690d0-b2d6-11e7-9ebe-33e210b2f334.png)
