### PR TITLE
Fixes #792 where validation and mapping counts incorrect on profile

### DIFF
--- a/server/models/dtos/user_dto.py
+++ b/server/models/dtos/user_dto.py
@@ -64,7 +64,6 @@ class MappedProject(Model):
     tasks_validated = IntType(serialized_name='tasksValidated')
     status = StringType()
     centroid = BaseType()
-    aoi = BaseType()
 
 
 class UserMappedProjectsDTO(Model):

--- a/server/models/postgis/user.py
+++ b/server/models/postgis/user.py
@@ -178,7 +178,7 @@ class User(db.Model):
                             AND t.mapped_by = {0}
                           GROUP BY t.project_id, t.mapped_by) m
                          ON v.project_id = m.project_id) c
-                   WHERE p.id = c.project_id'''.format(user_id)
+                   WHERE p.id = c.project_id ORDER BY p.id DESC'''.format(user_id)
 
         results = db.engine.execute(sql)
 

--- a/server/models/postgis/user.py
+++ b/server/models/postgis/user.py
@@ -159,8 +159,7 @@ class User(db.Model):
                         p.default_locale,
                         c.mapped,
                         c.validated,
-                        st_asgeojson(p.centroid),
-                        st_asgeojson(p.geometry)
+                        st_asgeojson(p.centroid)
                    FROM projects p,
                         (SELECT coalesce(v.project_id, m.project_id) project_id,
                                 coalesce(v.validated, 0) validated,
@@ -194,7 +193,6 @@ class User(db.Model):
             mapped_project.tasks_mapped = row[3]
             mapped_project.tasks_validated = row[4]
             mapped_project.centroid = geojson.loads(row[5])
-            mapped_project.aoi = geojson.loads(row[6])
 
             project_info = ProjectInfo.get_dto_for_locale(row[0], preferred_locale, row[2])
             mapped_project.name = project_info.name


### PR DESCRIPTION
Hi folks

Thought I'd try and help out for Hacktoberfest 😄 

This PR should fix issue #792 The original query was somewhat naive and expected at least 1 mapped contribution on each project.  So in cases were users were only validating these counts were missed.

The fixed query looks much more complex, but essentially we're just joining the results from all mapping contributions for a user and all validation contributions.

My local testing showed the query to be performant on large datasets, and fixes cases where I only validated tasks 

![image](https://user-images.githubusercontent.com/1523510/46319870-a3b32c80-c5d3-11e8-9d60-507cc3852500.png)
