### PR TITLE
Update Flask to 0.12.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cachetools==2.0.0
 click==6.7
 coverage==4.3.4
 flake8==3.3.0
-Flask==0.12.3
+Flask==0.12.4
 Flask-Cors==3.0.2
 Flask-HTTPAuth==3.2.3
 Flask-Migrate==2.0.4


### PR DESCRIPTION
Okay, apparently pip install failed when I updated and I didn't look closely enough. Adding that to my review checklist.

After 0.12.3 was correctly updated on my local machine, I confirmed that the same CircleCI error came up. Upgrading to 0.12.4 then fixed it. Sorry about that @dakotabenjamin !