### PR TITLE
Option to reset project tasks, preserving history.

### DIFF
--- a/client/app/admin/edit-project/edit-project.controller.js
+++ b/client/app/admin/edit-project/edit-project.controller.js
@@ -59,12 +59,17 @@
         // Delete
         vm.showDeleteConfirmationModal = false;
 
+        // Reset
+        vm.showResetConfirmationModal = false;
+
         // Private project/add users
         vm.addUserEnabled = false;
 
         // Error messages
         vm.deleteProjectFail = false;
         vm.deleteProjectSuccess = false;
+        vm.resetProjectFail = false;
+        vm.resetProjectSuccess = false;
         vm.invalidateTasksFail = false;
         vm.invalidateTasksSuccess = false;
         vm.validateTasksFail = false;
@@ -370,6 +375,37 @@
         };
 
 
+        /*
+         * Set the reset confirmation modal to visible/invisible
+         * @param showModal
+         */
+        vm.showResetConfirmation = function(showModal){
+            vm.showResetConfirmationModal = showModal;
+            if (!showModal && vm.resetProjectSuccess){
+                $location.path('/');
+            }
+        };
+
+        /**
+         * Reset a project
+         */
+        vm.resetProject = function(){
+            vm.resetProjectFail = false;
+            vm.resetProjectSuccess = false;
+            var resultsPromise = projectService.resetProject(vm.project.projectId);
+            resultsPromise.then(function () {
+                // Project reset successfully
+                vm.resetProjectFail = false;
+                vm.resetProjectSuccess = true;
+                // Reset the page elements
+                getProjectMetadata(vm.project.projectId);
+            }, function(){
+                // Project not reset successfully
+                vm.resetProjectFail = true;
+                vm.resetProjectSuccess = false;
+            });
+        };
+
         /**
          * Set the invalidate confirmation modal to visible/invisible
          * @param showModal
@@ -425,6 +461,27 @@
                 vm.validateTasksFail = true;
                 vm.validateTasksSuccess = false;
                 vm.validateInProgress = false;
+            })
+        };
+
+        /**
+         * Reset all tasks on a project
+         */
+        vm.resetAllTasks = function(){
+            vm.resetInProgress = true;
+            vm.resetTasksFail = false;
+            vm.resetTasksSuccess = false;
+            var resultsPromise = projectService.resetAllTasks(vm.project.projectId);
+            resultsPromise.then(function(){
+                // Tasks reset successfully
+                vm.resetTasksFail = false;
+                vm.resetTasksSuccess = true;
+                vm.resetInProgress = false;
+            }, function(){
+                // Tasks not reset successfully
+                vm.resetTasksFail = true;
+                vm.resetTasksSuccess = false;
+                vm.resetInProgress = false;
             })
         };
 

--- a/client/app/admin/edit-project/edit-project.html
+++ b/client/app/admin/edit-project/edit-project.html
@@ -493,6 +493,17 @@
                                     </button>
                                 </div>
                                 <div class="form__group form__group--section">
+                                    <label class="form__label">{{ 'Reset tasks' | translate }}</label>
+                                    <p>{{ 'Reset all tasks in the project to ready to map, preserving history.' | translate }}</p>
+                                    <div class="alert alert--warning" role="alert">
+                                        <p><strong>{{ 'Warning' | translate }}:</strong> {{ 'This cannot be undone.' | translate }}</p>
+                                    </div>
+                                    <button class="button button--secondary" type="button"
+                                            ng-click="editProjectCtrl.showResetConfirmation(true)">
+                                        {{ 'Reset tasks' | translate }}
+                                    </button>
+                                </div>
+                                <div class="form__group form__group--section">
                                     <label class="form__label">{{ 'Clone project' | translate }}</label>
                                     <p>{{ 'This will clone all descriptions, instructions, metadata etc. The Area of Interest, the tasks and the priority areas will not be cloned. You will have to redraw/import these. Your newly cloned project will be in draft status.' | translate }}</p>
                                     <button class="button button--secondary" type="button"
@@ -728,6 +739,53 @@
     </button>
 </section>
 <!-- validate tasks confirmation modal -->
+
+<!-- reset tasks confirmation modal -->
+<section class="modal modal-tm" ng-show="editProjectCtrl.showResetConfirmationModal">
+    <div class="modal__inner">
+        <header class="modal__header">
+            <div class="modal__headline">
+                <h1 class="modal__title">{{ 'Task reset' | translate }}</h1>
+            </div>
+        </header>
+        <div class="modal__body">
+            <div ng-hide="editProjectCtrl.resetTasksSuccess">
+                <p>
+                    {{ 'Are you sure you want to reset all tasks? You cannot undo this.' | translate }}
+                </p>
+                <p>
+                    {{ 'This will reset all tasks to ready to map (preserving existing history). Please use this only if you are sure of what you are doing.' | translate }}
+                </p>
+            </div>
+            <p ng-show="editProjectCtrl.resetTasksSuccess">
+                {{ 'The tasks were reset successfully.' | translate }}
+            </p>
+            <p ng-show="editProjectCtrl.resetTasksFail" class="error">
+                {{ 'Failed to reset all tasks for an unknown reason.' | translate }}
+            </p>
+        </div>
+        <footer class="modal__footer">
+            <div ng-hide="editProjectCtrl.resetTasksSuccess">
+                <button class="button button--achromic" type="button"
+                        ng-click="editProjectCtrl.showResetConfirmation(false)">{{ 'Cancel' | translate }}
+                </button>
+                <button class="button button--base" type="button"
+                        ng-click="editProjectCtrl.resetAllTasks()">{{ 'Reset all tasks' | translate }}
+                </button>
+                <span ng-show="editProjectCtrl.resetInProgress">{{ 'Resetting...' | translate }}</span>
+            </div>
+            <div ng-show="editProjectCtrl.resetTasksSuccess">
+                 <button class="button button--base" type="button"
+                        ng-click="editProjectCtrl.showResetConfirmation(false)">{{ 'Close message' | translate }}
+                </button>
+            </div>
+        </footer>
+    </div>
+    <button class="modal__button-dismiss" title="{{ 'Close' | translate }}" ng-click="editProjectCtrl.showResetConfirmation(false)">
+        {{ 'Dismiss' | translate }}
+    </button>
+</section>
+<!-- reset tasks confirmation modal -->
 
 <!-- message contributors modal -->
 <section class="modal modal-tm" ng-show="editProjectCtrl.showMessageContributorsModal">

--- a/client/app/services/project.service.js
+++ b/client/app/services/project.service.js
@@ -47,6 +47,7 @@
             mapAllTasks: mapAllTasks,
             invalidateAllTasks: invalidateAllTasks,
             validateAllTasks: validateAllTasks,
+            resetAllTasks: resetAllTasks,
             getCommentsForProject: getCommentsForProject,
             userCanMapProject: userCanMapProject,
             userCanValidateProject: userCanValidateProject,
@@ -533,6 +534,28 @@
             return $http({
                 method: 'POST',
                 url: configService.tmAPI + '/admin/project/' + projectId + '/validate-all',
+                headers: authService.getAuthenticatedHeader()
+            }).then(function successCallback(response) {
+                // this callback will be called asynchronously
+                // when the response is available
+                return response.data;
+            }, function errorCallback() {
+                // called asynchronously if an error occurs
+                // or server returns response with an error status.
+                return $q.reject("error");
+            });
+        }
+
+        /**
+         * Resets all tasks on the project
+         * @param projectId
+         * @returns {!jQuery.deferred|*|!jQuery.jqXHR|!jQuery.Promise}
+         */
+        function resetAllTasks(projectId) {
+            // Returns a promise
+            return $http({
+                method: 'POST',
+                url: configService.tmAPI + '/admin/project/' + projectId + '/reset-all',
                 headers: authService.getAuthenticatedHeader()
             }).then(function successCallback(response) {
                 // this callback will be called asynchronously

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -104,7 +104,7 @@ def init_flask_restful_routes(app):
         ResendEmailValidationAPI
     from server.api.messaging.project_chat_apis import ProjectChatAPI
     from server.api.project_admin_api import ProjectAdminAPI, ProjectCommentsAPI, ProjectInvalidateAll,\
-        ProjectValidateAll, ProjectMapAll, ProjectsForAdminAPI
+        ProjectValidateAll, ProjectMapAll, ProjectResetAll, ProjectsForAdminAPI
     from server.api.project_apis import ProjectAPI, ProjectAOIAPI, ProjectSearchAPI, HasUserTaskOnProject,\
         HasUserTaskOnProjectDetails, ProjectSearchBBoxAPI, ProjectSummaryAPI
     from server.api.swagger_docs_api import SwaggerDocsAPI
@@ -126,6 +126,7 @@ def init_flask_restful_routes(app):
     api.add_resource(ProjectInvalidateAll,          '/api/v1/admin/project/<int:project_id>/invalidate-all')
     api.add_resource(ProjectValidateAll,            '/api/v1/admin/project/<int:project_id>/validate-all')
     api.add_resource(ProjectMapAll,                 '/api/v1/admin/project/<int:project_id>/map-all')
+    api.add_resource(ProjectResetAll,               '/api/v1/admin/project/<int:project_id>/reset-all')
     api.add_resource(ProjectsMessageAll,            '/api/v1/admin/project/<int:project_id>/message-all')
     api.add_resource(ProjectsForAdminAPI,           '/api/v1/admin/my-projects')
     api.add_resource(LoginAPI,                      '/api/v1/auth/login')

--- a/server/api/project_admin_api.py
+++ b/server/api/project_admin_api.py
@@ -434,6 +434,47 @@ class ProjectValidateAll(Resource):
             current_app.logger.critical(error_msg)
             return {"error": error_msg}, 500
 
+class ProjectResetAll(Resource):
+
+    @tm.pm_only()
+    @token_auth.login_required
+    def post(self, project_id):
+        """
+        Reset all tasks on project back to ready, preserving history.
+        ---
+        tags:
+            - project-admin
+        produces:
+            - application/json
+        parameters:
+            - in: header
+              name: Authorization
+              description: Base64 encoded session token
+              required: true
+              type: string
+              default: Token sessionTokenHere==
+            - name: project_id
+              in: path
+              description: The unique project ID
+              required: true
+              type: integer
+              default: 1
+        responses:
+            200:
+                description: All tasks reset
+            401:
+                description: Unauthorized - Invalid credentials
+            500:
+                description: Internal Server Error
+        """
+        try:
+            ProjectAdminService.reset_all_tasks(project_id, tm.authenticated_user_id)
+            return {"Success": "All tasks reset"}, 200
+        except Exception as e:
+            error_msg = f'Project GET - unhandled error: {str(e)}'
+            current_app.logger.critical(error_msg)
+            return {"error": error_msg}, 500
+
 
 class ProjectMapAll(Resource):
 

--- a/server/models/postgis/task.py
+++ b/server/models/postgis/task.py
@@ -302,6 +302,17 @@ class Task(db.Model):
         self.locked_by = user_id
         self.update()
 
+    def reset_task(self, user_id: int):
+        if TaskStatus(self.task_status) in [TaskStatus.LOCKED_FOR_MAPPING, TaskStatus.LOCKED_FOR_VALIDATION]:
+            self.clear_task_lock()
+
+        self.set_task_history(TaskAction.STATE_CHANGE, user_id, None, TaskStatus.READY)
+        self.mapped_by = None
+        self.validated_by = None
+        self.locked_by = None
+        self.task_status = TaskStatus.READY.value
+        self.update()
+
     def clear_task_lock(self, lock_duration):
         """
         Unlocks task in scope in the database.  Clears the lock as though it never happened.

--- a/server/services/project_admin_service.py
+++ b/server/services/project_admin_service.py
@@ -6,7 +6,7 @@ from flask import current_app
 from server.models.dtos.project_dto import DraftProjectDTO, ProjectDTO, ProjectCommentsDTO
 from server.models.postgis.project import Project, Task, ProjectStatus
 from server.models.postgis.statuses import TaskCreationMode
-from server.models.postgis.task import TaskHistory
+from server.models.postgis.task import TaskHistory, TaskStatus, TaskAction
 from server.models.postgis.utils import NotFound, InvalidData, InvalidGeoJson
 from server.services.grid.grid_service import GridService
 from server.services.license_service import LicenseService
@@ -134,6 +134,21 @@ class ProjectAdminService:
             project.delete()
         else:
             raise ProjectAdminServiceError('Project has mapped tasks, cannot be deleted')
+
+    @staticmethod
+    def reset_all_tasks(project_id: int, user_id: int):
+        """ Resets all tasks on project, preserving history"""
+        tasks_to_reset = Task.query.filter(Task.project_id == project_id).all()
+
+        for task in tasks_to_reset:
+            task.set_task_history(TaskAction.COMMENT, user_id, "Task reset", TaskStatus.READY)
+            task.reset_task(user_id)
+
+        # Reset project counters
+        project = ProjectAdminService._get_project_by_id(project_id)
+        project.tasks_mapped = 0
+        project.tasks_validated = 0
+        project.save()
 
     @staticmethod
     def get_all_comments(project_id: int) -> ProjectCommentsDTO:

--- a/tests/server/unit/models/postgis/test_task.py
+++ b/tests/server/unit/models/postgis/test_task.py
@@ -2,6 +2,8 @@ import geojson
 import unittest
 from server import create_app
 from server.models.postgis.task import InvalidGeoJson, InvalidData, Task, TaskAction
+from server.models.postgis.statuses import TaskStatus
+from unittest.mock import patch, MagicMock
 
 
 class TestTask(unittest.TestCase):
@@ -12,6 +14,32 @@ class TestTask(unittest.TestCase):
 
     def tearDown(self):
         self.ctx.pop()
+
+    @patch.object(Task, 'update')
+    @patch.object(Task, 'set_task_history')
+    def test_reset_task_sets_to_ready_status(self, mock_set_task_history, mock_update):
+        user_id = 123
+
+        test_task = Task()
+        test_task.task_status = TaskStatus.MAPPED
+        test_task.reset_task(user_id)
+
+        mock_set_task_history.assert_called_with(TaskAction.STATE_CHANGE, user_id, None, TaskStatus.READY)
+        mock_update.assert_called()
+        self.assertEqual(test_task.task_status, TaskStatus.READY.value)
+
+    @patch.object(Task, 'update')
+    @patch.object(Task, 'clear_task_lock')
+    @patch.object(Task, 'set_task_history')
+    def test_reset_task_clears_any_existing_locks(self, mock_set_task_history, mock_clear_task_lock, mock_update):
+        user_id = 123
+
+        test_task = Task()
+        test_task.task_status = TaskStatus.LOCKED_FOR_MAPPING
+        test_task.reset_task(user_id)
+
+        mock_clear_task_lock.assert_called()
+        self.assertEqual(test_task.task_status, TaskStatus.READY.value)
 
     def test_cant_add_task_if_feature_geometry_is_invalid(self):
         # Arrange

--- a/tests/server/unit/services/test_project_admin_service.py
+++ b/tests/server/unit/services/test_project_admin_service.py
@@ -124,7 +124,7 @@ class TestProjectAdminService(unittest.TestCase):
             ProjectAdminService._validate_imagery_licence(1)
 
     @patch.object(ProjectAdminService, '_get_project_by_id')
-    @patch.object(Task, 'query')
+    @patch('flask_sqlalchemy._QueryProperty.__get__')
     @patch.object(Task, 'set_task_history')
     def test_reset_all_tasks(self, mock_set_task_history, mock_query, mock_get_project):
         user_id = 123
@@ -134,7 +134,7 @@ class TestProjectAdminService(unittest.TestCase):
         test_project.tasks_validated = 2
         test_tasks = [MagicMock(spec=Task), MagicMock(spec=Task), MagicMock(spec=Task)]
 
-        mock_query.filter().all.return_value = test_tasks
+        mock_query.return_value.filter.return_value.all.return_value = test_tasks
         mock_get_project.return_value = test_project
 
         ProjectAdminService.reset_all_tasks(test_project.id, user_id)

--- a/tests/server/unit/services/test_project_admin_service.py
+++ b/tests/server/unit/services/test_project_admin_service.py
@@ -4,9 +4,19 @@ from unittest.mock import MagicMock, patch
 from server.services.project_admin_service import ProjectAdminService, InvalidGeoJson, Project, \
     ProjectAdminServiceError, ProjectDTO, ProjectStatus, NotFound, LicenseService
 from server.models.dtos.project_dto import ProjectInfoDTO
+from server.models.postgis.task import Task
+from server import create_app
 
 
 class TestProjectAdminService(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app()
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+
+    def tearDown(self):
+        self.ctx.pop()
+
     def test_cant_add_tasks_if_geojson_not_feature_collection(self):
         # Arrange
         invalid_feature = '{"coordinates": [[[[-4.0237, 56.0904], [-3.9111, 56.1715], [-3.8122, 56.098],' \
@@ -112,3 +122,28 @@ class TestProjectAdminService(unittest.TestCase):
 
         with self.assertRaises(ProjectAdminServiceError):
             ProjectAdminService._validate_imagery_licence(1)
+
+    @patch.object(ProjectAdminService, '_get_project_by_id')
+    @patch.object(Task, 'query')
+    @patch.object(Task, 'set_task_history')
+    def test_reset_all_tasks(self, mock_set_task_history, mock_query, mock_get_project):
+        user_id = 123
+        test_project = MagicMock(spec=Project)
+        test_project.id = 456
+        test_project.tasks_mapped = 2
+        test_project.tasks_validated = 2
+        test_tasks = [MagicMock(spec=Task), MagicMock(spec=Task), MagicMock(spec=Task)]
+
+        mock_query.filter().all.return_value = test_tasks
+        mock_get_project.return_value = test_project
+
+        ProjectAdminService.reset_all_tasks(test_project.id, user_id)
+
+        for test_task in test_tasks:
+            test_task.set_task_history.assert_called()
+            test_task.reset_task.assert_called_with(user_id)
+
+        mock_get_project.assert_called_with(test_project.id)
+        self.assertEqual(test_project.tasks_mapped, 0)
+        self.assertEqual(test_project.tasks_validated, 0)
+        test_project.save.assert_called()


### PR DESCRIPTION
* Add API endpoint for resetting all tasks in a project back to ready status while preserving task history

* Add comment to each task indicating it was reset.

* Add action to Edit Project page for project managers to reset all tasks