### PR TITLE
Add exact time to history, chat

### DIFF
--- a/client/app/components/project-chat/project-chat.html
+++ b/client/app/components/project-chat/project-chat.html
@@ -4,7 +4,7 @@
             <p class="space-bottom--none">
                 <strong>
                     <a href="./user/{{ message.username }}" target="_blank"/>{{ message.username }}</a>
-                </strong> <span class="metadata" am-time-ago="message.timestamp | amUtc | amLocal"></span></p>
+                </strong> <span class="metadata" am-time-ago="message.timestamp | amUtc | amLocal" title="{{ message.timestamp }}"></span></p>
             <p ng-bind-html="message.message"></p>
         </div>
         <div ng-show="projectChatCtrl.messages.length < 1">

--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -961,7 +961,7 @@
                                             <span ng-bind-html="item.actionText" ng-show="item.action === 'COMMENT'"></span>
                                         </div>
                                         <div class="metadata">
-                                            <span am-time-ago="item.actionDate | amUtc | amLocal"></span>
+                                            <span am-time-ago="item.actionDate | amUtc | amLocal" title="{{ item.actionDate }}"></span>
                                             <span ng-show="item.action === 'LOCKED_FOR_MAPPING' && item.actionText"> for {{ item.actionText |  amDurationFormat : 'minute'}} </span>
                                             <span ng-show="item.action === 'LOCKED_FOR_VALIDATION' && item.actionText"> for {{ item.actionText |  amDurationFormat : 'minute'}} </span>
                                             <span ng-show="item.action === 'AUTO_UNLOCKED_FOR_MAPPING' && item.actionText"> after {{ item.actionText |  amDurationFormat : 'minute'}}</span>


### PR DESCRIPTION
Fixes #1152 

This adds the exact date and time to project history entries and chat messages for folks that want a bit more granularity to event times.