### PR TITLE
Update env var CI flag

### DIFF
--- a/tests/server/integration/models/postgis/test_project.py
+++ b/tests/server/integration/models/postgis/test_project.py
@@ -17,7 +17,7 @@ class TestProject(unittest.TestCase):
     def setUpClass(cls):
         env = os.getenv('CI', 'false')
 
-        # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
+        # Firewall rules mean we can't hit Postgres from CI so we have to skip them in the CI build
         if env == 'true':
             cls.skip_tests = True
 

--- a/tests/server/integration/models/postgis/test_project.py
+++ b/tests/server/integration/models/postgis/test_project.py
@@ -15,7 +15,7 @@ class TestProject(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        env = os.getenv('SHIPPABLE', 'false')
+        env = os.getenv('CI', 'false')
 
         # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
         if env == 'true':

--- a/tests/server/integration/models/postgis/test_user.py
+++ b/tests/server/integration/models/postgis/test_user.py
@@ -10,7 +10,7 @@ class TestUser(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        env = os.getenv('SHIPPABLE', 'false')
+        env = os.getenv('CI', 'false')
 
         # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
         if env == 'true':

--- a/tests/server/integration/models/postgis/test_user.py
+++ b/tests/server/integration/models/postgis/test_user.py
@@ -12,7 +12,7 @@ class TestUser(unittest.TestCase):
     def setUpClass(cls):
         env = os.getenv('CI', 'false')
 
-        # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
+        # Firewall rules mean we can't hit Postgres from CI so we have to skip them in the CI build
         if env == 'true':
             cls.skip_tests = True
 

--- a/tests/server/integration/services/grid/test_split_service.py
+++ b/tests/server/integration/services/grid/test_split_service.py
@@ -18,7 +18,7 @@ class TestSplitService(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        env = os.getenv('SHIPPABLE', 'false')
+        env = os.getenv('CI', 'false')
 
         # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
         if env == 'true':

--- a/tests/server/integration/services/grid/test_split_service.py
+++ b/tests/server/integration/services/grid/test_split_service.py
@@ -20,7 +20,7 @@ class TestSplitService(unittest.TestCase):
     def setUpClass(cls):
         env = os.getenv('CI', 'false')
 
-        # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
+        # Firewall rules mean we can't hit Postgres from CI so we have to skip them in the CI build
         if env == 'true':
             cls.skip_tests = True
 

--- a/tests/server/integration/services/messaging/test_messaging_service.py
+++ b/tests/server/integration/services/messaging/test_messaging_service.py
@@ -15,7 +15,7 @@ class TestMessageService(unittest.TestCase):
     def setUpClass(cls):
         env = os.getenv('CI', 'false')
 
-        # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
+        # Firewall rules mean we can't hit Postgres from CI so we have to skip them in the CI build
         if env == 'true':
             cls.skip_tests = True
 

--- a/tests/server/integration/services/messaging/test_messaging_service.py
+++ b/tests/server/integration/services/messaging/test_messaging_service.py
@@ -13,7 +13,7 @@ class TestMessageService(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        env = os.getenv('SHIPPABLE', 'false')
+        env = os.getenv('CI', 'false')
 
         # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
         if env == 'true':

--- a/tests/server/integration/services/messaging/test_smtp_service.py
+++ b/tests/server/integration/services/messaging/test_smtp_service.py
@@ -13,7 +13,7 @@ class TestStatsService(unittest.TestCase):
     def setUpClass(cls):
         env = os.getenv('CI', 'false')
 
-        # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
+        # Firewall rules mean we can't hit Postgres from CI so we have to skip them in the CI build
         if env == 'true':
             cls.skip_tests = True
 

--- a/tests/server/integration/services/messaging/test_smtp_service.py
+++ b/tests/server/integration/services/messaging/test_smtp_service.py
@@ -11,7 +11,7 @@ class TestStatsService(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        env = os.getenv('SHIPPABLE', 'false')
+        env = os.getenv('CI', 'false')
 
         # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
         if env == 'true':

--- a/tests/server/integration/services/test_license_service.py
+++ b/tests/server/integration/services/test_license_service.py
@@ -11,7 +11,7 @@ class TestLicenseService(unittest.TestCase):
     def setUpClass(cls):
         env = os.getenv('CI', 'false')
 
-        # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
+        # Firewall rules mean we can't hit Postgres from CI so we have to skip them in the CI build
         if env == 'true':
             cls.skip_tests = True
 

--- a/tests/server/integration/services/test_license_service.py
+++ b/tests/server/integration/services/test_license_service.py
@@ -9,7 +9,7 @@ class TestLicenseService(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        env = os.getenv('SHIPPABLE', 'false')
+        env = os.getenv('CI', 'false')
 
         # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
         if env == 'true':

--- a/tests/server/integration/services/test_mapping_service.py
+++ b/tests/server/integration/services/test_mapping_service.py
@@ -18,7 +18,7 @@ class TestMappingService(unittest.TestCase):
     def setUpClass(cls):
         env = os.getenv('CI', 'false')
 
-        # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
+        # Firewall rules mean we can't hit Postgres from CI so we have to skip them in the CI build
         if env == 'true':
             cls.skip_tests = True
 

--- a/tests/server/integration/services/test_mapping_service.py
+++ b/tests/server/integration/services/test_mapping_service.py
@@ -16,7 +16,7 @@ class TestMappingService(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        env = os.getenv('SHIPPABLE', 'false')
+        env = os.getenv('CI', 'false')
 
         # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
         if env == 'true':

--- a/tests/server/integration/services/test_project_search_service.py
+++ b/tests/server/integration/services/test_project_search_service.py
@@ -20,7 +20,7 @@ class TestProjectSearchService(unittest.TestCase):
 
         env = os.getenv('CI', 'false')
 
-        # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
+        # Firewall rules mean we can't hit Postgres from CI so we have to skip them in the CI build
         if env == 'true':
             cls.skip_tests = True
 

--- a/tests/server/integration/services/test_project_search_service.py
+++ b/tests/server/integration/services/test_project_search_service.py
@@ -18,7 +18,7 @@ class TestProjectSearchService(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
 
-        env = os.getenv('SHIPPABLE', 'false')
+        env = os.getenv('CI', 'false')
 
         # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
         if env == 'true':

--- a/tests/server/integration/services/test_validation_service.py
+++ b/tests/server/integration/services/test_validation_service.py
@@ -13,7 +13,7 @@ class TestValidationService(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        env = os.getenv('SHIPPABLE', 'false')
+        env = os.getenv('CI', 'false')
 
         # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
         if env == 'true':

--- a/tests/server/integration/services/test_validation_service.py
+++ b/tests/server/integration/services/test_validation_service.py
@@ -15,7 +15,7 @@ class TestValidationService(unittest.TestCase):
     def setUpClass(cls):
         env = os.getenv('CI', 'false')
 
-        # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
+        # Firewall rules mean we can't hit Postgres from CI so we have to skip them in the CI build
         if env == 'true':
             cls.skip_tests = True
 

--- a/tests/server/integration/services/users/test_authentication_service.py
+++ b/tests/server/integration/services/users/test_authentication_service.py
@@ -13,7 +13,7 @@ class TestAuthenticationService(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        env = os.getenv('SHIPPABLE', 'false')
+        env = os.getenv('CI', 'false')
 
         # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
         if env == 'true':

--- a/tests/server/integration/services/users/test_authentication_service.py
+++ b/tests/server/integration/services/users/test_authentication_service.py
@@ -15,7 +15,7 @@ class TestAuthenticationService(unittest.TestCase):
     def setUpClass(cls):
         env = os.getenv('CI', 'false')
 
-        # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
+        # Firewall rules mean we can't hit Postgres from CI so we have to skip them in the CI build
         if env == 'true':
             cls.skip_tests = True
 

--- a/tests/server/integration/services/users/test_user_service.py
+++ b/tests/server/integration/services/users/test_user_service.py
@@ -15,7 +15,7 @@ class TestAuthenticationService(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        env = os.getenv('SHIPPABLE', 'false')
+        env = os.getenv('CI', 'false')
 
         # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
         if env == 'true':

--- a/tests/server/integration/services/users/test_user_service.py
+++ b/tests/server/integration/services/users/test_user_service.py
@@ -17,7 +17,7 @@ class TestAuthenticationService(unittest.TestCase):
     def setUpClass(cls):
         env = os.getenv('CI', 'false')
 
-        # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
+        # Firewall rules mean we can't hit Postgres from CI so we have to skip them in the CI build
         if env == 'true':
             cls.skip_tests = True
 


### PR DESCRIPTION
See https://github.com/hotosm/tasking-manager/pull/1013#issuecomment-356638724 for background.

Since we are relying only on CircleCI now, we need to rely on another environmental variable to flag whether it's a CI build or not. (As an aside, developers should be running tests locally as well to ensure tests that require database access pass.)

The behavior that this fixes only surfaces on PRs from branches of forks because the CircleCI secure variables (including `SHIPPABLE=true` that we manually set) are not passed into those for security reasons. But, `CI` and `CIRCLECI` are set to `true` in the builds so we can use that instead. And we settled on `CI` to generalize it in case of future CI platform changes or for users using other platforms.