### PR TITLE
update stories section to include donate

### DIFF
--- a/client/app/home/home.html
+++ b/client/app/home/home.html
@@ -10,18 +10,13 @@
 </header>
 <section class="section__body section__body--secondary">
     <div class="field-stories-container inner">
-        <h2>{{ 'Causes You Can Help' | translate }}</h2>
+        <h2>{{ 'Causes You Can Help | Join Our Year End Fundraising Campaign' | translate }}</h2>
         <ul class="field-stories__cards">
             <li id="story-1" class="field-stories__card">
-                <h5>Red Cross - Ayeyarwady Delta</h5>
-                <blockquote>
-                    <p>"The Red Cross is mapping the Ayeyarwady Delta area in Myanmar as part of a multi-year mapping and data readiness activity to better understand where critical infrastructure and roads are to inform decision making during potential disasters. As recently as 2008 a cyclone killed at least 77,000 people with over 55,900 missing, and left about 2.5 million homeless."
-                    </p>
-                    <footer>
-                        <cite>Matt Gibb, Red Cross</cite>
-                    </footer>
-                    <p><a ng-href="/contribute?difficulty=ALL&text=Ayeyarwady">Find Ayeyarwady Delta Projects</a></p>
-                </blockquote>
+                <h5>#MapTheDifference Funding Campaign</h5>
+                  <p>Humanitarian OpenStreetMap Team (HOT) is an NGO and global volunteer community that creates and provides digital and print maps to address the world's toughest challenges. In times of crisis and natural disaster, HOT rallies a network of volunteers worldwide to rapidly produce maps relied upon by humanitarian relief organizations to reach those in need. Help us stay ready by supporting our end of the year fundraising campaign.
+                  </p>
+                  <p><a href="http://bit.ly/TM2017YearEndFundingDrive" target="_blank" rel="noopener">Please Donate Now &#x2197;</a></p>
             </li>
             <li id="story-2" class="field-stories__card">
                 <h5>Tanzania Development Trust</h5>


### PR DESCRIPTION
This rearranges and adds text and a link to the HOT #MapTheDifference fundraising campaign. This is the first solution idea for #990. 

This may suffice as a good way going forward for custom text on the front page, but it isn't very eye-catching and blends in a bit. Open to other recommendations for how we can achieve the goal of highlight the text and link to the campaign. 

![hot tasking manager 2017-12-11 13-07-17](https://user-images.githubusercontent.com/796838/33849783-421af1ea-de77-11e7-829a-c42f4af3d02a.png)
