### PR TITLE
Create new common css entry for markdown-to-html

### DIFF
--- a/client/assets/styles/sass/_base.scss
+++ b/client/assets/styles/sass/_base.scss
@@ -428,3 +428,12 @@ table {
   display: block;
   margin-top: .5em;
 }
+
+
+/* Markdown-to-html (Showdown) common stylings
+   ========================================================================== */
+p[markdown-to-html] {
+    code {
+        color: $red;
+    }
+}


### PR DESCRIPTION
Rather than having to change the colors of all sections,
have it only aimed for markdown-to-html directive.

So this would also allow it not to override other elements with
the same structure or classes.

This initial addition will set code to red.

Resolves #693