### PR TITLE
Count only tasks locked for mapping

### DIFF
--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -317,8 +317,7 @@ class Project(db.Model):
         """ Get count of Locked tasks as a proxy for users who are currently active on the project """
 
         return Task.query \
-            .filter(Task.task_status.in_((TaskStatus.LOCKED_FOR_MAPPING.value,
-                                         TaskStatus.LOCKED_FOR_VALIDATION.value))) \
+            .filter(Task.task_status == TaskStatus.LOCKED_FOR_MAPPING.value) \
             .filter(Task.project_id == project_id) \
             .count()
 


### PR DESCRIPTION
It makes more sense to exclude the tasks locked for validation. Even more when we take into account that a validator can lock several tasks at a time.