### PR TITLE
Increase AWS upload size limit

### DIFF
--- a/.ebextensions/environment.config
+++ b/.ebextensions/environment.config
@@ -10,12 +10,12 @@ files:
     content: |
       #! /bin/bash
 
-      CONFIGURED=`grep -c "client_max_body_size 10M;" /etc/nginx/sites-available/elasticbeanstalk-nginx-docker-proxy.conf`
+      CONFIGURED=`grep -c "client_max_body_size 25M;" /etc/nginx/sites-available/elasticbeanstalk-nginx-docker-proxy.conf`
 
       if [ $CONFIGURED = 0 ]
         then
           sed -i "/listen 80;/a \ \ proxy_read_timeout 180;" /etc/nginx/sites-available/elasticbeanstalk-nginx-docker-proxy.conf
-          sed -i "/listen 80;/a \ \ client_max_body_size 10M;" /etc/nginx/sites-available/elasticbeanstalk-nginx-docker-proxy.conf
+          sed -i "/listen 80;/a \ \ client_max_body_size 25M;" /etc/nginx/sites-available/elasticbeanstalk-nginx-docker-proxy.conf
           logger -t nginx_rw "Modified config"
           exit 0
         else


### PR DESCRIPTION
From user feedback, it sounds like 10MB may be a bit too small in some use cases, so this ups the limit to 25MB. (This only affects deploys that use the elastic beanstalk configuration files.)

More generally, we should perhaps add a note in the create project UI if a file is detected to be above X MB that alerts the PM performance could be impacted for some users.

@smit1678 