### PR TITLE
EB db upgrade

### DIFF
--- a/.ebextensions/aws.config
+++ b/.ebextensions/aws.config
@@ -1,0 +1,12 @@
+commands:
+  create_post_dir:
+    command: "mkdir /opt/elasticbeanstalk/hooks/appdeploy/post"
+    ignoreErrors: true
+files:
+  "/opt/elasticbeanstalk/hooks/appdeploy/post/99_upgrade_db.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+        #!/usr/bin/env bash
+        docker exec $(docker ps -q) sh -c "cd /src && python3.6 manage.py db upgrade"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.6-jessie
 
 # Install dependencies for shapely
 RUN apt-get update

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /app
     docker:
-      - image: python:3.6
+      - image: python:3.6-jessie
     steps:
       - checkout
       - setup_remote_docker
@@ -13,7 +13,7 @@ jobs:
               # Install latest LTS node
               apt-get update
               curl -sL https://deb.nodesource.com/setup_6.x | bash -
-              apt-get install -y nodejs libgeos-c1 libgeos-dev # Required for shapely
+              apt-get install -y nodejs libgeos-dev # Required for shapely
               node --version
       - restore_cache:
           keys:

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -7,6 +7,7 @@
 # set to 'true' to run the environment during
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
+script_location = /src/migrations
 
 # Custom param that enables us to specify tables to ignore when determining migrations
 [alembic:exclude]


### PR DESCRIPTION
This PR creates a script in EB that will run the python db upgrade after deployment. Please note that this happens every time an instance is deployed which is not ideal but for the most part will do nothing. 

@smit1678 @bgirardot @ethan-nelson this is a precursor to being able to re-merge the dev changes (new relic, etc) into `master`. 