### PR TITLE
Allow uppercase project file imports

### DIFF
--- a/client/app/admin/create-project/create-project.controller.js
+++ b/client/app/admin/create-project/create-project.controller.js
@@ -331,15 +331,15 @@
                 fileReader.onloadend = function (e) {
                     var data = e.target.result;
                     var uploadedFeatures = null;
-                    if (file.name.substr(-4) === 'json') {
+                    if (file.name.substr(-4).toLowerCase() === 'json') {
                         uploadedFeatures = geospatialService.getFeaturesFromGeoJSON(data);
                         setUploadedFeatures(uploadedFeatures);
                     }
-                    else if (file.name.substr(-3) === 'kml') {
+                    else if (file.name.substr(-3).toLowerCase() === 'kml') {
                         uploadedFeatures = geospatialService.getFeaturesFromKML(data);
                         setUploadedFeatures(uploadedFeatures);
                     }
-                    else if (file.name.substr(-3) === 'zip') {
+                    else if (file.name.substr(-3).toLowerCase() === 'zip') {
                         // Use the Shapefile.js library to read the zipped Shapefile (with GeoJSON as output)
                         shp(data).then(function (geojson) {
                             var uploadedFeatures = geospatialService.getFeaturesFromGeoJSON(geojson);
@@ -347,13 +347,13 @@
                         });
                     }
                 };
-                if (file.name.substr(-4) === 'json') {
+                if (file.name.substr(-4).toLowerCase() === 'json') {
                     fileReader.readAsText(file);
                 }
-                else if (file.name.substr(-3) === 'kml') {
+                else if (file.name.substr(-3).toLowerCase() === 'kml') {
                     fileReader.readAsText(file);
                 }
-                else if (file.name.substr(-3) === 'zip') {
+                else if (file.name.substr(-3).toLowerCase() === 'zip') {
                     fileReader.readAsArrayBuffer(file);
                 }
                 else {


### PR DESCRIPTION
Someone may try to upload a file with an uppercase extension, such as `.ZIP` or `.geoJSON`. This will make sure the upload doesn't fail simply because of that.