### PR TITLE
Add more homepage stats

### DIFF
--- a/server/models/dtos/stats_dto.py
+++ b/server/models/dtos/stats_dto.py
@@ -59,4 +59,7 @@ class HomePageStatsDTO(Model):
     """ DTO for stats we want to display on the homepage """
     mappers_online = IntType(serialized_name='mappersOnline')
     tasks_mapped = IntType(serialized_name='tasksMapped')
+    tasks_validated = IntType(serialized_name='tasksValidated')
     total_mappers = IntType(serialized_name='totalMappers')
+    total_validators = IntType(serialized_name='totalValidators')
+    avg_completion_time = IntType(serialized_name='averageCompletionTime')

--- a/server/models/dtos/stats_dto.py
+++ b/server/models/dtos/stats_dto.py
@@ -55,11 +55,26 @@ class ProjectActivityDTO(Model):
     activity = ListType(ModelType(TaskHistoryDTO))
 
 
+class OrganizationStatsDTO(Model):
+    def __init__(self, tup):
+        super().__init__()
+        self.tag = tup[0]
+        self.projects_created = tup[1]
+
+    tag = StringType()
+    projects_created = IntType(serialized_name='projectsCreated')
+
+
 class HomePageStatsDTO(Model):
     """ DTO for stats we want to display on the homepage """
+    def __init__(self):
+        super().__init__()
+        self.organizations = []
+
     mappers_online = IntType(serialized_name='mappersOnline')
     tasks_mapped = IntType(serialized_name='tasksMapped')
     tasks_validated = IntType(serialized_name='tasksValidated')
     total_mappers = IntType(serialized_name='totalMappers')
     total_validators = IntType(serialized_name='totalValidators')
     avg_completion_time = IntType(serialized_name='averageCompletionTime')
+    organizations = ListType(ModelType(OrganizationStatsDTO))

--- a/server/models/dtos/stats_dto.py
+++ b/server/models/dtos/stats_dto.py
@@ -76,5 +76,5 @@ class HomePageStatsDTO(Model):
     tasks_validated = IntType(serialized_name='tasksValidated')
     total_mappers = IntType(serialized_name='totalMappers')
     total_validators = IntType(serialized_name='totalValidators')
-    avg_completion_time = IntType(serialized_name='averageCompletionTime')
+    # avg_completion_time = IntType(serialized_name='averageCompletionTime')
     organizations = ListType(ModelType(OrganizationStatsDTO))

--- a/server/services/stats_service.py
+++ b/server/services/stats_service.py
@@ -185,26 +185,6 @@ class StatsService:
             .filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value))).count()
         dto.tasks_validated = Task.query.filter(Task.task_status == TaskStatus.VALIDATED.value).count()
 
-        # lock_times = db.session.query(TaskHistory.action_text)\
-        #     .filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value)))\
-        #     .filter(TaskHistory.action.in_(("LOCKED_FOR_MAPPING", "LOCKED_FOR_VALIDATION")))\
-        #     .filter(Task.id == TaskHistory.task_id)\
-        #     .all()
-
-        # task_count = Task.query.filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value)))\
-        #     .count()
-
-        # total_time_spent = datetime.datetime.fromtimestamp(0)
-
-        # for t in lock_times:
-        #     duration = dateutil.parser.parse(t[0])
-        #     total_time_spent += datetime.timedelta(hours=duration.hour,
-        #                                            minutes=duration.minute,
-        #                                            seconds=duration.second,
-        #                                            microseconds=duration.microsecond)
-
-        # dto.avg_completion_time = total_time_spent.timestamp() / task_count
-
         org_proj_count = db.session.query(Project.organisation_tag, func.count(Project.organisation_tag))\
             .group_by(Project.organisation_tag).all()
 

--- a/server/services/stats_service.py
+++ b/server/services/stats_service.py
@@ -185,25 +185,25 @@ class StatsService:
             .filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value))).count()
         dto.tasks_validated = Task.query.filter(Task.task_status == TaskStatus.VALIDATED.value).count()
 
-        lock_times = db.session.query(TaskHistory.action_text)\
-            .filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value)))\
-            .filter(TaskHistory.action.in_(("LOCKED_FOR_MAPPING", "LOCKED_FOR_VALIDATION")))\
-            .filter(Task.id == TaskHistory.task_id)\
-            .all()
+        # lock_times = db.session.query(TaskHistory.action_text)\
+        #     .filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value)))\
+        #     .filter(TaskHistory.action.in_(("LOCKED_FOR_MAPPING", "LOCKED_FOR_VALIDATION")))\
+        #     .filter(Task.id == TaskHistory.task_id)\
+        #     .all()
 
-        task_count = Task.query.filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value)))\
-            .count()
+        # task_count = Task.query.filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value)))\
+        #     .count()
 
-        total_time_spent = datetime.datetime.fromtimestamp(0)
+        # total_time_spent = datetime.datetime.fromtimestamp(0)
 
-        for t in lock_times:
-            duration = dateutil.parser.parse(t[0])
-            total_time_spent += datetime.timedelta(hours=duration.hour,
-                                                   minutes=duration.minute,
-                                                   seconds=duration.second,
-                                                   microseconds=duration.microsecond)
+        # for t in lock_times:
+        #     duration = dateutil.parser.parse(t[0])
+        #     total_time_spent += datetime.timedelta(hours=duration.hour,
+        #                                            minutes=duration.minute,
+        #                                            seconds=duration.second,
+        #                                            microseconds=duration.microsecond)
 
-        dto.avg_completion_time = total_time_spent.timestamp() / task_count
+        # dto.avg_completion_time = total_time_spent.timestamp() / task_count
 
         org_proj_count = db.session.query(Project.organisation_tag, func.count(Project.organisation_tag))\
             .group_by(Project.organisation_tag).all()

--- a/server/services/stats_service.py
+++ b/server/services/stats_service.py
@@ -1,11 +1,13 @@
 from cachetools import TTLCache, cached
+import dateutil.parser
+import datetime
 
 from server import db
 from server.models.dtos.stats_dto import ProjectContributionsDTO, UserContribution, Pagination, TaskHistoryDTO, \
     ProjectActivityDTO, HomePageStatsDTO
 from server.models.postgis.project import Project
 from server.models.postgis.statuses import TaskStatus
-from server.models.postgis.task import TaskHistory, User, Task
+from server.models.postgis.task import TaskHistory, User, Task, TaskAction
 from server.models.postgis.utils import timestamp, NotFound
 from server.services.project_service import ProjectService
 from server.services.users.user_service import UserService
@@ -176,7 +178,30 @@ class StatsService:
 
         dto.mappers_online = Task.query.filter(Task.locked_by != None).distinct(Task.locked_by).count()
         dto.total_mappers = User.query.count()
-        dto.tasks_mapped = Task.query.\
-            filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value))).count()
+        dto.total_validators = Task.query.filter(Task.task_status == TaskStatus.VALIDATED.value)\
+            .distinct(Task.validated_by).count()
+        dto.tasks_mapped = Task.query\
+            .filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value))).count()
+        dto.tasks_validated = Task.query.filter(Task.task_status == TaskStatus.VALIDATED.value).count()
+
+        lock_times = db.session.query(TaskHistory.action_text)\
+            .filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value)))\
+            .filter(TaskHistory.action.in_(("LOCKED_FOR_MAPPING", "LOCKED_FOR_VALIDATION")))\
+            .filter(Task.id == TaskHistory.task_id)\
+            .all()
+
+        task_count = Task.query.filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value)))\
+            .count()
+
+        total_time_spent = datetime.datetime.fromtimestamp(0)
+
+        for t in lock_times:
+            duration = dateutil.parser.parse(t[0])
+            total_time_spent += datetime.timedelta(hours=duration.hour,
+                                                   minutes=duration.minute,
+                                                   seconds=duration.second,
+                                                   microseconds=duration.microsecond)
+
+        dto.avg_completion_time = total_time_spent.timestamp() / task_count
 
         return dto


### PR DESCRIPTION
This PR focuses on the list of stats proposed in #1147 for the homepage section.

> Homepage
> - [x] Mappers online
> - [x] Tasks mapped
> - [ ] Tasks validated
> - [x] Total mappers
> - [ ] Total number of users who validate
> - [ ] Total area mapped and validated
> - [ ] Average task completion time
> - [ ] Number of projects by organization
> - [ ] Enable querying by date

- Added tasks validated
- Added total number of users who validate
- Added number of projects by organization