### PR TITLE
Spoof task outline gpx file extension for iD

### DIFF
--- a/client/app/services/editor.service.js
+++ b/client/app/services/editor.service.js
@@ -155,7 +155,7 @@
          * @returns string - gpxUrl
          */
         function getGPXUrl(projectId, taskIds, as_file){
-            var gpxUrl = configService.tmAPI + '/project/' + projectId + '/tasks_as_gpx?tasks=' + taskIds + '&as_file='+(as_file?true:false) + '&filename=.gpx';
+            var gpxUrl = configService.tmAPI + '/project/' + projectId + '/tasks_as_gpx?tasks=' + taskIds + '&as_file='+(as_file?true:false) + '&filename=task.gpx';
             // If it is not a full path, then it must be relative and for the GPX callback to work it needs
             // a full URL so get the current host and append it
             // Check if it is a full URL

--- a/client/app/services/editor.service.js
+++ b/client/app/services/editor.service.js
@@ -155,7 +155,7 @@
          * @returns string - gpxUrl
          */
         function getGPXUrl(projectId, taskIds, as_file){
-            var gpxUrl = configService.tmAPI + '/project/' + projectId + '/tasks_as_gpx?tasks=' + taskIds + '&as_file='+(as_file?true:false);
+            var gpxUrl = configService.tmAPI + '/project/' + projectId + '/tasks_as_gpx?tasks=' + taskIds + '&as_file='+(as_file?true:false) + '&filename=.gpx';
             // If it is not a full path, then it must be relative and for the GPX callback to work it needs
             // a full URL so get the current host and append it
             // Check if it is a full URL


### PR DESCRIPTION
Latest iD release doesn't load GPX files without an extension, so we add a fake one to the URL for now.