### PR TITLE
Allow commenting on task without locking it

### DIFF
--- a/client/app/project/comment-box.html
+++ b/client/app/project/comment-box.html
@@ -1,0 +1,14 @@
+<div>
+    <textarea class="form__control space-bottom--none" type="text" mentio
+              rows="4"
+              maxlength="{{ projectCtrl.maxlengthComment }}"
+              placeholder="{{ 'Leave a comment' | translate }}"
+              mentio-typed-text="typedTerm"
+              mentio-search="projectCtrl.searchUser(term)"
+              mentio-select="projectCtrl.formatUserTag(item)"
+              mentio-items="projectCtrl.suggestedUsers"
+              mentio-template-url="/app/project/user-suggestions-menu.html"
+              ng-model="projectCtrl.comment"></textarea>
+    <p>{{ projectCtrl.maxlengthComment - projectCtrl.comment.length }}
+        {{ 'characters remaining' | translate }}</p>
+</div>

--- a/client/app/project/project.controller.js
+++ b/client/app/project/project.controller.js
@@ -38,6 +38,8 @@
         vm.taskUnLockErrorMessage = '';
         vm.taskSplitError = false;
         vm.taskSplitCode == null;
+        vm.taskCommentError = false;
+        vm.taskCommentErrorMessage = '';
         vm.wasAutoUnlocked = false;
 
         //authorization
@@ -191,6 +193,8 @@
             vm.taskSplitError = false;
             vm.taskSplitCode == null;
             vm.taskUndoError = false;
+            vm.taskCommentError = false;
+            vm.taskCommentErrorMessage = '';
             vm.wasAutoUnlocked = false;
         }
 
@@ -266,6 +270,23 @@
                 vm.selectInteraction.setActive(false);
                 vm.drawPolygonInteraction.setActive(true);
             }
+        };
+
+        /**
+         * Add stand-alone comment, adding it to task history.
+         */
+        vm.addStandaloneComment = function() {
+            var projectId = vm.projectData.projectId;
+            var taskId = vm.selectedTaskData.taskId;
+            var commentPromise = taskService.addTaskComment(projectId, taskId, vm.comment);
+            commentPromise.then(function (data) {
+                vm.comment = '';
+                vm.resetErrors();
+                setUpSelectedTask(data);
+            }, function (error) {
+                vm.taskCommentError = true;
+                vm.taskCommentErrorMessage = error.data.Error;
+            });
         };
 
         /**

--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -398,6 +398,24 @@
                                                 </div>
                                             </div>
                                         </div>
+                                        <div class="form__group--section">
+                                            <div ng-include="'/app/project/comment-box.html'"></div>
+                                            <ul class="list-type--none buttons--sidebyside">
+                                                <li>
+                                                    <button class="button"
+                                                            ng-click="projectCtrl.addStandaloneComment()">
+                                                        {{ 'Add Comment' | translate }}
+                                                     </button>
+                                                </li>
+                                            </ul>
+                                            <div ng-show="projectCtrl.taskCommentError">
+                                                <div>
+                                                    <div class="error" role="alert">
+                                                        <p>{{ 'There was a problem commenting on the task.' | translate }} {{ projectCtrl.taskCommentErrorMessage }}</p>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                                 <!-- task locked UI -->
@@ -449,21 +467,8 @@
                                         </div>
                                     </div>
                                     <div class="form__group form__group--section">
-                                        <div>
-                                            <h6>Done editing? Leave a comment and select one of the options below that matches your editing status</h6>
-                                            <textarea class="form__control space-bottom--none" type="text" mentio
-                                                      rows="4"
-                                                      maxlength="{{ projectCtrl.maxlengthComment }}"
-                                                      placeholder="{{ 'Leave a comment' | translate }}"
-                                                      mentio-typed-text="typedTerm"
-                                                      mentio-search="projectCtrl.searchUser(term)"
-                                                      mentio-select="projectCtrl.formatUserTag(item)"
-                                                      mentio-items="projectCtrl.suggestedUsers"
-                                                      mentio-template-url="/app/project/user-suggestions-menu.html"
-                                                      ng-model="projectCtrl.comment"></textarea>
-                                            <p>{{ projectCtrl.maxlengthComment - projectCtrl.comment.length }}
-                                                {{ 'characters remaining' | translate }}</p>
-                                        </div>
+                                        <h6>Done editing? Leave a comment and select one of the options below that matches your editing status</h6>
+                                        <div ng-include="'/app/project/comment-box.html'"></div>
                                         <ul class="list-type--none buttons--sidebyside">
                                             <li>
                                                 <button class="button"
@@ -742,6 +747,24 @@
                                             </div>
                                         </div>
                                     </div>
+                                    <div class="form__group--section">
+                                        <div ng-include="'/app/project/comment-box.html'"></div>
+                                        <ul class="list-type--none buttons--sidebyside">
+                                            <li>
+                                                <button class="button"
+                                                        ng-click="projectCtrl.addStandaloneComment()">
+                                                    {{ 'Add Comment' | translate }}
+                                                </button>
+                                            </li>
+                                        </ul>
+                                        <div ng-show="projectCtrl.taskCommentError">
+                                            <div>
+                                                <div class="error" role="alert">
+                                                    <p>{{ 'There was a problem commenting on the task.' | translate }} {{ projectCtrl.taskCommentErrorMessage }}</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
                                 <!-- task locked UI -->
                                 <div ng-show="projectCtrl.validatingStep === 'locked'"><!-- task mapping UI -->
@@ -793,18 +816,7 @@
                                     </div>
                                     <div class="form__group form__group--section">
                                         <h6>Done editing? Leave a comment and select one of the options below that matches your editing status</h6>
-                                         <textarea class="form__control space-bottom--none" type="text" mentio
-                                                   rows="4"
-                                                   maxlength="{{ projectCtrl.maxlengthComment }}"
-                                                   placeholder="{{ 'Leave a comment' | translate }}"
-                                                   mentio-typed-text="typedTerm"
-                                                   mentio-search="projectCtrl.searchUser(term)"
-                                                   mentio-select="projectCtrl.formatUserTag(item)"
-                                                   mentio-items="projectCtrl.suggestedUsers"
-                                                   mentio-template-url="/app/project/user-suggestions-menu.html"
-                                                   ng-model="projectCtrl.comment"></textarea>
-                                        <p>{{ projectCtrl.maxlengthComment - projectCtrl.comment.length }}
-                                            {{ 'characters remaining' | translate }}</p>
+                                        <div ng-include="'/app/project/comment-box.html'"></div>
                                         <ul class="list-type--none buttons--sidebyside">
                                             <li>
                                                 <button class="button"
@@ -885,19 +897,7 @@
                                     </div>
                                     <div class="form__group form__group--section">
                                         <h6>Done editing? Leave a comment and select one of the options below that matches your editing status</h6>
-                                         <textarea class="form__control space-bottom--none" type="text" mentio
-                                                   rows="4"
-                                                   maxlength="{{ projectCtrl.maxlengthComment }}"
-                                                   placeholder="{{ 'Leave a comment' | translate }}"
-                                                   mentio-typed-text="typedTerm"
-                                                   mentio-search="projectCtrl.searchUser(term)"
-                                                   mentio-select="projectCtrl.formatUserTag(item)"
-                                                   mentio-items="projectCtrl.suggestedUsers"
-                                                   mentio-template-url="/app/project/user-suggestions-menu.html"
-                                                   ng-model="projectCtrl.comment"></textarea>
-                                        <p>{{ projectCtrl.maxlengthComment - projectCtrl.comment.length }}
-                                            {{ 'characters remaining' | translate }}</p>
-
+                                        <div ng-include="'/app/project/comment-box.html'"></div>
                                         <ul class="list-type--none buttons--sidebyside">
                                             <li>
                                                 <button class="button"

--- a/client/app/services/task.service.js
+++ b/client/app/services/task.service.js
@@ -15,6 +15,7 @@
             unLockTaskMapping: unLockTaskMapping,
             stopMapping: stopMapping,
             lockTaskMapping: lockTaskMapping,
+            addTaskComment: addTaskComment,
             unLockTaskValidation: unLockTaskValidation,
             stopValidating: stopValidating,
             lockTasksValidation: lockTasksValidation,
@@ -131,6 +132,33 @@
             return $http({
                 method: 'POST',
                 url: configService.tmAPI + '/project/' + projectId + '/task/' + taskId + '/lock-for-mapping',
+                headers: authService.getAuthenticatedHeader()
+            }).then(function successCallback(response) {
+                // this callback will be called asynchronously
+                // when the response is available
+                return (response.data);
+            }, function errorCallback(error) {
+                // called asynchronously if an error occurs
+                // or server returns response with an error status.
+                return $q.reject(error);
+            });
+        }
+
+        /**
+         * Adds a comment to a task outside of a locked session
+         * @param projectId - id of the task project
+         * @param taskId - id of the task
+         * @param comment - the comment text
+         * @returns {!jQuery.jqXHR|!jQuery.Promise|*|!jQuery.deferred}
+         */
+        function addTaskComment(projectId, taskId, comment) {
+            // Returns a promise
+            return $http({
+                method: 'POST',
+                data: {
+                    comment: comment,
+                },
+                url: configService.tmAPI + '/project/' + projectId + '/task/' + taskId + '/comment',
                 headers: authService.getAuthenticatedHeader()
             }).then(function successCallback(response) {
                 // this callback will be called asynchronously

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -99,7 +99,7 @@ def init_flask_restful_routes(app):
     from server.api.health_check_api import HealthCheckAPI
     from server.api.license_apis import LicenseAPI, LicenceListAPI
     from server.api.mapping_apis import MappingTaskAPI, LockTaskForMappingAPI, UnlockTaskForMappingAPI, StopMappingAPI,\
-        TasksAsJson, TasksAsGPX, TasksAsOSM, UndoMappingAPI
+        CommentOnTaskAPI, TasksAsJson, TasksAsGPX, TasksAsOSM, UndoMappingAPI
     from server.api.messaging.message_apis import ProjectsMessageAll, HasNewMessages, GetAllMessages, MessagesAPI,\
         ResendEmailValidationAPI
     from server.api.messaging.project_chat_apis import ProjectChatAPI
@@ -157,6 +157,7 @@ def init_flask_restful_routes(app):
     api.add_resource(MappingTaskAPI,                '/api/v1/project/<int:project_id>/task/<int:task_id>')
     api.add_resource(UnlockTaskForMappingAPI,       '/api/v1/project/<int:project_id>/task/<int:task_id>/unlock-after-mapping')
     api.add_resource(StopMappingAPI,                '/api/v1/project/<int:project_id>/task/<int:task_id>/stop-mapping')
+    api.add_resource(CommentOnTaskAPI,              '/api/v1/project/<int:project_id>/task/<int:task_id>/comment')
     api.add_resource(LockTasksForValidationAPI,     '/api/v1/project/<int:project_id>/lock-for-validation')
     api.add_resource(UnlockTasksAfterValidationAPI, '/api/v1/project/<int:project_id>/unlock-after-validation')
     api.add_resource(StopValidatingAPI,             '/api/v1/project/<int:project_id>/stop-validating')

--- a/server/api/mapping_apis.py
+++ b/server/api/mapping_apis.py
@@ -5,7 +5,7 @@ from flask import send_file, Response
 from flask_restful import Resource, current_app, request
 from schematics.exceptions import DataError
 
-from server.models.dtos.mapping_dto import MappedTaskDTO, LockTaskDTO, StopMappingTaskDTO
+from server.models.dtos.mapping_dto import MappedTaskDTO, LockTaskDTO, StopMappingTaskDTO, TaskCommentDTO
 from server.services.mapping_service import MappingService, MappingServiceError, NotFound, UserLicenseError
 from server.services.project_service import ProjectService, ProjectServiceError
 from server.services.users.authentication_service import token_auth, tm, verify_token
@@ -325,6 +325,85 @@ class UnlockTaskForMappingAPI(Resource):
         finally:
             # Refresh mapper level after mapping
             UserService.check_and_update_mapper_level(tm.authenticated_user_id)
+
+class CommentOnTaskAPI(Resource):
+
+    @tm.pm_only(False)
+    @token_auth.login_required
+    def post(self, project_id, task_id):
+        """
+        Adds a comment to the task outside of mapping/validation
+        ---
+        tags:
+            - mapping
+        produces:
+            - application/json
+        parameters:
+            - in: header
+              name: Authorization
+              description: Base64 encoded session token
+              required: true
+              type: string
+              default: Token sessionTokenHere==
+            - name: project_id
+              in: path
+              description: The ID of the project the task is associated with
+              required: true
+              type: integer
+              default: 1
+            - name: task_id
+              in: path
+              description: The unique task ID
+              required: true
+              type: integer
+              default: 1
+            - in: body
+              name: body
+              required: true
+              description: JSON object representing the comment
+              schema:
+                  id: TaskComment
+                  required:
+                      - comment
+                  properties:
+                      comment:
+                          type: string
+                          description: user comment about the task
+        responses:
+            200:
+                description: Comment added
+            400:
+                description: Client Error
+            401:
+                description: Unauthorized - Invalid credentials
+            403:
+                description: Forbidden
+            404:
+                description: Task not found
+            500:
+                description: Internal Server Error
+        """
+        try:
+            task_comment = TaskCommentDTO(request.get_json())
+            task_comment.user_id = tm.authenticated_user_id
+            task_comment.task_id = task_id
+            task_comment.project_id = project_id
+            task_comment.validate()
+        except DataError as e:
+            current_app.logger.error(f'Error validating request: {str(e)}')
+            return str(e), 400
+
+        try:
+            task = MappingService.add_task_comment(task_comment)
+            return task.to_primitive(), 200
+        except NotFound:
+            return {"Error": "Task Not Found"}, 404
+        except MappingServiceError as e:
+            return {"Error": str(e)}, 403
+        except Exception as e:
+            error_msg = f'Task Comment API - unhandled error: {str(e)}'
+            current_app.logger.critical(error_msg)
+            return {"Error": error_msg}, 500
 
 
 class TasksAsJson(Resource):

--- a/server/models/dtos/mapping_dto.py
+++ b/server/models/dtos/mapping_dto.py
@@ -67,3 +67,11 @@ class TaskDTO(Model):
 class TaskDTOs(Model):
     """ Describes an array of Task DTOs"""
     tasks = ListType(ModelType(TaskDTO))
+
+class TaskCommentDTO(Model):
+    """ Describes the model used to add a standalone comment to a task outside of mapping/validation """
+    user_id = IntType(required=True)
+    comment = StringType(required=True)
+    task_id = IntType(required=True)
+    project_id = IntType(required=True)
+    preferred_locale = StringType(default='en')


### PR DESCRIPTION
* Add a comment box to tasks that is always present and can be used to comment on a task without first locking it for mapping or validation

* Extract comment box markup into a comment-box.html template to reduce duplication of markup

* Add new server API endpoint for adding a stand-alone comment to a task

<img width="625" alt="standalone_comment" src="https://user-images.githubusercontent.com/445970/46513009-74870000-c80b-11e8-82f5-bf082555b066.png">
