### PR TITLE
Update TM3 username if OSM username changed

### DIFF
--- a/server/models/postgis/user.py
+++ b/server/models/postgis/user.py
@@ -48,6 +48,11 @@ class User(db.Model):
         """ Return the user for the specified username, or None if not found """
         return User.query.filter_by(username=username).one_or_none()
 
+    def update_username(self, username: str):
+        """ Update the username """
+        self.username = username
+        db.session.commit()
+
     def update(self, user_dto: UserDTO):
         """ Update the user details """
         self.email_address = user_dto.email_address.lower() if user_dto.email_address else None

--- a/server/services/users/authentication_service.py
+++ b/server/services/users/authentication_service.py
@@ -71,6 +71,7 @@ class AuthenticationService:
 
         try:
             UserService.get_user_by_id(osm_id)
+            UserService.update_username(osm_id, username)
         except NotFound:
             # User not found, so must be new user
             changesets = osm_user.find('changesets')

--- a/server/services/users/user_service.py
+++ b/server/services/users/user_service.py
@@ -40,6 +40,14 @@ class UserService:
         return user
 
     @staticmethod
+    def update_username(user_id: int, osm_username: str) -> User:
+        user = UserService.get_user_by_id(user_id)
+        if user.username != osm_username:
+            user.update_username(osm_username)
+
+        return user
+
+    @staticmethod
     def register_user(osm_id, username, changeset_count):
         """
         Creates user in DB 

--- a/tests/server/helpers/test_files/osm_user_details_changed_name.xml
+++ b/tests/server/helpers/test_files/osm_user_details_changed_name.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="OpenStreetMap server">
+    <user id="7777777" display_name="Thinkwhere Test Changed" account_created="2017-01-23T16:23:22Z">
+        <description />
+        <contributor-terms agreed="true" pd="false" />
+        <roles />
+        <changesets count="16" />
+        <traces count="0" />
+        <blocks>
+            <received count="0" active="0" />
+        </blocks>
+        <languages>
+            <lang>en-GB</lang>
+            <lang>en</lang>
+        </languages>
+        <messages>
+            <received count="0" unread="0" />
+            <sent count="0" />
+        </messages>
+    </user>
+</osm>

--- a/tests/server/helpers/test_helpers.py
+++ b/tests/server/helpers/test_helpers.py
@@ -24,6 +24,18 @@ def get_canned_osm_user_details():
         raise FileNotFoundError('osm_user_details.xml not found')
 
 
+def get_canned_osm_user_details_changed_name():
+    """ Helper method to find test file, dependent on where tests are being run from """
+
+    location = os.path.join(os.path.dirname(__file__), 'test_files', 'osm_user_details_changed_name.xml')
+
+    try:
+        open(location, 'r')
+        return ET.parse(location)
+    except FileNotFoundError:
+        raise FileNotFoundError('osm_user_details_changed_name.xml not found')
+
+
 def get_canned_json(name_of_file):
     """ Read canned Grid request from file """
 

--- a/tests/server/integration/services/users/test_authentication_service.py
+++ b/tests/server/integration/services/users/test_authentication_service.py
@@ -4,7 +4,8 @@ from urllib.parse import urlparse, parse_qs
 
 from server import create_app
 from server.services.users.authentication_service import AuthenticationService
-from tests.server.helpers.test_helpers import get_canned_osm_user_details
+from tests.server.helpers.test_helpers import get_canned_osm_user_details, \
+    get_canned_osm_user_details_changed_name
 
 
 class TestAuthenticationService(unittest.TestCase):
@@ -47,5 +48,23 @@ class TestAuthenticationService(unittest.TestCase):
         query = parse_qs(parsed_url.query)
 
         self.assertEqual(query['username'][0], 'Thinkwhere Test')
+        self.assertTrue(query['session_token'][0])
+        self.assertEqual(query['redirect_to'][0], '/test/redirect')
+
+    def test_existing_user_changed_name(self):
+        if self.skip_tests:
+            return
+
+        # Arrange
+        osm_response = get_canned_osm_user_details_changed_name()
+
+        # Act
+        redirect_url = AuthenticationService().login_user(osm_response, '/test/redirect')
+
+        # Assert
+        parsed_url = urlparse(redirect_url)
+        query = parse_qs(parsed_url.query)
+
+        self.assertEqual(query['username'][0], 'Thinkwhere Test Changed')
         self.assertTrue(query['session_token'][0])
         self.assertEqual(query['redirect_to'][0], '/test/redirect')


### PR DESCRIPTION
Fixes #832 and other issues in Slack chat associated with users changing their OSM username then attempting to log into TM3 again.

I tested this manually and it worked. I'll write an automated test for this soon, but please feel free to review. 