### PR TITLE
Fix broken tests on empty db

### DIFF
--- a/tests/server/integration/models/postgis/test_project.py
+++ b/tests/server/integration/models/postgis/test_project.py
@@ -128,7 +128,7 @@ class TestProject(unittest.TestCase):
 
         # Act
         original_id = copy.copy(self.test_project.id)
-        cloned_project = Project.clone(original_id, 5175337)
+        cloned_project = Project.clone(original_id, self.test_user.id)
 
         self.assertTrue(cloned_project)
         self.assertEqual(cloned_project.project_info[0].name, 'Thinkwhere Test')

--- a/tests/server/integration/services/messaging/test_smtp_service.py
+++ b/tests/server/integration/services/messaging/test_smtp_service.py
@@ -29,11 +29,17 @@ class TestStatsService(unittest.TestCase):
         if self.skip_tests:
             return
 
+        if os.getenv('TM_SMTP_HOST') is None:
+            return  # If SMTP not setup there's no value attempting the integration tests
+
         self.assertTrue(SMTPService.send_verification_email('hot-test@mailinator.com', 'mrtest'))
 
     def test_send_alert(self):
         if self.skip_tests:
             return
+
+        if os.getenv('TM_SMTP_HOST') is None:
+            return  # If SMTP not setup there's no value attempting the integration tests
 
         self.assertTrue(SMTPService.send_email_alert('hot-test@mailinator.com',
                                                      'Iain Hunter'))


### PR DESCRIPTION
Hi @ethan-nelson setup the project at home and saw the broken test issue for myself.  Looks like I left a bit of debug code in the test (oops) 😖 

I also made it possible to skip the SMTP integration tests, which I'm guessing most people won't have setup at home

Will at least make it easier to increase coverage for #951 