### PR TITLE
Include bad imagery in mapped, validation stat calculations

### DIFF
--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -297,8 +297,8 @@ class Project(db.Model):
         centroid_geojson = db.session.scalar(self.centroid.ST_AsGeoJSON())
         summary.aoi_centroid = geojson.loads(centroid_geojson)
 
-        summary.percent_mapped = int((self.tasks_mapped / (self.total_tasks - self.tasks_bad_imagery)) * 100)
-        summary.percent_validated = int(((self.tasks_validated + self.tasks_bad_imagery) / self.total_tasks) * 100)
+        summary.percent_mapped = int(((self.tasks_mapped + self.tasks_bad_imagery) / self.total_tasks) * 100)
+        summary.percent_validated = int((self.tasks_validated  / self.total_tasks) * 100)
 
         project_info = ProjectInfo.get_dto_for_locale(self.id, preferred_locale, self.default_locale)
         summary.name = project_info.name

--- a/server/services/project_search_service.py
+++ b/server/services/project_search_service.py
@@ -78,9 +78,9 @@ class ProjectSearchService:
             list_dto.organisation_tag = project.organisation_tag
             list_dto.campaign_tag = project.campaign_tag
             list_dto.percent_mapped = round(
-                (project.tasks_mapped / (project.total_tasks - project.tasks_bad_imagery)) * 100, 0)
+                ((project.tasks_mapped + project.tasks_bad_imagery) / project.total_tasks) * 100, 0)
             list_dto.percent_validated = round(
-                ((project.tasks_validated + project.tasks_bad_imagery) / project.total_tasks) * 100, 0)
+                (project.tasks_validated / project.total_tasks) * 100, 0)
             list_dto.status = ProjectStatus(project.status).name
             list_dto.active_mappers = Project.get_active_mappers(project.id)
 

--- a/server/services/validator_service.py
+++ b/server/services/validator_service.py
@@ -227,5 +227,5 @@ class ValidatorService:
         # Set counters to fully mapped and validated
         project = ProjectService.get_project_by_id(project_id)
         project.tasks_mapped = (project.total_tasks - project.tasks_bad_imagery)
-        project.tasks_validated = (project.total_tasks - project.tasks_bad_imagery)
+        project.tasks_validated = project.total_tasks
         project.save()


### PR DESCRIPTION
Currently, bad imagery is excluded from mapped percentages but is added to validated percentages in the UI. This is opposite of what we want because bad imagery tasks _can_ be validated.

A task that is "ready to be mapped" can be marked mapped or bad imagery; these two choices are on an equivalent level in terms of task completion but are disjointed. (These two choices are not collectively exhaustive, though, as a state can be re-marked as ready to be mapped.) We therefore want the percent mapped to include both mapped and bad imagery counts.

Tasks either in a mapped or bad imagery state can be validated, after which they share the same status. Thus, we want the validated percentage to only count validated tasks over all tasks.

The statistics calculated and returned to the UI have been modified to match this. This fixes half of the problem mentioned in #945 (the other half related to invalidations that is more than just a display fix).