### PR TITLE
Bugfix for gpx generation error

### DIFF
--- a/server/services/mapping_service.py
+++ b/server/services/mapping_service.py
@@ -179,11 +179,11 @@ class MappingService:
         if task_ids_str is not None:
             task_ids = map(int, task_ids_str.split(','))
             tasks = Task.get_tasks(project_id, task_ids)
-            if not tasks or len(tasks) == 0:
+            if not tasks or tasks.count() == 0:
                 raise NotFound()
         else:
             tasks = Task.get_all_tasks(project_id)
-            if not tasks or len(tasks) == 0:
+            if not tasks or tasks.count() == 0:
                 raise NotFound()
 
         for task in tasks:


### PR DESCRIPTION
Re #1266 switching back getting the size of a task query using the object function count instead of len. This is an undo to changes at https://github.com/hotosm/tasking-manager/pull/1211/files#diff-4864ec93a020afee0531607d8a0e7fa4