### PR TITLE
update banner text to january 7 deadline

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -116,7 +116,7 @@
 <div class="mob-disclaimer" ng-show="!hideMobileMessage">
     <p class="centered">
         <i class="modal__button-dismiss pull-right pointer" ng-click="hideMobileMessage = true"></i>
-        {{ 'Help support local OpenStreetMap communities and provide humanitarian mapping tools by donating today to HOT\'s \#MaptheDifference end of the year campaign. Please contribute and help us raise $30,000 by December 31.' | translate }}
+        {{ 'Support local OpenStreetMap communities and provide humanitarian mapping tools by donating to HOT\'s \#MaptheDifference end of the year campaign. We\'ve extended the deadline to January 7. Please help us reach $30,000.' | translate }}
     </p>
     <a href="http://bit.ly/TM2017YearEndFundingDrive" class="button button--outline--white">{{ 'Help support HOT today' | translate }}</a>
 </div>


### PR DESCRIPTION
Updates the banner text to adjust to the last extended deadline of January 7. I cut some text to keep the banner at 2 lines on my laptop screen. 

![hot tasking manager 2018-01-02 16-02-56](https://user-images.githubusercontent.com/796838/34490108-a1de837e-efd6-11e7-8aa7-9050fdef4a31.png)

