### PR TITLE
Change fundraising campaign to a banner

### DIFF
--- a/client/app/home/home.html
+++ b/client/app/home/home.html
@@ -10,13 +10,18 @@
 </header>
 <section class="section__body section__body--secondary">
     <div class="field-stories-container inner">
-        <h2>{{ 'Causes You Can Help | Join Our Year End Fundraising Campaign' | translate }}</h2>
+        <h2>{{ 'Causes You Can Help' | translate }}</h2>
         <ul class="field-stories__cards">
             <li id="story-1" class="field-stories__card">
-                <h5>#MapTheDifference Funding Campaign</h5>
-                  <p>Humanitarian OpenStreetMap Team (HOT) is an NGO and global volunteer community that creates and provides digital and print maps to address the world's toughest challenges. In times of crisis and natural disaster, HOT rallies a network of volunteers worldwide to rapidly produce maps relied upon by humanitarian relief organizations to reach those in need. Help us stay ready by supporting our end of the year fundraising campaign.
+                <h5>Red Cross - Ayeyarwady Delta</h5>
+                <blockquote>
+                  <p>"The Red Cross is mapping the Ayeyarwady Delta area in Myanmar as part of a multi-year mapping and data readiness activity to better understand where critical infrastructure and roads are to inform decision making during potential disasters. As recently as 2008 a cyclone killed at least 77,000 people with over 55,900 missing, and left about 2.5 million homeless."
                   </p>
-                  <p><a href="http://bit.ly/TM2017YearEndFundingDrive" target="_blank" rel="noopener">Please Donate Now &#x2197;</a></p>
+                  <footer>
+                    <cite>Matt Gibb, Red Cross</cite>
+                  </footer>
+                  <p><a ng-href="/contribute?difficulty=ALL&text=Ayeyarwady">Find Ayeyarwady Delta Projects</a></p>
+                </blockquote>
             </li>
             <li id="story-2" class="field-stories__card">
                 <h5>Tanzania Development Trust</h5>

--- a/client/assets/styles/sass/_mobile.scss
+++ b/client/assets/styles/sass/_mobile.scss
@@ -5,10 +5,7 @@
   width: 100%;
   padding: .5em 4em;
   z-index: 10;
-  background: $primary-color;
+  background: #d34143;
   color: white;
   text-align: center;
-  @include media(large-up) {
-    display: none;
-  }
 }

--- a/client/index.html
+++ b/client/index.html
@@ -116,7 +116,7 @@
 <div class="mob-disclaimer" ng-show="!hideMobileMessage">
     <p class="centered">
         <i class="modal__button-dismiss pull-right pointer" ng-click="hideMobileMessage = true"></i>
-        {{ 'Help support local OpenStreetMap communities and provide humanitarian mapping tools by donating today to HOT. Contribute and help us get to 200 donors by December 25.' | translate }}
+        {{ 'Help support local OpenStreetMap communities and provide humanitarian mapping tools by donating today to HOT\'s \#MaptheDifference end of the year campaign. Please contribute and help us get to 200 donors by December 25.' | translate }}
     </p>
     <a href="http://bit.ly/TM2017YearEndFundingDrive" class="button button--outline--white">{{ 'Help us get to 200 donors today' | translate }}</a>
 </div>

--- a/client/index.html
+++ b/client/index.html
@@ -114,11 +114,11 @@
 
 <!-- mobile message -->
 <div class="mob-disclaimer" ng-show="!hideMobileMessage">
-    <p>
+    <p class="centered">
         <i class="modal__button-dismiss pull-right pointer" ng-click="hideMobileMessage = true"></i>
-        {{ 'In order to make full use of the many features in the Tasking Manager, please use a desktop or laptop computer rather than a mobile device. If you would like to contribute on a mobile device, please use MapSwipe instead.' | translate }}
+        {{ 'Help support local OpenStreetMap communities and provide humanitarian mapping tools by donating today to HOT. Contribute and help us get to 200 donors by December 25.' | translate }}
     </p>
-    <a href="https://mapswipe.org" class="button button--achromic">{{ 'Go to MapSwipe' | translate }}</a>
+    <a href="http://bit.ly/TM2017YearEndFundingDrive" class="button button--outline--white">{{ 'Help us get to 200 donors today' | translate }}</a>
 </div>
 <!--/ mobile message -->
 


### PR DESCRIPTION
Based on some feedback and request from Fundraising WG, we want to help promote linking to the end of the year campaign where it is visible and accessible. Previous implementation was too buried. So this is a new proposal for leveraging the banner used for Mapswipe temporarily. This has the same functionality and so it can be closed. 

Includes: 
* reverting back to the Red Cross story for front page 
* banner always shows up - desktop and mobile with the fundraising message and link
* adjusts the dark red to a lighter red

## Frontpage
![hot tasking manager 2017-12-19 17-49-45](https://user-images.githubusercontent.com/796838/34184458-842e26b4-e4e5-11e7-8c64-b1c901811d0f.png)

## Contribute page (local instance running without data)
![hot tasking manager 2017-12-19 17-50-00](https://user-images.githubusercontent.com/796838/34184460-86dd9eb2-e4e5-11e7-9e2c-4f0cd88d6cb5.png)
