### PR TITLE
Add fix for AWS rate limiting when sending messages to all

### DIFF
--- a/server/services/messaging/message_service.py
+++ b/server/services/messaging/message_service.py
@@ -1,4 +1,5 @@
 import re
+import time
 
 from cachetools import TTLCache, cached
 from typing import List
@@ -70,11 +71,16 @@ class MessageService:
 
         message_dto.message = f'{project_link}<br/><br/>' + message_dto.message  # Append project link to end of message
 
+        msg_count = 0
         for contributor in contributors:
             message = Message.from_dto(contributor[0], message_dto)
             message.save()
             user = UserService.get_user_by_id(contributor[0])
             SMTPService.send_email_alert(user.email_address, user.username)
+            msg_count += 1
+            if msg_count == 13:
+                time.sleep(1.5)  # Sleep for 1.5 seconds, after every 13 messages so we don't hit AWS rate limits
+                msg_count = 0
 
     @staticmethod
     def send_message_after_comment(comment_from: int, comment: str, task_id: int, project_id: int):

--- a/server/services/messaging/message_service.py
+++ b/server/services/messaging/message_service.py
@@ -78,8 +78,8 @@ class MessageService:
             user = UserService.get_user_by_id(contributor[0])
             SMTPService.send_email_alert(user.email_address, user.username)
             msg_count += 1
-            if msg_count == 13:
-                time.sleep(1.5)  # Sleep for 1.5 seconds, after every 13 messages so we don't hit AWS rate limits
+            if msg_count == 5:
+                time.sleep(0.5)  # Sleep for 0.5 seconds to avoid hitting AWS rate limits every 5 messages
                 msg_count = 0
 
     @staticmethod


### PR DESCRIPTION
This hopefully fixes #961 - my suspicion is we're hitting AWS Rate Limits which are set at 14 emails per second.  So a a large project can easily have 50+ contributors - so when we can the AWS API to send all 50, Amazon will time us out.

This PR add a 0.5 seconds sleep after every 5 emails.  (Reduced number in case other emails being sent at same time)
