### PR TITLE
Allow project managers to map archived projects

### DIFF
--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -97,7 +97,7 @@ class ProjectService:
 
         project = ProjectService.get_project_by_id(project_id)
 
-        if ProjectStatus(project.status) != ProjectStatus.PUBLISHED:
+        if ProjectStatus(project.status) != ProjectStatus.PUBLISHED and not UserService.is_user_a_project_manager(user_id):
             return False, MappingNotAllowed.PROJECT_NOT_PUBLISHED
 
         tasks = project.get_locked_tasks_for_user(user_id)

--- a/tests/server/unit/services/test_project_service.py
+++ b/tests/server/unit/services/test_project_service.py
@@ -42,14 +42,16 @@ class TestProjectService(unittest.TestCase):
         # Assert
         self.assertFalse(allowed)
 
+    @patch.object(UserService, 'is_user_a_project_manager')
     @patch.object(UserService, 'is_user_blocked')
     @patch.object(Project, 'get')
-    def test_user_cant_map_if_project_not_published(self, mock_project, mock_user_blocked):
+    def test_user_cant_map_if_project_not_published(self, mock_project, mock_user_blocked, mock_user_pm_status):
         # Arrange
         stub_project = Project()
         stub_project.status = ProjectStatus.DRAFT.value
         mock_project.return_value = stub_project
 
+        mock_user_pm_status.return_value = False
         mock_user_blocked.return_value = False
 
         # Act


### PR DESCRIPTION
This provides project managers the ability to mark tiles as mapped or unmapped for projects that are either draft or archived. 

Fixes part of #866. This is a sibling to the #920 PR.