### PR TITLE
Improve GPX box

### DIFF
--- a/server/services/mapping_service.py
+++ b/server/services/mapping_service.py
@@ -158,7 +158,7 @@ class MappingService:
         # Create trk element
         trk = ET.Element('trk')
         root.append(trk)
-        ET.SubElement(trk, 'name').text = f'Task for project {project_id}. Do not edit outside of this box!'
+        ET.SubElement(trk, 'name').text = f'Task for project {project_id}. Do not edit outside of this area!'
 
         # Construct trkseg elements
         if task_ids_str is not None:
@@ -180,7 +180,6 @@ class MappingService:
 
                     # Append wpt elements to end of doc
                     wpt = ET.Element('wpt', attrib=dict(lon=str(point[0]), lat=str(point[1])))
-                    ET.SubElement(wpt, 'name').text = 'Do not edit outside of this colored area!'
                     root.append(wpt)
 
         xml_gpx = ET.tostring(root, encoding='utf8')


### PR DESCRIPTION
Based on a recent discussion, this PR removes the warnings from nodes on a task GPX. Now the warning is only shown in the middle of the task geometry.

This also fixes a lingering issue of the GPX warning saying `box` instead of `area`.