### PR TITLE
Add ability to filter for archived or draft projects

### DIFF
--- a/client/app/contribute/contribute.controller.js
+++ b/client/app/contribute/contribute.controller.js
@@ -25,6 +25,8 @@
 
         // Search parameters
         vm.mapperLevel = 'ALL'; // default to ALL
+        vm.searchDraft = false;
+        vm.searchArchived = false;
         vm.searchRoads = false;
         vm.searchBuildings = false;
         vm.searchWaterways = false;
@@ -79,7 +81,14 @@
          * @param page
          */
         function searchProjects(page) {
+            vm.projectStatuses = [];
             vm.mappingTypes = [];
+            if (vm.searchDraft) {
+                vm.projectStatuses.push("DRAFT");
+            }
+            if (vm.searchArchived) {
+                vm.projectStatuses.push("ARCHIVED");
+            }
             if (vm.searchRoads) {
                 vm.mappingTypes.push("ROADS");
             }
@@ -101,6 +110,15 @@
             // Only add parameters if set
             if (vm.mapperLevel) {
                 searchParams.mapperLevel = vm.mapperLevel;
+            }
+            if (vm.projectStatuses.length > 0) {
+                searchParams.projectStatuses = '';
+                for (var i = 0; i < vm.projectStatuses.length; i++) {
+                    searchParams.projectStatuses += vm.projectStatuses[i];
+                    if (i < vm.projectStatuses.length - 1) {
+                        searchParams.projectStatuses += ',';
+                    }
+                }
             }
             if (vm.mappingTypes.length > 0) {
                 searchParams.mappingTypes = '';
@@ -182,6 +200,7 @@
             $location.search('difficulty', searchParams.mapperLevel);
             $location.search('organisation', searchParams.organisationTag);
             $location.search('campaign', searchParams.campaignTag);
+            $location.search('statuses', searchParams.projectStatuses);
             $location.search('types', searchParams.mappingTypes);
             $location.search('page', searchParams.page);
             $location.search('text', searchParams.textSearch);
@@ -195,6 +214,10 @@
             vm.searchCampaign = $location.search().campaign;
             vm.currentPage = $location.search().page;
             vm.searchText = $location.search().text;
+            var projectStatuses = $location.search().statuses;
+            if (projectStatuses) {
+                populateProjectStatuses(projectStatuses);
+            }
             var mappingTypes = $location.search().types;
             if (mappingTypes) {
                 populateMappingTypes(mappingTypes);
@@ -202,6 +225,21 @@
             // Only update the mapperLevel when it is set
             if ($location.search().difficulty) {
                 vm.mapperLevel = $location.search().difficulty;
+            }
+        }
+        /**
+         * Extract the project statuses from a string
+         * @param projectStatuses
+         */
+        function populateProjectStatuses(projectStatuses) {
+            var projectStatusesArray = projectStatuses.split(',');
+            for (var i = 0; i < projectStatusesArray.length; i++) {
+                if (projectStatusesArray[i] === 'DRAFT') {
+                    vm.searchDraft = true;
+                }
+                if (projectStatusesArray[i] === 'ARCHIVED') {
+                    vm.searchArchived = true;
+                }
             }
         }
 

--- a/client/app/contribute/contribute.html
+++ b/client/app/contribute/contribute.html
@@ -49,6 +49,24 @@
                                   <form class="form">
                                       <fieldset class="form__fieldset">
                                           <div class="search-options-container">
+                                              <div class="form__group search-option" ng-show="accountNavCtrl.account.role === 'PROJECT_MANAGER' || accountNavCtrl.account.role === 'ADMIN'">
+                                                  <div>
+                                                      <label class="form__option form__option--custom-checkbox">
+                                                          <input type="checkbox" name="form-custom-checkbox"
+                                                                 ng-click="contributeCtrl.search()"
+                                                                 ng-model="contributeCtrl.searchDraft"/>
+                                                          <span class="form__option__text">{{ 'Include draft projects' | translate }}</span>
+                                                          <span class="form__option__ui"></span>
+                                                      </label>
+                                                      <label class="form__option form__option--custom-checkbox">
+                                                          <input type="checkbox" name="form-custom-checkbox"
+                                                                 ng-click="contributeCtrl.search()"
+                                                                 ng-model="contributeCtrl.searchArchived"/>
+                                                          <span class="form__option__text">{{ 'Include archived projects' | translate }}</span>
+                                                          <span class="form__option__ui"></span>
+                                                      </label>
+                                                  </div>
+                                              </div>
                                               <div class="form__group search-option form__group--section--sm">
                                                   <label class="form__label">{{ 'Mapping difficulty' | translate }}</label>
                                                   <select class="form__control form__control--medium"

--- a/server/api/project_apis.py
+++ b/server/api/project_apis.py
@@ -250,6 +250,10 @@ class ProjectSearchAPI(Resource):
               description: text to search
               type: string
               default: serbia
+            - in: query
+              name: projectStatuses
+              description: Authenticated PMs can search for archived or draft statuses
+              type: string
         responses:
             200:
                 description: Projects found
@@ -278,6 +282,9 @@ class ProjectSearchAPI(Resource):
             mapping_types_str = request.args.get('mappingTypes')
             if mapping_types_str:
                 search_dto.mapping_types = map(str, mapping_types_str.split(','))  # Extract list from string
+            project_statuses_str = request.args.get('projectStatuses')
+            if project_statuses_str:
+                search_dto.project_statuses = map(str, project_statuses_str.split(','))
             search_dto.validate()
         except DataError as e:
             current_app.logger.error(f'Error validating request: {str(e)}')

--- a/server/models/dtos/project_dto.py
+++ b/server/models/dtos/project_dto.py
@@ -9,6 +9,9 @@ from server.models.postgis.statuses import ProjectStatus, ProjectPriority, Mappi
 
 def is_known_project_status(value):
     """ Validates that Project Status is known value """
+    if type(value) == list:
+        return  # Don't validate the entire list, just the individual values
+
     try:
         ProjectStatus[value.upper()]
     except KeyError:
@@ -97,6 +100,7 @@ class ProjectSearchDTO(Model):
     preferred_locale = StringType(required=True, default='en')
     mapper_level = StringType(validators=[is_known_mapping_level])
     mapping_types = ListType(StringType, validators=[is_known_mapping_type])
+    project_statuses = ListType(StringType, validators=[is_known_project_status])
     organisation_tag = StringType()
     campaign_tag = StringType()
     page = IntType(required=True)
@@ -109,9 +113,13 @@ class ProjectSearchDTO(Model):
         if self.mapping_types:
             for mapping_type in self.mapping_types:
                 hashable_mapping_types = hashable_mapping_types + mapping_type
+        hashable_project_statuses = ''
+        if self.project_statuses:
+            for project_status in self.project_statuses:
+                hashable_project_statuses = hashable_project_statuses + project_status
 
-        return hash((self.preferred_locale, self.mapper_level, hashable_mapping_types, self.organisation_tag,
-                     self.campaign_tag, self.page, self.text_search, self.is_project_manager))
+        return hash((self.preferred_locale, self.mapper_level, hashable_mapping_types, hashable_project_statuses,
+                     self.organisation_tag, self.campaign_tag, self.page, self.text_search, self.is_project_manager))
 
 
 class ProjectSearchBBoxDTO(Model):

--- a/server/services/project_search_service.py
+++ b/server/services/project_search_service.py
@@ -109,6 +109,13 @@ class ProjectSearchService:
 
         if not search_dto.is_project_manager:
             query = query.filter(Project.status == ProjectStatus.PUBLISHED.value)
+        else:
+            project_status_array = [ProjectStatus.PUBLISHED.value]
+            if search_dto.project_statuses:
+                for project_status in search_dto.project_statuses:
+                    project_status_array.append(ProjectStatus[project_status].value)
+
+            query = query.filter(Project.status.in_(project_status_array))
 
         if search_dto.mapper_level and search_dto.mapper_level.upper() != 'ALL':
             query = query.filter(Project.mapper_level == MappingLevel[search_dto.mapper_level].value)


### PR DESCRIPTION
#858 added the initial ability for searches to include draft and archived projects in results for authenticated project managers.

#922 clarified this functionality by removing a reliance on a possibly out-of-date authentication variable in the API.

The next step as requested is to expose a filter for project managers that will include/exclude draft and/or archived projects in the results. This PR accomplishes that.

Filters turned off
![Filters turned off](https://user-images.githubusercontent.com/8998918/35022770-4b4e977e-fafd-11e7-95ae-fb29a11b55da.PNG)

Filters turned on:
![Filters turned on](https://user-images.githubusercontent.com/8998918/35022774-4f7baf6c-fafd-11e7-8231-46e571beeb81.PNG)
