### PR TITLE
Enhance readability of task history

### DIFF
--- a/client/app/components/project-chat/project-chat.html
+++ b/client/app/components/project-chat/project-chat.html
@@ -5,7 +5,7 @@
                 <strong>
                     <a href="./user/{{ message.username }}" target="_blank"/>{{ message.username }}</a>
                 </strong> <span class="metadata" am-time-ago="message.timestamp | amUtc | amLocal"></span></p>
-            <p ng-bind-html="message.message"></p>
+            <p markdown-to-html="message.message"></p>
         </div>
         <div ng-show="projectChatCtrl.messages.length < 1">
             {{ 'No project discussion yet' | translate }}

--- a/client/app/project/project-dashboard.html
+++ b/client/app/project/project-dashboard.html
@@ -21,33 +21,39 @@
                     <div class="dashboard-container">
                         <div class="left">
                             <h2>{{ 'Last activity' | translate }}</h2>
-                            <p ng-show="!projectDashboardCtrl.projectActivity.length > 0">{{ 'No activity (yet).' | translate }}</p>
-                            <div ng-show="projectDashboardCtrl.projectActivity.length > 0">
-                                <div class="content">
-                                    <div ng-repeat="item in projectDashboardCtrl.projectActivity">
-                                        <span ng-show="item.action === 'LOCKED_FOR_MAPPING'">{{ 'Task locked for mapping by' | translate }} <a
-                                                href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                        <span ng-show="item.action === 'LOCKED_FOR_VALIDATION'">{{ 'Task locked for validation by' | translate }} <a
-                                                href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                        <span ng-show="item.action === 'AUTO_UNLOCKED_FOR_MAPPING'">{{ 'Task automatically unlocked for mapping by' | translate }} <a
-                                                href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                        <span ng-show="item.action === 'AUTO_UNLOCKED_FOR_VALIDATION'">{{ 'Task automatically unlocked for validation by' | translate }} <a
-                                                href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                        <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'BADIMAGERY'">{{ 'Task marked as bad imagery by' | translate }} <a
-                                                href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                        <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'MAPPED'">{{ 'Task mapped by' | translate }} <a
-                                                href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                        <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'VALIDATED'">{{ 'Task validated by' | translate }} <a
-                                                href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                        <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'INVALIDATED'">{{ 'Task invalidated by' | translate }} <a
-                                                href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                        <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'READY'">{{ 'Task marked as ready by' | translate }} <a
-                                                href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                        <p>
-                                            <em am-time-ago="item.actionDate | amUtc | amLocal"></em>
-                                        </p>
-                                    </div>
-                                </div>
+                            <div class="content">
+                                <p ng-show="!projectDashboardCtrl.projectActivity.length > 0">{{ 'No activity (yet).' | translate }}</p>
+                                <table ng-show="projectDashboardCtrl.projectActivity.length > 0" class="table table-dashboard-project-activity">
+                                    <thead>
+                                        <tr>
+                                            <th>{{ 'Action' | translate }}</th>
+                                            <th>{{ 'User' | translate }}</th>
+                                            <th>{{ 'When' | translate }}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr ng-repeat="item in projectDashboardCtrl.projectActivity">
+                                            <td>
+                                                <span class="status-marker-locked-for-mapping" ng-show="item.action === 'LOCKED_FOR_MAPPING'">{{ 'Task locked for mapping' | translate }}</span>
+                                                <span class="status-marker-locked-for-validation" ng-show="item.action === 'LOCKED_FOR_VALIDATION'">{{ 'Task locked for validation' | translate }}</span>
+                                                <span class="status-marker-auto-unlocked-for-mapping" ng-show="item.action === 'AUTO_UNLOCKED_FOR_MAPPING'">{{ 'Task automatically unlocked for mapping' | translate }}</span>
+                                                <span class="status-marker-auto-unlocked-for-validation" ng-show="item.action === 'AUTO_UNLOCKED_FOR_VALIDATION'">{{ 'Task automatically unlocked for validation' | translate }}</span>
+                                                <span class="status-marker-badimagery" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'BADIMAGERY'">{{ 'Task marked as bad imagery' | translate }}</span>
+                                                <span class="status-marker-mapped" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'MAPPED'">{{ 'Task mapped' | translate }}</span>
+                                                <span class="status-marker-validated" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'VALIDATED'">{{ 'Task validated' | translate }}</span>
+                                                <span class="status-marker-invalidated" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'INVALIDATED'">{{ 'Task invalidated' | translate }}</span>
+                                                <span class="status-marker-split" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'SPLIT'">{{ 'Task split' | translate }}</span>
+                                                <span class="status-marker-ready" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'READY'">{{ 'Task marked as ready' | translate }}</span>
+                                            </td>
+                                            <td>
+                                                <a href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a>
+                                            </td>
+                                            <td>
+                                                <span am-time-ago="item.actionDate | amUtc | amLocal"></span>
+                                            </td>
+                                        </tr>
+                                  </tbody>
+                                </table>
                                 <button class="button button--achromic"
                                     ng-class="!projectDashboardCtrl.projectActivityPagination.hasPrev ? 'disabled' : ''"
                                     ng-click="projectDashboardCtrl.getLastActivity(projectDashboardCtrl.projectActivityPagination.prevNum)">

--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -946,44 +946,41 @@
                                 <h5>{{ 'History' | translate }}</h5>
                                 <div class="history">
                                     <p ng-show="projectCtrl.selectedTaskData.taskHistory.length < 1">{{ 'Nothing has happened yet.' | translate }}</p>
-                                    <div ng-repeat="item in projectCtrl.selectedTaskData.taskHistory | orderBy: '-actionDate' track by $index"
-                                         ng-class-odd="'odd'" ng-class-even="'even'">
-                                        <div>
-                                            <span ng-show="item.action === 'COMMENT'">{{ 'Comment left by' | translate }} <a
-                                                    href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                            <span ng-show="item.action === 'LOCKED_FOR_MAPPING'">{{ 'Locked for mapping by' | translate }} <a
-                                                    href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                            <span ng-show="item.action === 'LOCKED_FOR_VALIDATION'">{{ 'Locked for validation by' | translate }} <a
-                                                    href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                            <span ng-show="item.action === 'AUTO_UNLOCKED_FOR_MAPPING'">{{ 'Automatically unlocked for mapping by' | translate }} <a
-                                                    href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                            <span ng-show="item.action === 'AUTO_UNLOCKED_FOR_VALIDATION'">{{ 'Automatically unlocked for validation by' | translate }} <a
-                                                    href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                            <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'BADIMAGERY'">{{ 'Marked as bad imagery by' | translate }} <a
-                                                    href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                            <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'MAPPED'">{{ 'Mapped by' | translate }} <a
-                                                    href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                            <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'VALIDATED'">{{ 'Validated by' | translate }} <a
-                                                    href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                            <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'INVALIDATED'">{{ 'Invalidated by' | translate }} <a
-                                                    href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                            <span ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'READY'">{{ 'Marked as ready by' | translate }} <a
-                                                    href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a></span>
-                                        </div>
-                                        <div>
-                                            <span ng-bind-html="item.actionText" ng-show="item.action === 'COMMENT'"></span>
-                                        </div>
-                                        <div class="metadata">
-                                            <span am-time-ago="item.actionDate | amUtc | amLocal"></span>
-                                            <span ng-show="item.action === 'LOCKED_FOR_MAPPING' && item.actionText"> for {{ item.actionText |  amDurationFormat : 'minute'}} </span>
-                                            <span ng-show="item.action === 'LOCKED_FOR_VALIDATION' && item.actionText"> for {{ item.actionText |  amDurationFormat : 'minute'}} </span>
-                                            <span ng-show="item.action === 'AUTO_UNLOCKED_FOR_MAPPING' && item.actionText"> after {{ item.actionText |  amDurationFormat : 'minute'}}</span>
-                                            <span ng-show="item.action === 'AUTO_UNLOCKED_FOR_VALIDATION' && item.actionText"> after {{ item.actionText |  amDurationFormat : 'minute'}}</span>
-                                        </div>
-                                    </div>
+                                    <table ng-show="projectCtrl.selectedTaskData.taskHistory.length >= 1" class="table table-task-history">
+                                        <tbody ng-repeat="item in (orderedData = (projectCtrl.selectedTaskData.taskHistory | orderBy: '-actionDate')) track by $index">
+                                          <tr ng-show="item.actionBy !== orderedData[$index - 1].actionBy"
+                                              class="new-user-row">
+                                              <td colspan="2">
+                                                  <a href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a>
+                                              </td>
+                                          </tr>
+                                          <tr class="action-row {{ item.action | lowercase }} {{ projectCtrl.highlightHistory && projectCtrl.highlightHistory === item.historyId ? 'highlighted' : '' }}">
+                                              <td class="action">
+                                                  <span class="status-marker-comment" ng-show="item.action === 'COMMENT'">{{ 'Commented' | translate }}</span>
+                                                  <span class="status-marker-locked-for-mapping" ng-show="item.action === 'LOCKED_FOR_MAPPING'">{{ 'Locked for mapping' | translate }}</span>
+                                                  <span class="status-marker-locked-for-validation" ng-show="item.action === 'LOCKED_FOR_VALIDATION'">{{ 'Locked for validation' | translate }}</span>
+                                                  <span class="status-marker-auto-unlocked-for-mapping" ng-show="item.action === 'AUTO_UNLOCKED_FOR_MAPPING'">{{ 'Automatically unlocked for mapping' | translate }}</span>
+                                                  <span class="status-marker-auto-unlocked-for-validation" ng-show="item.action === 'AUTO_UNLOCKED_FOR_VALIDATION'">{{ 'Automatically unlocked for validation' | translate }}</span>
+                                                  <span class="status-marker-badimagery" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'BADIMAGERY'">{{ 'Marked as bad imagery' | translate }}</span>
+                                                  <span class="status-marker-mapped" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'MAPPED'">{{ 'Mapped' | translate }}</span>
+                                                  <span class="status-marker-validated" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'VALIDATED'">{{ 'Validated' | translate }}</span>
+                                                  <span class="status-marker-invalidated" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'INVALIDATED'">{{ 'Invalidated' | translate }}</span>
+                                                  <span class="status-marker-split" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'SPLIT'">{{ 'Split' | translate }}</span>
+                                                  <span class="status-marker-ready" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'READY'">{{ 'Marked as ready' | translate }}</span>
+                                              </td>
+                                              <td>
+                                                  <span am-time-ago="item.actionDate | amUtc | amLocal"></span>
+                                              </td>
+                                          </tr>
+                                          <tr ng-show="item.action === 'COMMENT'">
+                                            <td colspan="2" class="comment-text">
+                                              <span markdown-to-html="item.actionText"></span>
+                                            </td>
+                                          </tr>
+                                      </tbody>
+                                    </table>
                                 </div>
                             </div>
-                            <hr/>
                             <div>
                                 <h5 ng-click="showAdvanced=!showAdvanced" class="pointer"
                                     title="{{ 'Show advanced options' | translate }}">

--- a/client/assets/styles/sass/_status.scss
+++ b/client/assets/styles/sass/_status.scss
@@ -1,0 +1,72 @@
+/* Status Colors */
+$status-color-ready: rgba(223, 223, 223, 0.1);               // very light grey, 0.1 opacity
+$status-color-invalidated: rgba(233, 11, 67, 0.4);           // red, 0.4 opacity
+$status-color-mapped: rgba(255, 198, 12, 0.4);               // orange, 0.4 opacity
+$status-color-validated: rgba(0, 128, 0, 0.4);               // green, 0.4 opacity
+$status-color-locked-for-mapping: rgba(18, 89, 240, 0.4);    // blue, 0.4 opacity
+$status-color-locked-for-validation: rgba(18, 89, 240, 0.4); // blue, 0.4 opacity
+$status-color-badimagery: rgba(0, 0, 0, 0.4);                // black, 0.4 opacity
+
+$status-marker-border-color: rgba(84, 84, 84, 0.7);          // medium grey, 0.7 opacity
+
+@mixin status-marker($color) {
+  &:before {
+    content: ' ';
+    display: inline-block;
+    background-color: $color;
+    margin-right: 0.75em;
+    width: 1em;
+    height: 1em;
+    box-shadow: 0px 0px 0px 0.5px $status-marker-border-color;
+  }
+}
+
+@mixin status-marker-icon($fa-hex-value) {
+  &:before {
+    font-family: FontAwesome;
+    content: $fa-hex-value;
+    display: inline-block;
+    margin-right: 0.75em;
+    width: 1em;
+  }
+}
+
+.status-marker-ready {
+  @include status-marker($status-color-ready);
+}
+
+.status-marker-invalidated {
+  @include status-marker($status-color-invalidated);
+}
+
+.status-marker-mapped {
+  @include status-marker($status-color-mapped);
+}
+
+.status-marker-validated {
+  @include status-marker($status-color-validated);
+}
+
+.status-marker-locked-for-mapping {
+  @include status-marker($status-color-locked-for-mapping);
+}
+
+.status-marker-locked-for-validation {
+  @include status-marker($status-color-locked-for-validation);
+}
+
+.status-marker-badimagery {
+  @include status-marker($status-color-badimagery);
+}
+
+.status-marker-comment {
+  @include status-marker-icon('\f0e5');
+}
+
+.status-marker-auto-unlocked-for-mapping, .status-marker-auto-unlocked-for-validation {
+  @include status-marker-icon('\f017');
+}
+
+.status-marker-split {
+  @include status-marker-icon('\f009');
+}

--- a/client/assets/styles/sass/_tables.scss
+++ b/client/assets/styles/sass/_tables.scss
@@ -15,6 +15,26 @@
     box-shadow: inset 0 -1px 0 0 $base-alpha-color;
   }
 
+  tr.new-user-row {
+    border-top: 1px solid;
+
+    td {
+      box-shadow: none;
+      padding-left: 0;
+    }
+  }
+
+  tr.action-row.comment {
+    td {
+      box-shadow: none;
+      padding-bottom: 0.5em;
+    }
+  }
+
+  td.comment-text {
+    word-break: break-word;
+  }
+
   th:first-child,
   td:first-child {
     padding-left: 1rem;

--- a/client/assets/styles/sass/taskingmanager.scss
+++ b/client/assets/styles/sass/taskingmanager.scss
@@ -39,3 +39,4 @@
 @import "profile";
 @import "structure";
 @import "users";
+@import "status";


### PR DESCRIPTION
* Change display of task history to a table structure, grouping together consecutive history entries from the same user with visual dividers between groups

* Show icons or color-coded status markers on entries based on status to make the history easier to scan

* Use table structure for Last Activity section of project Activity and Stats page, including color-coded status markers for entries

* Support rendering of Markdown in comments
<img width="1267" alt="new_history_layout" src="https://user-images.githubusercontent.com/445970/46566453-95b32380-c8d3-11e8-85ef-fcd154f3938c.png">
