### PR TITLE
fix text overflow for long titles

### DIFF
--- a/client/assets/styles/sass/_contribute.scss
+++ b/client/assets/styles/sass/_contribute.scss
@@ -107,6 +107,7 @@
 
   &__content {
     padding: 1.3rem 1.8rem 1.75rem;
+    overflow: hidden;
 
     @include media(medium-up) {
       padding: 2.5rem 2.5rem 3rem;


### PR DESCRIPTION
Adds `overflow: hidden` to a section of the individual contribute panels. This makes the panel longer. 

![hot tasking manager 2017-10-18 05-16-53](https://user-images.githubusercontent.com/796838/31701010-24202bba-b3c5-11e7-85b0-30c0a6b35252.png)

Fix makes the panel longer. May want to address this in a different way. Like limit title length. 

![hot tasking manager 2017-10-18 05-28-53](https://user-images.githubusercontent.com/796838/31701022-4842a068-b3c5-11e7-963b-f774c2a23be2.png)

