### PR TITLE
Add proposed roadmap document

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,26 @@
+# Roadmap
+
+## Plan 
+
+### 0-2 months
+* Resolve performance and scalability issues
+* Conduct user testing and a design review
+* Resolve feature parity between TMv2 and TMv3
+* Refactor frontend to React
+
+### 2 - 4 months
+* Add groups/organizations for improved project and team management
+* Add new analytics for users, projects, groups
+* Add AI/ML integration for improved mapping efficiency
+
+### 4 - 6 months
+* Improved validation methods
+* Data quality feedback, integrations
+
+## Longer term ideas/directions
+
+- Address the overlap of TM and MapCampaigner functionalities, should they be separate tools
+- Improve the connection between remote and field (not just API but workflow and engagement)
+- Support moving from creating data in unmapped areas to updating areas with new imagery or information
+
+Have an idea you'd like to see on the roadmap? Or want to help contribute to a large part of the development of the roadmap? Open up a PR with your idea, or get in touch with HOT directly -- nate@hotosm.org.


### PR DESCRIPTION
This PR adds a roadmap document to help set the goals and direction for continuous development. After our initial community conversation, one of the items we said we would follow up on would be to move our draft of a roadmap into this repo and start to plan out a process for reviewing a roadmap, getting more input, and work to start to implement that roadmap. 

This proposed roadmap is based off of previous community conversations and a draft roadmap that was discussed through the HOT Tech Working Group , see: https://github.com/hotosm/tech/issues/112#issuecomment-382006285. 

Using a markdown document in the repo instead of a wiki page to better track changes and make proposals for discussions around items. 

### Why do we need a roadmap?
One of the main reasons is to help document and share an overall vision and direction for the project. The roadmap will be informed by input of users and stakeholders and should address the needs of organizations that run TMs as well as the mappers who use it. 

### Proposed roadmap
The way I see a roadmap is that it is a list of specific features or development objectives. Each item in the roadmap will then have tasks/tickets to implement or solve that item. These items should be dropped into a milestone and labeled on Github.  

It may be many tasks to complete that development objective. Each development objective should also be fairly discrete and available for an organization to consider resourcing/working on themselves and submitting a pull request back to the main repo. 

Drop comments, questions into the thread here, or make them inline on the document. 
