### PR TITLE
Update task GPX/XML file APIS to allow retrieval of all tasks

### DIFF
--- a/server/models/postgis/task.py
+++ b/server/models/postgis/task.py
@@ -222,7 +222,7 @@ class Task(db.Model):
     @staticmethod
     def get_all_tasks(project_id: int):
         """ Get all tasks for a given project """
-        return Task.query.filter(Task.project_id == project_id)
+        return Task.query.filter(Task.project_id == project_id).all()
 
     @staticmethod
     def auto_unlock_tasks(project_id: int):

--- a/server/models/postgis/task.py
+++ b/server/models/postgis/task.py
@@ -220,6 +220,11 @@ class Task(db.Model):
         return Task.query.filter(Task.project_id == project_id, Task.id.in_(task_ids))
 
     @staticmethod
+    def get_all_tasks(project_id: int):
+        """ Get all tasks for a given project """
+        return Task.query.filter(Task.project_id == project_id)
+
+    @staticmethod
     def auto_unlock_tasks(project_id: int):
         """Unlock all tasks locked more than 2 hours ago"""
         old_locks_query = '''SELECT t.id

--- a/server/services/mapping_service.py
+++ b/server/services/mapping_service.py
@@ -4,7 +4,9 @@ import xml.etree.ElementTree as ET
 from flask import current_app
 from geoalchemy2 import shape
 
+from server import db
 from server.models.dtos.mapping_dto import TaskDTO, MappedTaskDTO, LockTaskDTO, StopMappingTaskDTO
+from server.models.postgis.project import Project
 from server.models.postgis.statuses import MappingNotAllowed
 from server.models.postgis.task import Task, TaskStatus, TaskHistory
 from server.models.postgis.utils import NotFound, UserLicenseError
@@ -159,8 +161,15 @@ class MappingService:
         ET.SubElement(trk, 'name').text = f'Task for project {project_id}. Do not edit outside of this box!'
 
         # Construct trkseg elements
-        task_ids = map(int, task_ids_str.split(','))
-        tasks = Task.get_tasks(project_id, task_ids)
+        if task_ids_str is not None:
+            task_ids = map(int, task_ids_str.split(','))
+            tasks = Task.get_tasks(project_id, task_ids)
+        else:
+            tasks = Task.get_all_tasks(project_id)
+
+        if not tasks or tasks.count() == 0:
+            raise NotFound()
+
         for task in tasks:
             task_geom = shape.to_shape(task.geometry)
             for poly in task_geom:
@@ -183,8 +192,14 @@ class MappingService:
         # Note XML created with upload No to ensure it will be rejected by OSM if uploaded by mistake
         root = ET.Element('osm', attrib=dict(version='0.6', upload='never', creator='HOT Tasking Manager'))
 
-        task_ids = map(int, task_ids_str.split(','))
-        tasks = Task.get_tasks(project_id, task_ids)
+        if task_ids_str:
+            task_ids = map(int, task_ids_str.split(','))
+            tasks = Task.get_tasks(project_id, task_ids)
+        else:
+            tasks = Task.get_all_tasks(project_id)
+
+        if not tasks or tasks.count() == 0:
+            raise NotFound()
 
         fake_id = -1  # We use fake-ids to ensure XML will not be validated by OSM
         for task in tasks:

--- a/server/services/mapping_service.py
+++ b/server/services/mapping_service.py
@@ -167,7 +167,7 @@ class MappingService:
         else:
             tasks = Task.get_all_tasks(project_id)
 
-        if not tasks or tasks.count() == 0:
+        if not tasks or len(tasks) == 0:
             raise NotFound()
 
         for task in tasks:
@@ -198,7 +198,7 @@ class MappingService:
         else:
             tasks = Task.get_all_tasks(project_id)
 
-        if not tasks or tasks.count() == 0:
+        if not tasks or len(tasks) == 0:
             raise NotFound()
 
         fake_id = -1  # We use fake-ids to ensure XML will not be validated by OSM

--- a/tests/server/integration/services/test_mapping_service.py
+++ b/tests/server/integration/services/test_mapping_service.py
@@ -60,6 +60,26 @@ class TestMappingService(unittest.TestCase):
         # Assert
         self.assertEqual(gpx_hash, '97c4274c013964091974916ffee07846')
 
+    @patch.object(Task, 'get_all_tasks')
+    def test_gpx_xml_file_generated_correctly_all_tasks(self, mock_task):
+        if self.skip_tests:
+            return
+
+        # Arrange
+        task = Task.get(1, self.test_project.id)
+        mock_task.return_value = [task]
+        timestamp = datetime.date(2017, 4, 13)
+
+        # Act
+        gpx_xml = MappingService.generate_gpx(1, None, timestamp)
+
+        # Convert XML into a hash that should be identical every time
+        gpx_xml_str = gpx_xml.decode('utf-8')
+        gpx_hash = hashlib.md5(gpx_xml_str.encode('utf-8')).hexdigest()
+
+        # Assert
+        self.assertEqual(gpx_hash, '97c4274c013964091974916ffee07846')
+
     @patch.object(Task, 'get_tasks')
     def test_osm_xml_file_generated_correctly(self, mock_task):
         if self.skip_tests:
@@ -75,6 +95,28 @@ class TestMappingService(unittest.TestCase):
         # Covert XML into a hash that should be identical every time
         osm_xml_str = osm_xml.decode('utf-8')
         osm_hash = hashlib.md5(osm_xml_str.encode('utf-8')).hexdigest()
+
+        # Assert
+        self.assertEqual(osm_hash, 'eafd0760a0d372e2ab139e25a2d300f1')
+
+    @patch.object(Task, 'get_all_tasks')
+    def test_osm_xml_file_generated_correctly_all_tasks(self, mock_task):
+        if self.skip_tests:
+            return
+
+        # Arrange
+        task = Task.get(1, self.test_project.id)
+        mock_task.return_value = [task]
+
+        # Act
+        osm_xml = MappingService.generate_osm_xml(1, None)
+
+        # Convert XML into a hash that should be identical every time
+        osm_xml_str = osm_xml.decode('utf-8')
+        osm_hash = hashlib.md5(osm_xml_str.encode('utf-8')).hexdigest()
+        f = open('/home/enelson/test.xml', 'w')
+        f.write(osm_xml_str)
+        f.close()
 
         # Assert
         self.assertEqual(osm_hash, 'eafd0760a0d372e2ab139e25a2d300f1')


### PR DESCRIPTION
The API endpoint that allows task downloads in GPX or OSM XML files currently requires task numbers to be specified. Some are interested in download all of the tasks in this form, so this PR allows for that.

Also these two endpoints did not have the best error handling in the event of a project or task specified not existing, so I've added a few checks for that.

For some reason I am unable to get tests running locally anymore, but I will try to add a test if I can get that fixed soon.