### PR TITLE
Displays active mappers on contribute and mapping page

### DIFF
--- a/client/app/contribute/contribute.html
+++ b/client/app/contribute/contribute.html
@@ -164,8 +164,7 @@
                                                     <!--<uib-progressbar
                                                             value="project.percentValidated"></uib-progressbar>-->
 
-                                                        <dt class='num--large'>{{ project.activeMappers }}</dt>
-                                                        <dd>{{ 'Active Mappers' | translate }}</dd>
+                                                        <dd ng-show="project.activeMappers > 0" title="{{ 'Active Mappers' | translate }}"><span class="fa fa-user"></span> {{ project.activeMappers }}</dd>
                                                     </dl>
                                                </section>
                                             </a>

--- a/client/app/contribute/contribute.html
+++ b/client/app/contribute/contribute.html
@@ -163,6 +163,10 @@
                                                         <dd>{{ 'Validated' | translate }}</dd>
                                                     <!--<uib-progressbar
                                                             value="project.percentValidated"></uib-progressbar>-->
+
+                                                        <dt class='num--large'>{{ project.activeMappers }}</dt>
+                                                        <dd>{{ 'Active Mappers' | translate }}</dd>
+                                                  </dl>
                                                </section>
                                             </a>
                                         </div>

--- a/client/app/contribute/contribute.html
+++ b/client/app/contribute/contribute.html
@@ -166,7 +166,7 @@
 
                                                         <dt class='num--large'>{{ project.activeMappers }}</dt>
                                                         <dd>{{ 'Active Mappers' | translate }}</dd>
-                                                  </dl>
+                                                    </dl>
                                                </section>
                                             </a>
                                         </div>

--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -3,6 +3,7 @@
         <div class="inner">
             <div>
                 <mark>{{ projectCtrl.projectData.projectPriority }}</mark>
+                <span>{{ projectCtrl.projectData.activeMappers}} Active Mappers</span>
             </div>
             <div class="header--withShare">
                 <div class="section__header--left">

--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -3,7 +3,7 @@
         <div class="inner">
             <div>
                 <mark>{{ projectCtrl.projectData.projectPriority }}</mark>
-                <span>{{ projectCtrl.projectData.activeMappers}} Active Mappers</span>
+                <span class="active-mappers">{{ projectCtrl.projectData.activeMappers}} - Active Mappers</span>
             </div>
             <div class="header--withShare">
                 <div class="section__header--left">

--- a/client/assets/styles/sass/_contribute.scss
+++ b/client/assets/styles/sass/_contribute.scss
@@ -129,7 +129,7 @@
     dt, dd {
       margin-bottom: 0;
     }
-    dd { margin-right: 3em; }
+    dd { margin-right: 2em; }
   }
 }
 

--- a/client/assets/styles/sass/_contribute.scss
+++ b/client/assets/styles/sass/_contribute.scss
@@ -200,6 +200,11 @@
       width: 20%;
     }
   }
+  .active-mappers{
+    margin-left: 4em;
+    font-weight: bold;
+  }
+
   .ng-isolate-scope {
     overflow-y: visible;
     max-height: 100%;

--- a/client/taskingmanager.config.json
+++ b/client/taskingmanager.config.json
@@ -1,7 +1,7 @@
 {
   "development": {
     "EnvironmentConfig":{
-      "tmAPI": "http://tasking-manager-staging.eu-west-1.elasticbeanstalk.com/api/v1",
+      "tmAPI": "http://localhost:5000/api/v1",
       "layers": [
         {
           "id": "mapBoxAerial",

--- a/client/taskingmanager.config.json
+++ b/client/taskingmanager.config.json
@@ -1,7 +1,7 @@
 {
   "development": {
     "EnvironmentConfig":{
-      "tmAPI": "http://localhost:5000/api/v1",
+      "tmAPI": "http://tasking-manager-staging.eu-west-1.elasticbeanstalk.com/api/v1",
       "layers": [
         {
           "id": "mapBoxAerial",

--- a/server/models/dtos/project_dto.py
+++ b/server/models/dtos/project_dto.py
@@ -133,6 +133,7 @@ class ListSearchResultDTO(Model):
     percent_mapped = IntType(serialized_name='percentMapped')
     percent_validated = IntType(serialized_name='percentValidated')
     status = StringType(serialized_name='status')
+    active_mappers = IntType(serialized_name='activeMappers')
 
 
 class ProjectSearchResultsDTO(Model):

--- a/server/models/dtos/project_dto.py
+++ b/server/models/dtos/project_dto.py
@@ -89,6 +89,7 @@ class ProjectDTO(Model):
     priority_areas = BaseType(serialized_name='priorityAreas')
     last_updated = DateTimeType(serialized_name='lastUpdated')
     author = StringType()
+    active_mappers = IntType(serialized_name='activeMappers')
 
 
 class ProjectSearchDTO(Model):

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -316,14 +316,11 @@ class Project(db.Model):
     def get_active_mappers(project_id) -> int:
         """ Get count of Locked tasks as a proxy for users who are currently active on the project """
 
-        active_mappers_query = f'''SELECT COUNT(1) 
-                                    FROM tasks 
-                                   WHERE task_status IN (1, 3)
-                                     AND project_id = {project_id}'''
-
-        result = db.engine.execute(active_mappers_query)
-        for mappers in result:
-            return mappers[0]  # We know there will be only one row in result so return immediately
+        return Task.query \
+            .filter(Task.task_status.in_((TaskStatus.LOCKED_FOR_MAPPING.value,
+                                         TaskStatus.LOCKED_FOR_VALIDATION.value))) \
+            .filter(Task.project_id == project_id) \
+            .count()
 
     def _get_project_and_base_dto(self):
         """ Populates a project DTO with properties common to all roles """

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -308,6 +308,18 @@ class Project(db.Model):
         aoi_geojson = db.engine.execute(self.geometry.ST_AsGeoJSON()).scalar()
         return geojson.loads(aoi_geojson)
 
+    @staticmethod
+    def get_active_mappers(project_id) -> int:
+
+        active_mappers_query = f'''SELECT COUNT(1) 
+                                    FROM tasks 
+                                   WHERE task_status IN (1, 3)
+                                     AND project_id = {project_id}'''
+
+        result = db.engine.execute(active_mappers_query)
+        for mappers in result:
+            return mappers[0]  # We know there will be only one row in result so return immediately
+
     def _get_project_and_base_dto(self):
         """ Populates a project DTO with properties common to all roles """
         base_dto = ProjectDTO()

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -347,6 +347,7 @@ class Project(db.Model):
         base_dto.license_id = self.license_id
         base_dto.last_updated = self.last_updated
         base_dto.author = User().get_by_id(self.author_id).username
+        base_dto.active_mappers = Project.get_active_mappers(self.id)
 
         if self.private:
             # If project is private it should have a list of allowed users

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -317,8 +317,7 @@ class Project(db.Model):
         """ Get count of Locked tasks as a proxy for users who are currently active on the project """
 
         return Task.query \
-            .filter(Task.task_status.in_((TaskStatus.LOCKED_FOR_MAPPING.value,
-                                         TaskStatus.LOCKED_FOR_VALIDATION.value))) \
+            .filter(Task.task_status == TaskStatus.LOCKED_FOR_MAPPING.value) \
             .filter(Task.project_id == project_id) \
             .count()
 

--- a/server/services/project_search_service.py
+++ b/server/services/project_search_service.py
@@ -20,7 +20,6 @@ search_cache = TTLCache(maxsize=128, ttl=300)
 MAX_AREA = math.pow(1250*4275*1.5,2)
 
 
-
 class ProjectSearchServiceError(Exception):
     """ Custom Exception to notify callers an error occurred when handling mapping """
 
@@ -83,6 +82,7 @@ class ProjectSearchService:
             list_dto.percent_validated = round(
                 ((project.tasks_validated + project.tasks_bad_imagery) / project.total_tasks) * 100, 0)
             list_dto.status = ProjectStatus(project.status).name
+            list_dto.active_mappers = Project.get_active_mappers(project.id)
 
             dto.results.append(list_dto)
 


### PR DESCRIPTION
PR to show active mappers on contribute and project page to address #627  Couple of things to note:

* Counts use locked tasks as a proxy for active users (thanks @pgiraud for the awesome idea)
* Counts are cached for 30 seconds to reduce DB load, could reduce time a bit if needed
* @bgirardot you'll want to review the text I've used on the HTML and make sure it's translated as needed
* I'm not really a designer so someone might want to look at how counts are displayed, but works for now :)

Give me a shout if there's any questions

Thanks
Iain