### PR TITLE
Specify parent for ol-viewport style so overview map is not stretched. Fixes #699

### DIFF
--- a/client/assets/styles/sass/_map.scss
+++ b/client/assets/styles/sass/_map.scss
@@ -151,6 +151,6 @@
     height: 1.5em;
 }
 
-.ol-viewport {
+.map-container > .ol-viewport {
   min-height: 700px;
 }


### PR DESCRIPTION
Fixes #699 

As map (class .map-container) and overview map (class .ol-overviewmap-map) both contain .ol-viewport it needs to be specified that only for map it should have min-height: 700px