### PR TITLE
Round project percent done/validated down

### DIFF
--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -297,8 +297,8 @@ class Project(db.Model):
         centroid_geojson = db.session.scalar(self.centroid.ST_AsGeoJSON())
         summary.aoi_centroid = geojson.loads(centroid_geojson)
 
-        summary.percent_mapped = round((self.tasks_mapped / (self.total_tasks - self.tasks_bad_imagery)) * 100, 0)
-        summary.percent_validated = round(((self.tasks_validated + self.tasks_bad_imagery) / self.total_tasks) * 100, 0)
+        summary.percent_mapped = int((self.tasks_mapped / (self.total_tasks - self.tasks_bad_imagery)) * 100)
+        summary.percent_validated = int(((self.tasks_validated + self.tasks_bad_imagery) / self.total_tasks) * 100)
 
         project_info = ProjectInfo.get_dto_for_locale(self.id, preferred_locale, self.default_locale)
         summary.name = project_info.name


### PR DESCRIPTION
Rather than using the round function, int will floor the percent mapped or validated down to the nearest whole number--only 100% will happen when 100% are done. 99.9% will go to 99. 

Fixes #909, #829. Possibly the solution to #868 as well.