### PR TITLE
Fix notification close

### DIFF
--- a/client/app/components/account-nav/account-nav.html
+++ b/client/app/components/account-nav/account-nav.html
@@ -59,6 +59,6 @@
     </div>
 </a>
 <div ng-show="accountNavCtrl.userMessages.newMessages && accountNavCtrl.newMessageNotification" class="unread-messages-popover">
-    <i class="hot-ds-icon-sm-xmark pull-right pointer" ng-click="accountNavCtrl.hideNotification()"></i>
+    <i class="modal__button-dismiss pull-right pointer" ng-click="accountNavCtrl.hideNotification()"></i>
     <p class="pull-left">{{ 'You have unread messages.' | translate }}</p>
 </div>


### PR DESCRIPTION
The notification window previously could not be closed because it was referencing a deprecated style icon (similar to the MapSwipe banner). This fixes that:

![mod](https://user-images.githubusercontent.com/8998918/33449120-73425338-d5cd-11e7-9f63-ea4d58ae03d6.PNG)
