### PR TITLE
[WIP] update banner to revert to Mapswipe message

### DIFF
--- a/client/assets/styles/sass/_mobile.scss
+++ b/client/assets/styles/sass/_mobile.scss
@@ -8,4 +8,7 @@
   background: #d34143;
   color: white;
   text-align: center;
+  @include media(large-up) {
+  	display: none;
+  }
 }

--- a/client/index.html
+++ b/client/index.html
@@ -116,9 +116,9 @@
 <div class="mob-disclaimer" ng-show="!hideMobileMessage">
     <p class="centered">
         <i class="modal__button-dismiss pull-right pointer" ng-click="hideMobileMessage = true"></i>
-        {{ 'Support local OpenStreetMap communities and provide humanitarian mapping tools by donating to HOT\'s \#MaptheDifference end of the year campaign. We\'ve extended the deadline to January 7. Please help us reach $30,000.' | translate }}
+        {{ 'In order to make full use of the many features in the Tasking Manager, please use a desktop or laptop computer rather than a mobile device. If you would like to contribute on a mobile device, please use MapSwipe instead.' | translate }}
     </p>
-    <a href="http://bit.ly/TM2017YearEndFundingDrive" class="button button--outline--white">{{ 'Help support HOT today' | translate }}</a>
+    <a href="https://mapswipe.org" class="button button--outline--white">{{ 'Go to MapSwipe' | translate }}</a>
 </div>
 <!--/ mobile message -->
 


### PR DESCRIPTION
This PR adds back the original Mapswipe message on the banner as well as adds the restriction to only show the banner on mobile views. Reason for this change is that the end of the year campaign has been wrapped up. 

WIP - To be confirmed with Fundraising working group. 