### PR TITLE
Prevent file caching

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -19,6 +19,7 @@ class EnvironmentConfig:
         'access_token_url': 'https://www.openstreetmap.org/oauth/access_token',
         'authorize_url': 'https://www.openstreetmap.org/oauth/authorize'
     }
+    SEND_FILE_MAX_AGE_DEFAULT = 0
     SQLALCHEMY_DATABASE_URI = os.getenv('TM_DB', None)
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_POOL_SIZE = 10


### PR DESCRIPTION
Flask's [default](http://flask.pocoo.org/docs/0.12/api/#flask.Flask.send_file_max_age_default) is to set a 12 hour file cache header. This PR sets it to 0 so that users can immediately access new information from API file downloads.