### PR TITLE
Fix online mappers count

### DIFF
--- a/server/services/stats_service.py
+++ b/server/services/stats_service.py
@@ -174,7 +174,7 @@ class StatsService:
         """ Get overall TM stats to give community a feel for progress that's being made """
         dto = HomePageStatsDTO()
 
-        dto.mappers_online = Task.query.distinct(Task.locked_by).count()
+        dto.mappers_online = Task.query.filter(Task.locked_by != None).distinct(Task.locked_by).count()
         dto.total_mappers = User.query.count()
         dto.tasks_mapped = Task.query.\
             filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value))).count()


### PR DESCRIPTION
An unlocked task has the `locked_by` column value set to `None`, so this should be taken care of and all such entries should be ignored while calculating the online mapper count.

Noticed this on my development instance where the number of registered users was 1, but the online mapper count was showing 2.