### PR TITLE
Remove duplicates from results

### DIFF
--- a/server/services/project_search_service.py
+++ b/server/services/project_search_service.py
@@ -141,8 +141,10 @@ class ProjectSearchService:
             or_search = search_dto.text_search.replace(' ', ' | ')
             query = query.filter(ProjectInfo.text_searchable.match(or_search, postgresql_regconfig='english'))
 
-        all_results = query.order_by(Project.priority, Project.id.desc()).all()
-        paginated_results = query.order_by(Project.priority, Project.id.desc()).paginate(search_dto.page, 14, True)
+        all_results = query.order_by(Project.priority, Project.id.desc()) \
+            .distinct(Project.priority, Project.id).all()
+        paginated_results = query.order_by(Project.priority, Project.id.desc()) \
+            .distinct(Project.priority, Project.id).paginate(search_dto.page, 14, True)
 
         return all_results, paginated_results
 


### PR DESCRIPTION
Fixes #1131 

The way the search query is structured, it finds projects either with information in English or information in another locale (in this case, English is the fall back language). Unfortunately this generates duplicate results when there is indeed more than one language supplied in project information. Here, I use a distinct clause to ensure that only one project per id is supplied. Distinct with only the id (and not including priority) would not work because the distinct clause must match the order clause.