### PR TITLE
Added support for importing osm files

### DIFF
--- a/client/app/admin/create-project/create-project.controller.js
+++ b/client/app/admin/create-project/create-project.controller.js
@@ -346,6 +346,12 @@
                             setUploadedFeatures(uploadedFeatures);
                         });
                     }
+                    else if (file.name.substr(-3).toLowerCase() === 'osm') {
+                        // Use the osmtogeojson.js library to read the osm (with GeoJSON as output)
+                        var xml = (new DOMParser()).parseFromString(data, 'text/xml')
+                        uploadedFeatures = geospatialService.getFeaturesFromGeoJSON(osmtogeojson(xml, {flatProperties: true}));
+                        setUploadedFeatures(uploadedFeatures);
+                    }
                 };
                 if (file.name.substr(-4).toLowerCase() === 'json') {
                     fileReader.readAsText(file);
@@ -355,6 +361,9 @@
                 }
                 else if (file.name.substr(-3).toLowerCase() === 'zip') {
                     fileReader.readAsArrayBuffer(file);
+                }
+                else if (file.name.substr(-3).toLowerCase() === 'osm') {
+                    fileReader.readAsText(file);
                 }
                 else {
                     vm.isImportError = true;

--- a/client/app/admin/create-project/create-project.html
+++ b/client/app/admin/create-project/create-project.html
@@ -39,7 +39,7 @@
                             <dl>
                                 <dt>Option 1:</dt>
                                 <dd>
-                                    <p>Draw the Area of Interest on the map.</p>
+                                    <p>{{ 'Draw the Area of Interest on the map.' | translate }}</p>
                                     <button class="button button--achromic" type="button"
                                             ng-click="createProjectCtrl.drawAOI()"><span>{{ 'Draw' | translate }}</span>
                                     </button>
@@ -59,7 +59,7 @@
                             <dl>
                                 <dt>Option 2:</dt>
                                 <dd>
-                                    <p>{{ 'Import a GeoJSON, KML, or zipped SHP file.' | translate }}</p>
+                                    <p>{{ 'Import a GeoJSON, KML, OSM or zipped SHP file.' | translate }}</p>
                                     <button class="button button--achromic"
                                          ngf-select="createProjectCtrl.import($file)">{{ 'Import' | translate }}
                                     </button>
@@ -71,7 +71,6 @@
                                     <strong>{{ 'Error' | translate }}:</strong> {{ 'Please provide a valid GeoJSON, KML or zipped Shapefile.' | translate }}
                                 </p>
                             </div>
-
                             <div ng-show="createProjectCtrl.nonPolygonError"
                                  class="alert alert--danger" role="alert">
                                 <p>
@@ -84,18 +83,6 @@
                                     <strong>{{ 'Error' | translate }}:</strong> {{ 'The AOI contains self intersections' | translate }}
                                 </p>
                             </div>
-
-                        </div>
-                        <div class="form__group form__group--section--sm">
-                            <dl>
-                                <dt>Option 3:</dt>
-                                <dd>
-                                    <p>{{ 'Want to use an .osm file instead? You can use' | translate }} <a
-                                            href="http://geojson.io"
-                                            target="_blank" rel="noopener">GeoJSON.io</a>
-                                        {{ 'to convert it to GeoJSON.' | translate }}</p>
-                                </dd>
-                            </dl>
                         </div>
                     </form>
                     <div class="navigation-steps">

--- a/client/index.html
+++ b/client/index.html
@@ -213,6 +213,10 @@
 <script src="node_modules/angular-socialshare/dist/angular-socialshare.js"></script>
 <!-- /build -->
 
+<!-- build:js https://cdn.jsdelivr.net/npm/osmtogeojson@2.2.12/osmtogeojson.js -->
+<script src="node_modules/osmtogeojson/osmtogeojson.js"></script>
+<!-- /build -->
+
 <!-- build:js app/taskingmanager.min.js -->
 <script src="app/taskingmanager.config.js"></script>
 <script src="app/taskingmanager.app.js"></script>

--- a/client/package.json
+++ b/client/package.json
@@ -51,6 +51,7 @@
     "ol3-geocoder": "^2.5.0",
     "ol3-layerswitcher": "^1.1.0",
     "openlayers": "^4.0.1",
+    "osmtogeojson": "^2.2.12",
     "phantomjs-prebuilt": "^2.1.14",
     "react": "^15.4.2",
     "react-addons-css-transition-group": "^15.4.2",


### PR DESCRIPTION
Related to #1224 

Using https://github.com/tyrasd/osmtogeojson for converting osm to geojson

Translations for 'Import a GeoJSON, KML, or zipped SHP file.' were not changed. It can be done separately, if this solution is accepted.