### PR TITLE
Add api for geojson of all task features

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -90,7 +90,7 @@ def init_flask_restful_routes(app):
     from server.api.health_check_api import HealthCheckAPI
     from server.api.license_apis import LicenseAPI, LicenceListAPI
     from server.api.mapping_apis import MappingTaskAPI, LockTaskForMappingAPI, UnlockTaskForMappingAPI, StopMappingAPI,\
-        TasksAsGPX, TasksAsOSM, UndoMappingAPI
+        TasksAsJson, TasksAsGPX, TasksAsOSM, UndoMappingAPI
     from server.api.messaging.message_apis import ProjectsMessageAll, HasNewMessages, GetAllMessages, MessagesAPI,\
         ResendEmailValidationAPI
     from server.api.messaging.project_chat_apis import ProjectChatAPI
@@ -137,6 +137,7 @@ def init_flask_restful_routes(app):
     api.add_resource(HasUserTaskOnProjectDetails,   '/api/v1/project/<int:project_id>/has-user-locked-tasks/details')
     api.add_resource(MappedTasksByUser,             '/api/v1/project/<int:project_id>/mapped-tasks-by-user')
     api.add_resource(ProjectSummaryAPI,             '/api/v1/project/<int:project_id>/summary')
+    api.add_resource(TasksAsJson,                   '/api/v1/project/<int:project_id>/tasks')
     api.add_resource(TasksAsGPX,                    '/api/v1/project/<int:project_id>/tasks_as_gpx')
     api.add_resource(TasksAsOSM,                    '/api/v1/project/<int:project_id>/tasks-as-osm-xml')
     api.add_resource(LockTaskForMappingAPI,         '/api/v1/project/<int:project_id>/task/<int:task_id>/lock-for-mapping')

--- a/server/api/mapping_apis.py
+++ b/server/api/mapping_apis.py
@@ -7,6 +7,7 @@ from schematics.exceptions import DataError
 
 from server.models.dtos.mapping_dto import MappedTaskDTO, LockTaskDTO, StopMappingTaskDTO
 from server.services.mapping_service import MappingService, MappingServiceError, NotFound, UserLicenseError
+from server.services.project_service import ProjectService, ProjectServiceError
 from server.services.users.authentication_service import token_auth, tm, verify_token
 from server.services.users.user_service import UserService
 
@@ -324,6 +325,59 @@ class UnlockTaskForMappingAPI(Resource):
         finally:
             # Refresh mapper level after mapping
             UserService.check_and_update_mapper_level(tm.authenticated_user_id)
+
+
+class TasksAsJson(Resource):
+
+    def get(self, project_id):
+        """
+        Get tasks as JSON
+        ---
+        tags:
+            - mapping
+        produces:
+            - application/json
+        parameters:
+            - name: project_id
+              in: path
+              description: The ID of the project the task is associated with
+              required: true
+              type: integer
+              default: 1
+            - in: query
+              name: as_file
+              type: boolean
+              description: Set to true if file download preferred
+              default: True
+        responses:
+            200:
+                description: Project found
+            403:
+                description: Forbidden
+            404:
+                description: Project not found
+            500:
+                description: Internal Server Error
+        """
+        try:
+            as_file = strtobool(request.args.get('as_file')) if request.args.get('as_file') else True
+
+            tasks = ProjectService.get_project_tasks(int(project_id))
+
+            if as_file:
+                tasks = str(tasks).encode('utf-8')
+                return send_file(io.BytesIO(tasks), mimetype='application/json', as_attachment=True,
+                                 attachment_filename=f'{str(project_id)}-tasks.geoJSON')
+
+            return tasks, 200
+        except NotFound:
+            return {"Error": "Project or Task Not Found"}, 404
+        except ProjectServiceError as e:
+            return {"Error": str(e)}, 403
+        except Exception as e:
+            error_msg = f'Project GET - unhandled error: {str(e)}'
+            current_app.logger.critical(e)
+            return {"Error": error_msg}, 500
 
 
 class TasksAsGPX(Resource):

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -363,6 +363,12 @@ class Project(db.Model):
 
         return project_dto
 
+    def all_tasks_as_geojson(self):
+        """ Creates a geojson of all areas """
+        project_tasks = Task.get_tasks_as_geojson_feature_collection(self.id)
+
+        return project_tasks
+
     def as_dto_for_admin(self, project_id):
         """ Creates a Project DTO suitable for transmitting to project admins """
         project, project_dto = self._get_project_and_base_dto()

--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -46,6 +46,11 @@ class ProjectService:
         return project.as_dto_for_mapping(locale)
 
     @staticmethod
+    def get_project_tasks(project_id):
+        project = ProjectService.get_project_by_id(project_id)
+        return project.all_tasks_as_geojson()
+
+    @staticmethod
     def get_project_aoi(project_id):
         project = ProjectService.get_project_by_id(project_id)
         return project.get_aoi_geometry_as_geojson()


### PR DESCRIPTION
The API endpoint `/api/v1/{project_id}` currently returns a geojson stream that contains both project metadata and tasks with geometry and metadata. While #938 allows for one to download that information in a json format, it is still not a valid geojson file that can be opened in JOSM.

This PR provides that functionality. The hope is this endpoint can be used to reproduce the `Export` button as seen in TM2 for PMs.