### PR TITLE
Prevent map from being elongated. Fixes #843

### DIFF
--- a/client/assets/styles/sass/_map.scss
+++ b/client/assets/styles/sass/_map.scss
@@ -153,4 +153,5 @@
 
 .ol-viewport {
   min-height: 700px;
+  max-height: 700px;
 }


### PR DESCRIPTION
Fixes #843

Restrict max height of map.
If in some situation map must be larger, please let me know and I will try to find better solution.