### PR TITLE
Add invalidated count to user DTO/API call

### DIFF
--- a/server/models/dtos/user_dto.py
+++ b/server/models/dtos/user_dto.py
@@ -34,6 +34,7 @@ class UserDTO(Model):
     mapping_level = StringType(serialized_name='mappingLevel', validators=[is_known_mapping_level])
     tasks_mapped = IntType(serialized_name='tasksMapped')
     tasks_validated = IntType(serialized_name='tasksValidated')
+    tasks_invalidated = IntType(serialized_name='tasksInvalidated')
     email_address = EmailType(serialized_name='emailAddress', serialize_when_none=False)
     is_email_verified = EmailType(serialized_name='isEmailVerified', serialize_when_none=False)
     twitter_id = StringType(serialized_name='twitterId')

--- a/server/models/postgis/user.py
+++ b/server/models/postgis/user.py
@@ -205,6 +205,7 @@ class User(db.Model):
         user_dto.mapping_level = MappingLevel(self.mapping_level).name
         user_dto.tasks_mapped = self.tasks_mapped
         user_dto.tasks_validated = self.tasks_validated
+        user_dto.tasks_invalidated = self.tasks_invalidated
         user_dto.twitter_id = self.twitter_id
         user_dto.linkedin_id = self.linkedin_id
         user_dto.facebook_id = self.facebook_id


### PR DESCRIPTION
Currently the `/api/user` endpoint returns a DTO about a user that includes the counts of tasks validated and tasks mapped, but not tasks invalidated. This information is already in the database and is desired by data consumers, so this PR adds the tasks invalidated count to the base user DTO and also when the DTO is populated.