### PR TITLE
Fix YAML parsing error in swagger api

### DIFF
--- a/server/api/users/user_apis.py
+++ b/server/api/users/user_apis.py
@@ -466,7 +466,7 @@ class UserSetExpertMode(Resource):
               default: Token sessionTokenHere==
             - name: is_expert
               in: path
-              description: 'true' to enable expert mode, 'false' to disable
+              description: true to enable expert mode, false to disable
               required: true
               type: string
         responses:


### PR DESCRIPTION
Re: issue causing Swagger API to not render (note this bug only affects visiting the api-docs, not API functionality). It seems adding a quote as the first character of a YAML value requires the full value to be encapsulated in that quote. We just remove the quotes for now. Another method could be surrounding the whole value in double quotes.