### PR TITLE
Stop sending messages when tasks are validated

### DIFF
--- a/server/services/messaging/message_service.py
+++ b/server/services/messaging/message_service.py
@@ -43,28 +43,6 @@ class MessageService:
         return welcome_message.id
 
     @staticmethod
-    def send_message_after_validation(validated_by: int, mapped_by: int, task_id: int, project_id: int):
-        """ Sends mapper a thank you, after their task has been marked as valid """
-        if validated_by == mapped_by:
-            return  # No need to send a thankyou to yourself
-
-        text_template = get_template('validation_message_en.txt')
-        task_link = MessageService.get_task_link(project_id, task_id)
-
-        user = UserService.get_user_by_id(mapped_by)
-        text_template = text_template.replace('[USERNAME]', user.username)
-        text_template = text_template.replace('[TASK_LINK]', task_link)
-
-        validation_message = Message()
-        validation_message.from_user_id = validated_by
-        validation_message.to_user_id = mapped_by
-        validation_message.subject = f'Your mapping in Project {project_id} on {task_link} has just been validated'
-        validation_message.message = text_template
-        validation_message.add_message()
-
-        SMTPService.send_email_alert(user.email_address, user.username)
-
-    @staticmethod
     def send_message_to_all_contributors(project_id: int, message_dto: MessageDTO):
         """  Sends supplied message to all contributors on specified project.  Message all contributors can take
              over a minute to run, so this method is expected to be called on its own thread """

--- a/server/services/validator_service.py
+++ b/server/services/validator_service.py
@@ -99,9 +99,6 @@ class ValidatorService:
                                                           validated_dto.project_id)
 
             if task_to_unlock['new_state'] == TaskStatus.VALIDATED and task.mapped_by not in message_sent_to:
-                # All mappers get a thankyou if their task has been validated :)  Only once if multiple tasks mapped
-                MessageService.send_message_after_validation(validated_dto.user_id, task.mapped_by, task.id,
-                                                             validated_dto.project_id)
                 # Set last_validation_date for the mapper to current date
                 task.mapper.last_validation_date = timestamp()
                 message_sent_to.append(task.mapped_by)


### PR DESCRIPTION
Fixes https://github.com/hotosm/tasking-manager/issues/635 by simply removing the entire feature for sending messages when a task is validated.