### PR TITLE
Changes validation error msg to say validation, not mapping

### DIFF
--- a/server/services/validator_service.py
+++ b/server/services/validator_service.py
@@ -49,7 +49,7 @@ class ValidatorService:
             if error_reason == ValidatingNotAllowed.USER_NOT_ACCEPTED_LICENSE:
                 raise UserLicenseError('User must accept license to map this task')
             else:
-                raise ValidatatorServiceError(f'Mapping not allowed because: {error_reason.name}')
+                raise ValidatatorServiceError(f'Validation not allowed because: {error_reason.name}')
 
         # Lock all tasks for validation
         dtos = []


### PR DESCRIPTION
@smit1678 or @ethan-nelson If either one of you could quickly review this, I have tested it locally and merge it in. Pretty minor but needed clarification of an error message related to validation that currently says mapping.

Will affect the translation strings.