### PR TITLE
add piwik tracking code, fix #786

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -264,5 +264,22 @@
 <script src="app/components/project-chat/project-chat.directive.js"></script>
 <!-- /build -->
 
+<!-- Piwik -->
+<script type="text/javascript">
+  var _paq = _paq || [];
+  _paq.push(["setDomains", ["*.tasks.hotosm.org"]]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//piwik.hotosm.org/";
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', 7]);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="//piwik.hotosm.org/piwik.php?idsite=7" style="border:0;" alt="" /></p></noscript>
+<!-- End Piwik Code -->
+
 </body>
 </html>


### PR DESCRIPTION
This PR adds Piwik tracking code to enable tracking visit stats across the site. Fixes #786. Open to ideas for how we manage more custom HOT deployment code, but sticking this at the bottom of the main index.html for now. 