### PR TITLE
Remove hard-coded swagger url

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -42,7 +42,7 @@ class EnvironmentConfig:
 class ProdConfig(EnvironmentConfig):
     APP_BASE_URL = 'https://tasks.hotosm.org'
     API_DOCS_URL = f'{APP_BASE_URL}/api-docs/swagger-ui/index.html?' + \
-                   'url=https://tasks.hotosm.org/api/docs'
+                   f'url={APP_BASE_URL}/api/docs'
     LOG_DIR = '/var/log/tasking-manager-logs'
     LOG_LEVEL = logging.DEBUG
 
@@ -50,7 +50,7 @@ class ProdConfig(EnvironmentConfig):
 class StageConfig(EnvironmentConfig):
     APP_BASE_URL = 'https://tasks-stage.hotosm.org'
     API_DOCS_URL = f'{APP_BASE_URL}/api-docs/swagger-ui/index.html?' + \
-                   'url=https://tasks-stage.hotosm.org/api/docs'
+                   f'url={APP_BASE_URL}/api/docs'
     LOG_DIR = '/var/log/tasking-manager-logs'
     LOG_LEVEL = logging.DEBUG
 
@@ -58,7 +58,7 @@ class StageConfig(EnvironmentConfig):
 class DemoConfig(EnvironmentConfig):
     APP_BASE_URL = 'https://tasks-demo.hotosm.org'
     API_DOCS_URL = f'{APP_BASE_URL}/api-docs/swagger-ui/index.html?' + \
-                   'url=https://tasks-demo.hotosm.org/api/docs'
+                   f'url={APP_BASE_URL}/api/docs'
     LOG_DIR = '/var/log/tasking-manager-logs'
     LOG_LEVEL = logging.DEBUG
 
@@ -67,20 +67,22 @@ class StagingConfig(EnvironmentConfig):
     # Currently being used by Thinkwhere
     APP_BASE_URL = 'http://tasking-manager-staging.eu-west-1.elasticbeanstalk.com'
     API_DOCS_URL = f'{APP_BASE_URL}/api-docs/swagger-ui/index.html?' + \
-                   'url=http://tasking-manager-staging.eu-west-1.elasticbeanstalk.com/api/docs'
+                   f'url={APP_BASE_URL}/api/docs'
     LOG_DIR = '/var/log/tasking-manager-logs'
     LOG_LEVEL = logging.DEBUG
 
 
 class DevConfig(EnvironmentConfig):
     APP_BASE_URL = 'http://127.0.0.1:5000'
-    API_DOCS_URL = f'{APP_BASE_URL}/api-docs/swagger-ui/index.html?url=http://127.0.0.1:5000/api/docs'
+    API_DOCS_URL = f'{APP_BASE_URL}/api-docs/swagger-ui/index.html?' + \
+                   f'url={APP_BASE_URL}/api/docs'
     LOG_DIR = 'logs'
     LOG_LEVEL = logging.DEBUG
 
 
 class DevIPv6Config(EnvironmentConfig):
     APP_BASE_URL = 'http://[::1]:5000'
-    API_DOCS_URL = f'{APP_BASE_URL}/api-docs/swagger-ui/index.html?url=http://[::1]:5000/api/docs'
+    API_DOCS_URL = f'{APP_BASE_URL}/api-docs/swagger-ui/index.html?' + \
+                   f'url={APP_BASE_URL}/api/docs'
     LOG_DIR = 'logs'
     LOG_LEVEL = logging.DEBUG


### PR DESCRIPTION
Currently, the url that directs users to the Swagger API from `/api-docs` is hard-coded in the `server/config.py` file. This can present a problem if the app url is changed to another domain as users may be directed to the wrong Swagger API if the second url is not changed as well.

To mitigate this, the PR removes the hard-coded host and uses the `APP_BASE_URL` variable that is already used to define the first part of the url.