### PR TITLE
fix missing maps badges link in User profile section

### DIFF
--- a/client/app/profile/profile.html
+++ b/client/app/profile/profile.html
@@ -70,7 +70,7 @@
                                     </a>
                                    </p>
                                 <p>
-                                    <a href="http://www.missingmaps.org/users/#/{{ profileCtrl.username }}/history" target="_blank" rel="noopener">
+                                    <a href="http://www.missingmaps.org/users/#/{{ profileCtrl.username }}/badges" target="_blank" rel="noopener">
                                         {{ 'Missing Maps Badges' | translate }}
                                     </a>
                                     </p>


### PR DESCRIPTION
Current link to "Missing Maps Badges" takes to invalid URL. This commit will fix the link