### PR TITLE
Add expert augmented diff and attic query controls

### DIFF
--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -1017,6 +1017,9 @@
                                               </td>
                                               <td>
                                                   <span am-time-ago="item.actionDate | amUtc | amLocal"></span>
+                                                  <span ng-if="projectCtrl.user.isExpert">
+                                                    <a ng-show="projectCtrl.isAtticDateLive(item)" class="diff-control {{projectCtrl.selectedItem.actionDate === item.actionDate ? 'selected' : ''}}" ng-click="projectCtrl.selectItemForDiff(item)" title="{{ 'Choose two entries for diff or same once twice for attic data' | translate }}"></a>
+                                                 </span>
                                               </td>
                                           </tr>
                                           <tr ng-show="item.action === 'COMMENT'">

--- a/client/assets/styles/sass/_project.scss
+++ b/client/assets/styles/sass/_project.scss
@@ -115,6 +115,44 @@
   }
   a {
     color: $link-color;
+
+    &.diff-control {
+      display: inline-block;
+      margin-left: 0.5em;
+      border: 2px solid $orange;
+      border-radius: 4px;
+
+      &:before {
+        content: '\B1';
+        display: inline-block;
+        text-align: center;
+        width: 1.5em;
+        background-color: $orange;
+        color: white;
+        transition: all 0.3s ease 0s;
+      }
+
+      &.selected {
+        border-color: darken($link-color, 13%);
+
+        &:before {
+          content: '\2713';
+          border-radius: 4px;
+          color: darken($link-color, 13%);
+          background-color: white;
+        }
+      }
+
+      &:hover {
+        text-decoration: none;
+
+        &:before {
+          border-radius: 4px;
+          color: $orange;
+          background-color: white;
+        }
+      }
+    }
   }
 }
 

--- a/client/taskingmanager.config.json
+++ b/client/taskingmanager.config.json
@@ -26,6 +26,7 @@
           "imagerySet": "Aerial"
         }
       ],
+      "atticQueryOffsetMinutes": 10,
       "maxCommentLength": 5000,
       "maxChatLength": 5000
     }
@@ -58,6 +59,7 @@
           "imagerySet": "Aerial"
         }
       ],
+      "atticQueryOffsetMinutes": 10,
       "maxCommentLength": 5000,
       "maxChatLength": 5000
     }


### PR DESCRIPTION
* Add new control for users in expert mode to each history entry in task
history table for viewing an augmented diff between two entries or attic
query data for a single entry

* Selecting two separate entries will show an augmented diff of the
changes between those entries in Achavi in a new browser tab

* Selecting the same entry twice will perform an attic query and open
the data in either JOSM (if the user has selected it as their editor) or
Overpass Turbo in a new browser tab

* Add new `atticQueryOffsetMinutes` config setting for adjusting history
entry timestamps for the purpose of querying attic data to ensure that
data has had time to become available (defaults to 10 minutes)

* Reorganize some of the projectController bbox code into separate
methods to facilitate easier reuse
<img width="589" alt="attic" src="https://user-images.githubusercontent.com/445970/48440751-95157480-e73e-11e8-9e4b-fddcc4f2166a.png">
