### PR TITLE
Add authentication on search

### DIFF
--- a/client/app/services/search.service.js
+++ b/client/app/services/search.service.js
@@ -31,10 +31,7 @@
                 method: 'GET',
                 url: configService.tmAPI + '/project/search',
                 params: searchParams,
-                headers: {
-                    'Content-Type': 'application/json; charset=UTF-8',
-                    'Accept-Language': preferredLanguage
-                }
+                headers: authService.getAuthenticatedHeader()
             }).then(function successCallback(response) {
                 // this callback will be called asynchronously
                 // when the response is available

--- a/server/api/project_apis.py
+++ b/server/api/project_apis.py
@@ -253,6 +253,8 @@ class ProjectSearchAPI(Resource):
             search_dto.campaign_tag = request.args.get('campaignTag')
             search_dto.page = int(request.args.get('page')) if request.args.get('page') else 1
             search_dto.text_search = request.args.get('textSearch')
+
+            # See https://github.com/hotosm/tasking-manager/pull/922 for more info
             try:
                 verify_token(request.environ.get('HTTP_AUTHORIZATION').split(None, 1)[1])
                 if UserService.is_user_a_project_manager(tm.authenticated_user_id):

--- a/server/api/project_apis.py
+++ b/server/api/project_apis.py
@@ -7,7 +7,7 @@ from server.models.dtos.project_dto import ProjectSearchDTO, ProjectSearchBBoxDT
 from server.services.project_search_service import ProjectSearchService, ProjectSearchServiceError, BBoxTooBigError
 from server.services.project_service import ProjectService, ProjectServiceError, NotFound
 from server.services.users.user_service import UserService
-from server.services.users.authentication_service import token_auth, tm
+from server.services.users.authentication_service import token_auth, tm, verify_token
 
 
 class ProjectAPI(Resource):
@@ -201,6 +201,11 @@ class ProjectSearchAPI(Resource):
             - application/json
         parameters:
             - in: header
+              name: Authorization
+              description: Base64 encoded session token
+              type: string
+              default: Token sessionTokenHere==
+            - in: header
               name: Accept-Language
               description: Language user is requesting
               type: string
@@ -248,9 +253,12 @@ class ProjectSearchAPI(Resource):
             search_dto.campaign_tag = request.args.get('campaignTag')
             search_dto.page = int(request.args.get('page')) if request.args.get('page') else 1
             search_dto.text_search = request.args.get('textSearch')
-            if tm.authenticated_user_id and \
-                    UserService.is_user_a_project_manager(tm.authenticated_user_id):
-                search_dto.is_project_manager = True
+            try:
+                verify_token(request.environ.get('HTTP_AUTHORIZATION').split(None, 1)[1])
+                if UserService.is_user_a_project_manager(tm.authenticated_user_id):
+                    search_dto.is_project_manager = True
+            except:
+                pass
 
             mapping_types_str = request.args.get('mappingTypes')
             if mapping_types_str:


### PR DESCRIPTION
The end goal of this PR and prior (#858) is to allow project managers to see archived and draft projects in searching. We _don't_ want regular users to see draft and archived projects. This could normally be achieved by just adding `@tm.pm_only(False)` and `@token_auth.login_required` wrappers around the call, except we **also** want anonymous users to search for projects.

Unfortunately, the current state does not support that. The `tm.authenticated_user_id` variable is not set on a search call because

1) no authorization header is supplied and
2) there is no authentication token wrapper to define `tm.authenticated_user_id` based on the current user.

So we want a function that is (pseudo) `@token_auth.refresh_credentials` to solve these two items.

(1) is solved by adding the `HTTP_AUTHORIZATION` headers to the search call in the frontend and providing those as an input to the API call (L204-L209 of `server/api/project_apis.py`). This is in line with the other API endpoints that include authorization and is fairly straightforward.

(2) is a bit more complicated. To my knowledge from rummaging through the code and documentation for the flask_httpauth library, there isn't a function that will take the authorization headers as an input, parse the token from that, and update `tm.authenticated_user_id` to be either a) `None` if anonymous or b) the correct user id if logged in.

So, I've taken code from `auth_token.login_required` (https://github.com/miguelgrinberg/Flask-HTTPAuth/blob/master/flask_httpauth.py#L65-L71) that extracts the token from the authorization headers and implemented that here: `request.environ.get('HTTP_AUTHORIZATION').split(None, 1)[1]`

Then I call a pre-existing function that checks whether a token is valid and, if so, sets the `tm.authenticated_user_id` to be that of the user (https://github.com/hotosm/tasking-manager/blob/develop/server/services/users/authentication_service.py#L40): `verify_token(...)`.

After this, we know that `tm.authenticated_user_id` is associated with the user that is logged in. Or if they're not logged in, `verify_token` will fail due to an empty token and we will continue on in the function.

Please let me know if I'm interpreting any of these things the wrong way, or if there _is_ a function with this ability in the code.