### PR TITLE
Improved mapped projects by a user query

### DIFF
--- a/server/models/dtos/user_dto.py
+++ b/server/models/dtos/user_dto.py
@@ -59,7 +59,6 @@ class MappedProject(Model):
     tasks_validated = IntType(serialized_name='tasksValidated')
     status = StringType()
     centroid = BaseType()
-    aoi = BaseType()
 
 
 class UserMappedProjectsDTO(Model):

--- a/server/models/postgis/user.py
+++ b/server/models/postgis/user.py
@@ -143,7 +143,8 @@ class User(db.Model):
                         tasks t
                   where p.id in (select unnest(projects_mapped) from users where id = {0})
                     and p.id = t.project_id
-                    and (t.mapped_by = {0} or t.validated_by = {0})
+                    and (t.mapped_by = {0} or t.mapped_by is null)
+                    and (t.validated_by = {0} or t.validated_by is null)
                GROUP BY p.id, p.status, p.centroid'''.format(user_id)
 
         results = db.engine.execute(sql)

--- a/server/models/postgis/user.py
+++ b/server/models/postgis/user.py
@@ -138,14 +138,13 @@ class User(db.Model):
     @staticmethod
     def get_mapped_projects(user_id: int, preferred_locale: str) -> UserMappedProjectsDTO:
         """ Get all projects a user has mapped on """
-        sql = '''select p.id, p.status, p.default_locale, count(t.mapped_by), count(t.validated_by), st_asgeojson(p.centroid),
-                        st_asgeojson(p.geometry)
+        sql = '''select p.id, p.status, p.default_locale, count(t.mapped_by), count(t.validated_by), st_asgeojson(p.centroid)
                    from projects p,
                         tasks t
                   where p.id in (select unnest(projects_mapped) from users where id = {0})
                     and p.id = t.project_id
                     and (t.mapped_by = {0} or t.validated_by = {0})
-               GROUP BY p.id, p.status, p.centroid, p.geometry'''.format(user_id)
+               GROUP BY p.id, p.status, p.centroid'''.format(user_id)
 
         results = db.engine.execute(sql)
 
@@ -160,7 +159,6 @@ class User(db.Model):
             mapped_project.tasks_mapped = row[3]
             mapped_project.tasks_validated = row[4]
             mapped_project.centroid = geojson.loads(row[5])
-            mapped_project.aoi = geojson.loads(row[6])
 
             project_info = ProjectInfo.get_dto_for_locale(row[0], preferred_locale, row[2])
             mapped_project.name = project_info.name

--- a/server/models/postgis/user.py
+++ b/server/models/postgis/user.py
@@ -144,8 +144,7 @@ class User(db.Model):
                         tasks t
                   where p.id in (select unnest(projects_mapped) from users where id = {0})
                     and p.id = t.project_id
-                    and (t.mapped_by = {0} or t.mapped_by is null)
-                    and (t.validated_by = {0} or t.validated_by is null)
+                    and (t.mapped_by = {0} or t.validated_by = {0})
                GROUP BY p.id, p.status, p.centroid, p.geometry'''.format(user_id)
 
         results = db.engine.execute(sql)


### PR DESCRIPTION
A performance issue in query monitoring and lingering bug reports (e.g. #792, #917, personal communication from slack somewhere about people unable to load their own profile) led to a first step in possible performance improvements through queries.

This PR includes ~two~ _one_ main change~s~:

~1) (I believe) corrects logic so that we return projects where a user id has either mapped _or_ validated a task, not both. I'm also not sure why we were searching for null user IDs as well. Please double check this--I feel like this is a fix, but I could be thinking about it incorrectly.~
~2)~ Removes project AOI/geometry from results. From what I can see in the javascript and testing, only the centroid is loaded on the frontend (c.f. https://github.com/hotosm/tasking-manager/blob/2f9ee6bb3b2fe42c3b1e24c5da6f6bebf316aced/client/app/services/projectMap.service.js#L162). I can imagine a cool case where someone may zoom in and see the AOI instead of a point, but this really becomes a performance issue now (see below).

Testing `bgirardot`'s profile on the main server results in a time out after about 50 seconds.

Testing `bgirardot`'s profile in my local install, the original query returned about a 3 MB file. This however was not really a correct answer because of the abovementioned issues. 

Testing `bgirardot`'s profile in my local install after implementing 1), the query was a 11 MB file and it was truncated by Firefox (whether that's the server or my browser, I really don't know or care at this stage).

Testing `bgirardot`'s profile in my local install after implementing 2) after implementing 1), the query was 61 kb. Additionally, some very back of the envelope math of adding the validated and mapped counts in his profile seems to reach the numbers displayed at the top of the profile more than the original.