### PR TITLE
Use protocol naive URL for map tiles

### DIFF
--- a/client/app/services/map.service.js
+++ b/client/app/services/map.service.js
@@ -45,7 +45,7 @@
                 layers: [
                     new ol.layer.Tile({
                         source: new ol.source.OSM({
-                            url: "http://{a-c}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
+                            url: "//{a-c}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png",
                             attributions: "<a href='http://www.openstreetmap.org/copyright/' target='_blank'>© OpenStreetMap</a> contributors"
                         }),
                         title: 'OpenStreetMap',


### PR DESCRIPTION
This avoids "mixed content" warnings.