### PR TITLE
Include HOT Code of Conduct file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,82 @@
+(The latest version can be found at https://www.hotosm.org/code-of-conduct)
+
+Welcome to Humanitarian OpenStreetMap Team. HOT is committed to providing a welcoming and safe environment for people of all races, gender identities, gender expressions, sexual orientations, physical abilities, physical appearances, socio-economic backgrounds, nationalities, ages, religions, and beliefs.
+
+The HOT community principles are:
+
+**Be friendly and patient.** Be generous and kind in both giving and accepting critique. Critique is a natural and important part of our culture. Good critiques are kind, respectful, clear, and constructive, focused on goals and requirements rather than personal preferences. You are expected to give and receive criticism with grace. Be considerate in speech and actions, and actively seek to acknowledge and respect the boundaries of fellow attendees.
+
+**Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. Some examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language.
+
+- Being respectful of differing viewpoints and experiences.
+
+- Gracefully accepting constructive criticism.
+
+- Showing empathy towards other community members.
+
+- Placing collective interest before your own interest.
+
+**Be considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
+
+**Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the HOT community should be respectful when dealing with other members as well as with people outside the HOT community.
+
+**Be careful in your word choice.** We are a global community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to:
+
+- Violent threats or language directed against another person.
+
+- Discriminatory jokes and language.
+
+- Posting sexually explicit or violent material.
+
+- Posting (or threatening to post) other people's personally identifying information ("doxing").
+
+- Personal insults, especially those using racist or sexist terms.
+
+- Unwelcome sexual attention.
+
+- Advocating for, or encouraging, any of the above behavior.
+
+- Repeated harassment of others. In general, if someone asks you to stop, then stop.
+
+**Assume all communications are positive.** Always remain polite, and assume good faith. It is surprisingly easy to misunderstand each other, be it online or in person, particularly in such a culturally diverse setting as ours. Misunderstandings are particularly easy to arise when we are in a rush, or otherwise distracted. Please ask clarifying questions before assuming that a communication was inappropriate.
+
+**When we disagree, try to understand why.** Disagreements, both social and technical, happen easily and often. It is important that we resolve such disagreements and differing views constructively. At times it can be hard to appreciate a viewpoint that contradicts your own perceptions. Instead of pushing back, try to understand where the other person is coming from, and don’t be afraid to ask questions. You can be most helpful if your own replies serve to clarify, rather than to escalate an issue. Also don’t forget that it can be easy to make mistakes, and allow for the possibility that the mistake may have been yours. When this happens it is better to resolve the issue together, and to learn from the experience together, than to place blame.
+
+
+Original text courtesy of the [Speak Up! project](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html).
+
+Further sources:
+
+- [Ada Initiative: HOWTO design a code of conduct for your community](https://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/)
+
+- [Algorithm Club Code of Conduct](https://github.com/drtortoise/critical-algorithm-studies/blob/master/code-of-conduct.md)
+
+- [American Red Cross GIS Team Code of Conduct](https://github.com/AmericanRedCross/team-code-of-conduct)
+
+- [Contributor Covenant – A Code of Conduct for Open Source Projects](http://contributor-covenant.org/)
+
+- [Django Code of Conduct](https://www.djangoproject.com/conduct/)
+
+- [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
+
+- [Vox Media Code of Conduct](http://code-of-conduct.voxmedia.com/)
+
+## Complaint Handling Process
+
+As a first measure, it is preferable to work out issues directly with the people involved, or to work with other Community Members who can help you resolve the issue. This may take several forms:
+
+- Talk with one another. Assume that communications are positive and that people are treating each other with respect. Cues about emotions are often lacking from digital communications. Many of our modes of digital communication tend towards brevity, which can be easier to interpret incorrectly as being negative.
+
+- Contact a representative of the [Community Working Group](https://www.hotosm.org/community/working-groups/), which exists to support the HOT Community. Representatives are available to discuss any concerns about behaviour within the community, or ideas to promote positive behaviours. You can email them at [community@hotosm.org](mailto:community@hotosm.org).
+
+- Contact a representative of the [Governance Working Group](https://www.hotosm.org/community/working-groups/), which drafted these recommendations and the CoC. Representatives are available to provide advice on particular scenarios, as well as on the processes around the CoC.
+
+- Contact the HOT Chair of Voting Members.
+
+- Contact a [HOT Board Member](https://www.hotosm.org/board). Board members are well versed in the community and its management. They can offer advice on your particular situation, and know the resources of the organization that may be available to you.
+
+- Contact the HOT Community Partnerships Manager.
+
+When these informal processes fail, or when a situation warrants an immediate response by HOT, you can evoke the **HOT Policy and Code of Conduct Complaint Handling Process**. This process was adopted by HOT Voting Members in 2016 to provide a more formal means of enforcement for our community standards. You start it by emailing [complaints@hotosm.org](mailto:compaints@hotosm.org) with a description of your complaint, your name, and the name of the offending party. All complaints will be considered confidential. The full process is described [here](https://docs.google.com/document/d/1xb-SPADtSbgwl6mAgglHMPHpknt-E7lKRoIcSbW431A/edit)


### PR DESCRIPTION
We mention the Code of Conduct in the [contributing guidelines](https://github.com/hotosm/tasking-manager/blob/develop/CONTRIBUTING.md), but GitHub suggests in their [recommended community standards](https://opensource.guide/) to add a file with that information. This PR adds the full HOT CoC and complaint handling process in its own file.