### PR TITLE
Further bugfix for #1273

### DIFF
--- a/server/services/mapping_service.py
+++ b/server/services/mapping_service.py
@@ -183,7 +183,7 @@ class MappingService:
                 raise NotFound()
         else:
             tasks = Task.get_all_tasks(project_id)
-            if not tasks or tasks.count() == 0:
+            if not tasks or len(tasks) == 0:
                 raise NotFound()
 
         for task in tasks:
@@ -210,7 +210,7 @@ class MappingService:
         if task_ids_str:
             task_ids = map(int, task_ids_str.split(','))
             tasks = Task.get_tasks(project_id, task_ids)
-            if not tasks or len(tasks) == 0:
+            if not tasks or tasks.count() == 0:
                 raise NotFound()
         else:
             tasks = Task.get_all_tasks(project_id)


### PR DESCRIPTION
When applying the fix in #1267, I changed `count` to `len` in an incorrect line. This PR fixes that by reverting the one wrong change and applying a correct one instead. With these changes, the file should be the same as e.g. https://github.com/hotosm/tasking-manager/blob/0ee74c637a61e7e874e2b087a24028a86f04163b/server/services/mapping_service.py

This needs some further investigation in the future as there have been at least two other instances of (presumably) len working on someone else's machine but not mine or the deployment in the context of the two that have been reverted between this PR and #1267. 