### PR TITLE
Include pm status in search cache

### DIFF
--- a/server/models/dtos/project_dto.py
+++ b/server/models/dtos/project_dto.py
@@ -111,7 +111,7 @@ class ProjectSearchDTO(Model):
                 hashable_mapping_types = hashable_mapping_types + mapping_type
 
         return hash((self.preferred_locale, self.mapper_level, hashable_mapping_types, self.organisation_tag,
-                     self.campaign_tag, self.page, self.text_search))
+                     self.campaign_tag, self.page, self.text_search, self.is_project_manager))
 
 
 class ProjectSearchBBoxDTO(Model):


### PR DESCRIPTION
Currently, the hash for the project search that allows it to be cached does not include the recently introduced `is_project_manager` variable. This means some searches return draft and archived projects even for non-project managers.

The following PR should alleviate that by caching the project manager status in that hash.