### PR TITLE
Prevent user getting stuck in login loop

### DIFF
--- a/server/api/users/authentication_apis.py
+++ b/server/api/users/authentication_apis.py
@@ -37,7 +37,7 @@ class LoginAPI(Resource):
         """
         redirect_query = ''
         redirect_to = request.args.get('redirect_to')
-        if redirect_to:
+        if redirect_to and 'login' not in redirect_to:
             redirect_query = f'?redirect_to={parse.quote(redirect_to)}'
 
         base_url = current_app.config['APP_BASE_URL']


### PR DESCRIPTION
From #1031:

> After encountering this a few times, I think I have figured it out. Scenario:
> 
> 1) Someone has previously logged in but their token is expired
> 2) They are presented with the log in or return screen (https://tasks.hotosm.org/login)
> 3) Though there is a login button in the body of the page, they click login at the top right
> 4) The login process is started and they log in as normal. However, the login button on the top right of the screen set the return url once logged in to https://tasks.hotosm.org/login since that is where they originated. 

This PR does not add the redirect parameter to the login process if `login` is part of the supplied redirect url. Instead, once the user logs in successfully, they will be redirected to the home page.

Fixes #1031 