### PR TITLE
Fix mobile banner closer

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -115,7 +115,7 @@
 <!-- mobile message -->
 <div class="mob-disclaimer" ng-show="!hideMobileMessage">
     <p>
-        <i class="hot-ds-icon-xmark pull-right pointer" ng-click="hideMobileMessage = true"></i>
+        <i class="modal__button-dismiss pull-right pointer" ng-click="hideMobileMessage = true"></i>
         {{ 'In order to make full use of the many features in the Tasking Manager, please use a desktop or laptop computer rather than a mobile device. If you would like to contribute on a mobile device, please use MapSwipe instead.' | translate }}
     </p>
     <a href="https://mapswipe.org" class="button button--achromic">{{ 'Go to MapSwipe' | translate }}</a>


### PR DESCRIPTION
This PR replaces a deprecated css style to close the mobile banner with a style currently present in the code base.

Fixes #933 
Fixes #820 

![modal](https://user-images.githubusercontent.com/8998918/32702179-8382023a-c7a8-11e7-8282-902f549f7490.PNG)