### PR TITLE
Change CI var in stats test

### DIFF
--- a/tests/server/integration/services/test_stats_service.py
+++ b/tests/server/integration/services/test_stats_service.py
@@ -12,9 +12,9 @@ class TestStatsService(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        env = os.getenv('SHIPPABLE', 'false')
+        env = os.getenv('CI', 'false')
 
-        # Firewall rules mean we can't hit Postgres from Shippable so we have to skip them in the CI build
+        # Firewall rules mean we can't hit Postgres from CI so we have to skip them in the CI build
         if env == 'true':
             cls.skip_tests = True
 


### PR DESCRIPTION
One more `SHIPPABLE` to `CI` transition in the tests since this was a recent merge. See #1020 for more info.