### PR TITLE
Debian dependency fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6
 # Install dependencies for shapely
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get install -y libgeos-c1 libgeos-dev
+RUN apt-get install -y libgeos-dev
 
 # Uncomment and set with valid connection string for use locally
 #ENV TM_DB=postgresql://user:pass@host/db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6-jessie
 
 # Install dependencies for shapely
 RUN apt-get update


### PR DESCRIPTION
This pins to the `jessie` (Debian 8.10) variant of the `python:3.6` Docker image and removes the explicit installation of a `libgeos-dev` dependency for compatibility across versions.

Pinning to `jessie` will prevent other unexpected dependency changes.