### PR TITLE
Update flask version to 0.12.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cachetools==2.0.0
 click==6.7
 coverage==4.3.4
 flake8==3.3.0
-Flask==0.12.2
+Flask==0.12.3
 Flask-Cors==3.0.2
 Flask-HTTPAuth==3.2.3
 Flask-Migrate==2.0.4


### PR DESCRIPTION
There is a security vulnerability in Flask versions < 0.12.3: https://nvd.nist.gov/vuln/detail/CVE-2018-1000656

Since it is a minor version change, hopefully nothing breaks, but let's check all the same. 