### PR TITLE
Include other layers to release

### DIFF
--- a/client/taskingmanager.config.json
+++ b/client/taskingmanager.config.json
@@ -38,6 +38,21 @@
           "url": "https://api.mapbox.com/v4/openstreetmap.map-inh7ifmo/{z}/{x}/{y}.png?access_token=pk.eyJ1Ijoib3BlbnN0cmVldG1hcCIsImEiOiJhNVlHd29ZIn0.ti6wATGDWOmCnCYen-Ip7Q",
           "type": "XYZ",
           "attribution": "<a href='https://www.mapbox.com/about/maps/' target='_blank'>© Mapbox</a> <a href='http://www.openstreetmap.org/about/' target='_blank'>© OpenStreetMap</a> <a href='https://www.mapbox.com/feedback/#/-74.5/40/10' target='_blank'>Improve this map</a>"
+        },
+        {
+          "id": "Population density WMS",
+          "name": "Population density",
+          "url": "http://sedac.ciesin.columbia.edu/geoserver/wms",
+          "layerName": "gpw-v3:gpw-v3-population-density-future-estimates_2005",
+          "type": "WMS",
+          "attribution": "test"
+        },
+        {
+          "id": "bing",
+          "name": "Bing Imagery",
+          "type": "bing",
+          "key": "AioPAglzP9Qw32KN17dOkKYRdSlzj7W5kIQY6zct_UCmGc0WRxAh-QeiRBpRUgrv",
+          "imagerySet": "Aerial"
         }
       ]
     }


### PR DESCRIPTION
The other map layers, namely population density and Bing, are currently only configured to run on local instances. This is adding those to the "release" environment, which will make them appear on the tasks-stage. and tasks. sites.

cc: @bgirardot this is why https://github.com/hotosm/tasking-manager/commit/4a0a7a2d4dd7f92b63434305dfbaab6ffa1bd04f#commitcomment-25107692 is happening. To confirm, we want both of these layers on the live instance?