### PR TITLE
Support node, way, relation, viewport short codes

### DIFF
--- a/client/app/components/project-chat/project-chat.directive.js
+++ b/client/app/components/project-chat/project-chat.directive.js
@@ -90,7 +90,7 @@
             resultsPromise.then(function (data) {
                 vm.messages = data.chat;
                 for (var i = 0; i < vm.messages.length; i++) {
-                    vm.messages[i].message = messageService.formatUserNamesToLink(vm.messages[i].message);
+                    vm.messages[i].message = messageService.formatShortCodes(vm.messages[i].message);
                 }
                 // set the location.hash to the id of the element to scroll to
                 $timeout(function () {
@@ -150,7 +150,7 @@
             resultsPromise.then(function (data) {
                 vm.messages = data.chat;
                 for (var i = 0; i < vm.messages.length; i++) {
-                    vm.messages[i].message = messageService.formatUserNamesToLink(vm.messages[i].message);
+                    vm.messages[i].message = messageService.formatShortCodes(vm.messages[i].message);
                 }
                 // set the location.hash to the id of the element to scroll to
                 $timeout(function () {

--- a/client/app/message/message.controller.js
+++ b/client/app/message/message.controller.js
@@ -28,7 +28,7 @@
             resultsPromise.then(function (data) {
                 // success
                 vm.message = data;
-                vm.message.message = messageService.formatUserNamesToLink(vm.message.message);
+                vm.message.message = messageService.formatShortCodes(vm.message.message);
             }, function () {
                 // an error occurred
             });

--- a/client/app/project/comment-box.html
+++ b/client/app/project/comment-box.html
@@ -11,4 +11,11 @@
               ng-model="projectCtrl.comment"></textarea>
     <p>{{ projectCtrl.maxlengthComment - projectCtrl.comment.length }}
         {{ 'characters remaining' | translate }}</p>
+    <p><strong>{{ 'Tip' | translate }}:</strong> {{ 'You can use Markdown. (HTML is not allowed)' | translate }}</p>
+    <button class="button button--secondary button--small"
+            ng-click="projectCtrl.showPreviewComment = !projectCtrl.showPreviewComment">
+        {{ 'Preview' | translate }}
+    </button>
+    <p class="textblock--fulltext" ng-show="projectCtrl.showPreviewComment"
+       markdown-to-html="projectCtrl.formattedComment(projectCtrl.comment)"></p>
 </div>

--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -982,7 +982,7 @@
                                           </tr>
                                           <tr ng-show="item.action === 'COMMENT'">
                                             <td colspan="2" class="comment-text">
-                                              <span markdown-to-html="item.actionText"></span>
+                                              <span markdown-to-html="item.actionText" ng-click="projectCtrl.onShortCodeClick($event)"></span>
                                             </td>
                                           </tr>
                                       </tbody>
@@ -1144,4 +1144,34 @@
         {{ 'Dismiss' | translate }}
     </button>
 </section>
-<!-- accept license modal -->
+
+<!-- JOSM editor failed modal -->
+<section class="modal modal-tm" ng-show="projectCtrl.editorStartError === 'josm-error'">
+    <div class="modal__inner">
+        <header class="modal__header">
+            <div class="modal__headline">
+                <h3 class="modal__title">{{ 'Contact with JOSM Failed' | translate }}</h3>
+            </div>
+        </header>
+        <div class="modal__body">
+            <div>
+                <p>
+                    {{ 'JOSM remote control did not respond. Do you have JOSM running and configured to be controlled remotely?' | translate }}
+                </p>
+            </div>
+        </div>
+        <footer class="modal__footer">
+            <div>
+                <button class="button" type="button"
+                        ng-click="projectCtrl.editorStartError = ''">{{ 'Dismiss' | translate }}
+                </button>
+                <button class="button button--secondary" type="button"
+                        ng-click="projectCtrl.resetSelectedEditor()">{{ "Stop using JOSM" | translate }}
+                </button>
+            </div>
+        </footer>
+    </div>
+    <a class="modal__button-dismiss" title="{{ 'Close' | translate }}" ng-click="projectCtrl.editorStartError = ''">
+        {{ 'Dismiss' | translate }}
+    </a>
+</section>

--- a/client/index.html
+++ b/client/index.html
@@ -177,6 +177,10 @@
 <script src="node_modules/ng-showdown/dist/ng-showdown.js"></script>
 <!-- /build -->
 
+<!-- build:js https://cdn.jsdelivr.net/npm/@mapbox/geo-viewport@0.4.0/geo-viewport.js -->
+<script src="node_modules/@mapbox/geo-viewport/geo-viewport.js"></script>
+<!-- /build -->
+
 <!-- build:js https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.0/moment.min.js-->
 <script src="node_modules/moment/moment.js"></script>
 <!-- /build -->

--- a/client/package.json
+++ b/client/package.json
@@ -51,6 +51,7 @@
     "ol3-geocoder": "^2.5.0",
     "ol3-layerswitcher": "^1.1.0",
     "openlayers": "^4.0.1",
+    "@mapbox/geo-viewport": "^0.4.0",
     "phantomjs-prebuilt": "^2.1.14",
     "react": "^15.4.2",
     "react-addons-css-transition-group": "^15.4.2",

--- a/server/services/messaging/message_service.py
+++ b/server/services/messaging/message_service.py
@@ -110,7 +110,6 @@ class MessageService:
             try:
                 user = UserService.get_user_by_username(username)
             except NotFound:
-                current_app.logger.error(f'Username {username} not found')
                 continue  # If we can't find the user, keep going no need to fail
 
             message = Message()


### PR DESCRIPTION
* Add support in task comments for short-codes that generate links to
nodes, ways, relations, and OSM viewports

* Open linked entities from short codes in JOSM if user has chosen it
for their active editor, or in a new Overpass Turbo or OpenStreetMap tab
if not

* Offer user option to preview comment being authored, including markdown and
short-code links

* Display modal error if user has chosen JOSM as their editor but communication
with JOSM fails, and offer user option to stop using JOSM as their chosen
editor

* Supported short codes:
  - `[n/123]` or `[node/123]` for nodes
  - `[w/123]` or `[way/123]` for ways
  - `[r/123]` or `[rel/123]` or `[relation/123]` for relations
  - `[v/14/42.3824/12.2633]` or
    `[view/14/42.3824/12.2633]` or
    `[viewport/14/42.3824/12.2633]` for OSM viewports

> Note: for convenience, the full openstreetmap.org URL of simple OSM viewports
may be used in place of zoom/lat/lon in viewport short codes, e.g.
`[v/https://www.openstreetmap.org/#map=14/42.3824/12.2633]`

* Node, way, and relation short-codes may be combined into a combo code,
such as `[n/123, w/456]`, that generates a single link that loads all
entities together. Individual codes in a combo may be comma or space
separated. Viewport short-codes are not supported in combos

* Fix some minor eslint issues, such as missing semicolons