### PR TITLE
Fix validate all tasks button causing contributors list to be lost

### DIFF
--- a/server/services/validator_service.py
+++ b/server/services/validator_service.py
@@ -217,7 +217,7 @@ class ValidatorService:
                                               Task.task_status != TaskStatus.BADIMAGERY.value).all()
 
         for task in tasks_to_validate:
-            task.mapped_by = user_id  # Ensure we set mapped by value
+            task.mapped_by = task.mapped_by or user_id  # Ensure we set mapped by value
             if TaskStatus(task.task_status) not in [TaskStatus.LOCKED_FOR_MAPPING, TaskStatus.LOCKED_FOR_VALIDATION]:
                 # Only lock tasks that are not already locked to avoid double lock issue
                 task.lock_task_for_validating(user_id)

--- a/tests/server/integration/services/test_validation_service.py
+++ b/tests/server/integration/services/test_validation_service.py
@@ -77,5 +77,5 @@ class TestValidationService(unittest.TestCase):
         ValidatorService.validate_all_tasks(self.test_project.id, self.test_user.id)
 
         for task in self.test_project.tasks:
-            self.assertEqual(task.mapped_by, self.test_user.id)
+            self.assertIsNotNone(task.mapped_by)
             self.assertEqual(task.validated_by, self.test_user.id)


### PR DESCRIPTION
Made a feature branch for https://github.com/hotosm/tasking-manager/pull/1055

fixes issue #986 

----

According to the reported issue, when a project admin 'A' clicked "Validate all tasks", the application marked tasks as having been mapped by 'A' regardless of whether or not he/she actually mapped them.

The flow of this operation is as follows:

- The frontend sends a `POST` request to `/admin/project/<int:project_id>/validate-all`
- The backend calls `ValidatorService.validate_all_tasks` passing the project ID and the ID of the authenticated user (in this case the project admin, NOT the mapper). This ID is necessary to record the user performing the current action (validation).
- However, `validate_all_tasks` also sets the `mapped_by` value of each task to this user ID.

Removing the line that does so fixes this issue, because we need not record/update the mapper ID here. It is already taken care of in `task.unlock_task:314`

Update: For tasks that do not already have a `mapped_by` ID set, we set it to the project manager's (the user clicking the button) ID.

----