### PR TITLE
Revert init of homepage stats in manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import base64
 from flask_migrate import MigrateCommand
 from flask_script import Manager
 
-from server import create_app, init_counters
+from server import create_app
 from server.services.users.authentication_service import AuthenticationService
 from server.services.users.user_service import UserService
 
@@ -17,7 +17,6 @@ for key in ['TM_DB','TM_SECRET','TM_CONSUMER_KEY','TM_CONSUMER_SECRET','TM_ENV']
 
 # Initialise the flask app object
 application = create_app()
-init_counters(application)
 manager = Manager(application)
 
 


### PR DESCRIPTION
When starting with a fresh database that you plan to upgrade with alembic, the initialization of the homepage stats (eliminated in this PR) will cause everything to fail. For now, we can remove the init and rethink how we want to do that. This won't affect the stats displaying--it will just not run the query on boot to have the stats already cached.

Fixes #1032