### PR TITLE
Restrict validating to JOSM

### DIFF
--- a/client/app/project/project.controller.js
+++ b/client/app/project/project.controller.js
@@ -56,7 +56,8 @@
 
         //editor
         vm.editorStartError = '';
-        vm.selectedEditor = 'ideditor';
+        vm.selectedMappingEditor = 'ideditor';
+        vm.selectedValidatingEditor = 'josm';
 
         //interaction
         vm.selectInteraction = null;
@@ -93,7 +94,8 @@
             vm.currentTab = 'instructions';
             vm.mappingStep = 'selecting';
             vm.validatingStep = 'selecting';
-            vm.selectedEditor = 'ideditor'; // default to iD editor
+            vm.selectedMappingEditor = 'ideditor'; // default to iD editor
+            vm.selectedValidatingEditor = 'josm';
             mapService.createOSMMap('map');
             mapService.addOverviewMap();
             vm.map = mapService.getOSMMap();
@@ -130,7 +132,7 @@
             }, 10000);
 
             // set up the preferred editor from user preferences
-            vm.selectedEditor = userPreferencesService.getFavouriteEditor();
+            vm.selectedMappingEditor = userPreferencesService.getFavouriteEditor();
         }
 
         // listen for navigation away from the page event and stop the autrefresh timer
@@ -165,7 +167,7 @@
         }
 
         vm.updatePreferedEditor = function () {
-            userPreferencesService.setFavouriteEditor(vm.selectedEditor);
+            userPreferencesService.setFavouriteEditor(vm.selectedMappingEditor);
         }
 
         /**

--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -406,7 +406,7 @@
                                             <h6>Get started by choosing your editor of choice.</h6>
                                             <div class="form__input-group">
                                                 <select class="form__control form__control__medium"
-                                                        ng-model="projectCtrl.selectedEditor"
+                                                        ng-model="projectCtrl.selectedMappingEditor"
                                                         ng-change="projectCtrl.updatePreferedEditor()">
                                                     <option value="ideditor" selected="true">iD Editor</option>
                                                     <option value="josm">JOSM</option>
@@ -415,7 +415,7 @@
                                                 </select>
                                                 <span class="form__input-group-button">
                                                     <button class="button button--sm"
-                                                            ng-click="projectCtrl.startEditor(projectCtrl.selectedEditor)">
+                                                            ng-click="projectCtrl.startEditor(projectCtrl.selectedMappingEditor)">
                                                         {{ 'Start Editor' | translate }}
                                                     </button>
                                                 </span>
@@ -743,16 +743,12 @@
                                             <h6>Get started by choosing your editor of choice.</h6>
                                             <div class="form__input-group">
                                                 <select class="form__control form__control__medium"
-                                                        ng-model="projectCtrl.selectedEditor"
-                                                        ng-change="projectCtrl.updatePreferedEditor()">
-                                                    <option value="ideditor" selected="true">iD Editor</option>
-                                                    <option value="josm">JOSM</option>
-                                                    <option value="potlatch2">Potlatch 2</option>
-                                                    <option value="fieldpapers">Field Papers</option>
+                                                        ng-model="projectCtrl.selectedValidatingEditor">
+                                                    <option value="josm" selected="true">JOSM</option>
                                                 </select>
                                                 <span class="form__input-group-button">
                                                     <button class="button button--sm"
-                                                            ng-click="projectCtrl.startEditor(projectCtrl.selectedEditor)">
+                                                            ng-click="projectCtrl.startEditor(projectCtrl.selectedValidatingEditor)">
                                                             {{ 'Start Editor' | translate }}
                                                     </button>
                                                 </span>
@@ -837,16 +833,12 @@
                                             <h6>Get started by choosing your editor of choice.</h6>
                                             <div class="form__input-group">
                                                 <select class="form__control form__control__medium"
-                                                        ng-model="projectCtrl.selectedEditor"
-                                                        ng-change="projectCtrl.updatePreferedEditor()">
-                                                    <option value="ideditor" selected="true">iD Editor</option>
-                                                    <option value="josm">JOSM</option>
-                                                    <option value="potlatch2">Potlatch 2</option>
-                                                    <option value="fieldpapers">Field Papers</option>
+                                                        ng-model="projectCtrl.selectedValidatingEditor">
+                                                    <option value="josm" selected="true">JOSM</option>
                                                 </select>
                                                 <span class="form__input-group-button">
                                                     <button class="button button--sm"
-                                                            ng-click="projectCtrl.startEditor(projectCtrl.selectedEditor)">
+                                                            ng-click="projectCtrl.startEditor(projectCtrl.selectedValidatingEditor)">
                                                         {{ 'Start Editor' | translate }}
                                                     </button>
                                                 </span>


### PR DESCRIPTION
This comes from discussion in #893 and indeed fixes #893. This PR makes the only editor program shown on validating and multi-task validating JOSM.

We split out variables to hold the mapping and validating editor choices because the TM saves user preferences on the preferred map editor program. That interferes with the end goal of this PR by adding other elements in the editor choice menu if the user's preferred editor is not JOSM.

Please close if the discussion in #893 is no longer the preferred approach.