### PR TITLE
Disallow validation on projects in draft or archive status for mappers

### DIFF
--- a/server/models/postgis/statuses.py
+++ b/server/models/postgis/statuses.py
@@ -57,6 +57,7 @@ class ValidatingNotAllowed(Enum):
     USER_NOT_VALIDATOR = 100
     USER_NOT_ACCEPTED_LICENSE = 101
     USER_NOT_ON_ALLOWED_LIST = 102
+    PROJECT_NOT_PUBLISHED = 103
 
 
 class UserRole(Enum):

--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -134,6 +134,9 @@ class ProjectService:
         """ Check if the user is allowed to validate on the project in scope """
         project = ProjectService.get_project_by_id(project_id)
 
+        if ProjectStatus(project.status) != ProjectStatus.PUBLISHED:
+            return False, MappingNotAllowed.PROJECT_NOT_PUBLISHED
+
         if project.enforce_validator_role and not UserService.is_user_validator(user_id):
             return False, ValidatingNotAllowed.USER_NOT_VALIDATOR
 

--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -134,7 +134,7 @@ class ProjectService:
         """ Check if the user is allowed to validate on the project in scope """
         project = ProjectService.get_project_by_id(project_id)
 
-        if ProjectStatus(project.status) != ProjectStatus.PUBLISHED:
+        if ProjectStatus(project.status) != ProjectStatus.PUBLISHED and not UserService.is_user_a_project_manager(user_id):
             return False, ValidatingNotAllowed.PROJECT_NOT_PUBLISHED
 
         if project.enforce_validator_role and not UserService.is_user_validator(user_id):

--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -135,7 +135,7 @@ class ProjectService:
         project = ProjectService.get_project_by_id(project_id)
 
         if ProjectStatus(project.status) != ProjectStatus.PUBLISHED:
-            return False, MappingNotAllowed.PROJECT_NOT_PUBLISHED
+            return False, ValidatingNotAllowed.PROJECT_NOT_PUBLISHED
 
         if project.enforce_validator_role and not UserService.is_user_validator(user_id):
             return False, ValidatingNotAllowed.USER_NOT_VALIDATOR


### PR DESCRIPTION
Originally, anyone was able to validate or invalidate tasks on a project whether it was in draft, archive, or published mode. This restricts validation in archived or draft statuses to only project managers.

Fixes #919. Part of #866 is also resolved with this (only the validating).