### PR TITLE
Provide access limitation capability

### DIFF
--- a/client/app/profile/profile.html
+++ b/client/app/profile/profile.html
@@ -208,6 +208,11 @@
                                                     ng-show="profileCtrl.currentlyLoggedInUser.role === 'ADMIN'"
                                                     ng-click="profileCtrl.setRole('ADMIN')">{{ 'Administrator' | translate }}
                                             </button>
+                                            <button class="button button--achromic"
+                                                    ng-class="profileCtrl.userDetails.role === 'READ_ONLY'? 'button--active' : ''"
+                                                    ng-hide="profileCtrl.currentlyLoggedInUser.role === 'ADMIN' && profileCtrl.currentlyLoggedInUser.role === 'PROJECT_MANAGER'"
+                                                    ng-click="profileCtrl.setRole('READ_ONLY')">{{ 'Block user' | translate }}
+                                            </button>
                                         </div>
                                     </div>
                                 </div>

--- a/server/models/postgis/statuses.py
+++ b/server/models/postgis/statuses.py
@@ -61,6 +61,7 @@ class ValidatingNotAllowed(Enum):
 
 class UserRole(Enum):
     """ Describes the role a user can be assigned, app doesn't support multiple roles """
+    READ_ONLY = -1
     MAPPER = 0
     ADMIN = 1
     PROJECT_MANAGER = 2

--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -87,6 +87,9 @@ class ProjectService:
     @staticmethod
     def is_user_permitted_to_map(project_id: int, user_id: int):
         """ Check if the user is allowed to map the on the project in scope """
+        if UserService.is_user_blocked(user_id):
+            return False, MappingNotAllowed.USER_NOT_ON_ALLOWED_LIST
+
         project = ProjectService.get_project_by_id(project_id)
 
         if ProjectStatus(project.status) != ProjectStatus.PUBLISHED:
@@ -132,6 +135,9 @@ class ProjectService:
     @staticmethod
     def is_user_permitted_to_validate(project_id, user_id):
         """ Check if the user is allowed to validate on the project in scope """
+        if UserService.is_user_blocked(user_id):
+            return False, ValidatingNotAllowed.USER_NOT_ON_ALLOWED_LIST
+
         project = ProjectService.get_project_by_id(project_id)
 
         if project.enforce_validator_role and not UserService.is_user_validator(user_id):

--- a/server/services/users/user_service.py
+++ b/server/services/users/user_service.py
@@ -136,6 +136,16 @@ class UserService:
         return False
 
     @staticmethod
+    def is_user_blocked(user_id: int) -> bool:
+        """ Determines if a user is blocked """
+        user = UserService.get_user_by_id(user_id)
+
+        if UserRole(user.role) == UserRole.READ_ONLY:
+            return True
+
+        return False
+
+    @staticmethod
     def upsert_mapped_projects(user_id: int, project_id: int):
         """ Add project to mapped projects if it doesn't exist, otherwise return """
         User.upsert_mapped_projects(user_id, project_id)

--- a/tests/server/unit/services/test_project_service.py
+++ b/tests/server/unit/services/test_project_service.py
@@ -42,12 +42,15 @@ class TestProjectService(unittest.TestCase):
         # Assert
         self.assertFalse(allowed)
 
+    @patch.object(UserService, 'is_user_blocked')
     @patch.object(Project, 'get')
-    def test_user_cant_map_if_project_not_published(self, mock_project):
+    def test_user_cant_map_if_project_not_published(self, mock_project, mock_user_blocked):
         # Arrange
         stub_project = Project()
         stub_project.status = ProjectStatus.DRAFT.value
         mock_project.return_value = stub_project
+
+        mock_user_blocked.return_value = False
 
         # Act
         allowed, reason = ProjectService.is_user_permitted_to_map(1, 1)
@@ -57,10 +60,11 @@ class TestProjectService(unittest.TestCase):
         self.assertEqual(reason, MappingNotAllowed.PROJECT_NOT_PUBLISHED)
 
     @patch.object(UserService, 'has_user_accepted_license')
+    @patch.object(UserService, 'is_user_blocked')
     @patch.object(Project, 'get_locked_tasks_for_user')
     @patch.object(Project, 'get')
     def test_user_not_permitted_to_map_if_user_has_not_accepted_license(self, mock_project, mock_user_tasks,
-                                                                        mock_user_service):
+                                                                        mock_user_blocked, mock_user_service):
         # Arrange
         stub_project = Project()
         stub_project.status = ProjectStatus.PUBLISHED.value
@@ -69,6 +73,7 @@ class TestProjectService(unittest.TestCase):
         mock_project.return_value = stub_project
         mock_user_tasks.return_value = []
         mock_user_service.return_value = False
+        mock_user_blocked.return_value = False
 
         #Act
         allowed, reason = ProjectService.is_user_permitted_to_map(1, 1)
@@ -86,3 +91,18 @@ class TestProjectService(unittest.TestCase):
         #Act / Assert
         with self.assertRaises(NotFound):
             ProjectService.get_task_for_logged_in_user(1, 1)
+
+    @patch.object(UserService, 'is_user_blocked')
+    @patch.object(Project, 'get')
+    def test_user_not_permitted_to_map_if_user_is_blocked(self, mock_project, mock_user_blocked):
+
+        # Arrange
+        mock_project.return_value = Project()
+        mock_user_blocked.return_value = True
+
+        # Act
+        allowed, reason = ProjectService.is_user_permitted_to_map(1, 1)
+
+        # Assert
+        self.assertFalse(allowed)
+        self.assertEqual(reason, MappingNotAllowed.USER_NOT_ON_ALLOWED_LIST)


### PR DESCRIPTION
In some cases, it may be necessary to limit the ability for a user to interact with the tasking manager. This adds that functionality.