### PR TITLE
Handle homepage stats error in manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -17,7 +17,10 @@ for key in ['TM_DB','TM_SECRET','TM_CONSUMER_KEY','TM_CONSUMER_SECRET','TM_ENV']
 
 # Initialise the flask app object
 application = create_app()
-init_counters(application)
+try:
+    init_counters(application)
+except Exception:
+    warnings.warn('Homepage counters not initialized.')
 manager = Manager(application)
 
 


### PR DESCRIPTION
New and improved!

This time we ignore exceptions from the `init_counters` call and give a warning to the user if it didn't initialize.