### PR TITLE
Match circle dependencies to Dockerfile

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /app
     docker:
-      - image: python:3.6
+      - image: python:3.6-jessie
     steps:
       - checkout
       - setup_remote_docker
@@ -13,7 +13,7 @@ jobs:
               # Install latest LTS node
               apt-get update
               curl -sL https://deb.nodesource.com/setup_6.x | bash -
-              apt-get install -y nodejs libgeos-c1 libgeos-dev # Required for shapely
+              apt-get install -y nodejs libgeos-dev # Required for shapely
               node --version
       - restore_cache:
           keys:


### PR DESCRIPTION
This wasn't breaking CircleCI yet (`python:3.6` is probably cached since it only changed recently), but it will soon.