### PR TITLE
Thread message-all function

### DIFF
--- a/server/api/messaging/message_apis.py
+++ b/server/api/messaging/message_apis.py
@@ -1,3 +1,5 @@
+import threading
+
 from flask_restful import Resource, request, current_app
 from schematics.exceptions import DataError
 
@@ -62,8 +64,10 @@ class ProjectsMessageAll(Resource):
             return str(e), 400
 
         try:
-            MessageService.send_message_to_all_contributors(project_id, message_dto)
-            return {"Success": "Messages sent"}, 200
+            threading.Thread(target=MessageService.send_message_to_all_contributors,
+                             args=(project_id, message_dto)).start()
+
+            return {"Success": "Messages started"}, 200
         except Exception as e:
             error_msg = f'Send message all - unhandled error: {str(e)}'
             current_app.logger.critical(error_msg)


### PR DESCRIPTION
This hopefully fixes #961 once and for all.

Testing demonstrated that message all is taking over 1 minute to run, our theory is that the AWS load balancer is killing the request at the 1 minute mark which means a lot of contributors are not getting messaged.

This PR now launches the message_all function on a background thread.  This will mean that when you message all contributors, the UI will report that messages have been sent instantly.  However, a background thread on the server will be running for circa 2 mins sending all the emails.

I've tested locally and seems to be working fine for me.

cc @bgirardot 