### PR TITLE
Show missing xmark (close, delete) controls.

### DIFF
--- a/client/assets/styles/sass/_helpers.scss
+++ b/client/assets/styles/sass/_helpers.scss
@@ -169,3 +169,13 @@ hr {
 .button[disabled]{
   cursor: not-allowed;
 }
+
+.hot-ds-icon-sm-xmark:before {
+  width: 12px;
+  height: 12px;
+  background-size: 12px 12px;
+  content: " ";
+  background-image: url('../../icons/xmark.svg');
+  display: inline-block;
+  margin-right: .3em;
+}


### PR DESCRIPTION
Add style for xmark controls, such as the control to dismiss the new-message notification and the control to remove users from a private project, to ensure they are displayed (as hot-design-system styles are no longer pulled in).

<img width="259" alt="xmark" src="https://user-images.githubusercontent.com/445970/44879473-9fa39000-ac5e-11e8-84d4-dc4c091a9b67.png">
