### PR TITLE
Keep task history after split and show split actions in history

### DIFF
--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -956,6 +956,8 @@
                                                     href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
                                             <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'READY'">{{ 'Marked as ready by' | translate }} <a
                                                     href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
+                                            <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'SPLIT'">{{ 'Split by' | translate }} <a
+                                                    href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
                                         </div>
                                         <div>
                                             <span ng-bind-html="item.actionText" ng-show="item.action === 'COMMENT'"></span>

--- a/server/models/postgis/statuses.py
+++ b/server/models/postgis/statuses.py
@@ -31,6 +31,7 @@ class TaskStatus(Enum):
     VALIDATED = 4
     INVALIDATED = 5
     BADIMAGERY = 6  # Task cannot be mapped because of clouds, fuzzy imagery
+    SPLIT = 7
 
 
 class MappingLevel(Enum):

--- a/server/models/postgis/task.py
+++ b/server/models/postgis/task.py
@@ -358,6 +358,16 @@ class Task(db.Model):
         self.locked_by = None
         self.update()
 
+    def clone_task_history(self, actions):
+        for action in actions:
+            print(action.action_text,action.action_date,action.action)
+            history = TaskHistory(self.id, self.project_id, action.user_id)
+            history.action = action.action
+            history.action_text = action.action_text
+            history.action_date = action.action_date
+            self.task_history.append(history)
+        self.update()
+
     @staticmethod
     def get_tasks_as_geojson_feature_collection(project_id):
         """


### PR DESCRIPTION
This PR fixes the issue of task history lost during a task split. That's because the old task is deleted during a split and there is presently no transfer mechanism. In this PR, a clone_history function is introduced to loop over the history of the parent task and add task_history events in each of the children tasks. (N.B. this differs from the approach in TM2, where the original task and its history were maintained and children inherited task history events of their parent. We could maybe introduce this here instead to save some DB space for tasks, but it is not possible to recover the history for any task split in TM3 up to the merge of this PR.)

A problem arises however whenever we clone the full history of the parent task. Indeed, we copy every event, _including the lock of the parent task_. That means the user will, by default, also lock each of the child tasks. This problem is confounded by a user not being able to "unlock" a mapping task if it has not been set as being LOCKED_FOR_MAPPING in its task_status. (Keep in mind here that task_history--a table of events tied to a task by id--and the task_status column of a given task are separate.) We must bequeath the task_history value of LOCKED_FOR_MAPPING from the parent task to the child task, and we do so by [setting the value manually](https://github.com/hotosm/tasking-manager/compare/develop...ethan-nelson:retain-history-on-split?expand=1#diff-41e9aae54fefb69558fbbff6e598a0b1R127).

Okay, so we're making progress; we don't really get `more than one row found for one()` errors since our ducks are in a row regarding the status and history. But we need to indicate to users that the split has occurred. Sure, you can click around to the surrounding tasks and see that the history is the same among them and deduce a split was there. But, I like rigor, so a new task state has been included to indicate a state change caused by a split. This allows the frontend to pick up on that fact and include it in the history along with the transferred history:

![split history--that sounds like a breakup song](https://user-images.githubusercontent.com/8998918/43988485-f9c28dc6-9cea-11e8-8b62-790036bc631b.png)

Feedback needed, but please have mercy. Yes there should probably be and likely will be tests added.

Fixes #865, #992. Insights from the db experience added to #1045.