### PR TITLE
Add missing spaces to About and FAQ pages

### DIFF
--- a/client/app/about/about.html
+++ b/client/app/about/about.html
@@ -12,8 +12,8 @@
                     {{ 'This approach allows the distribution of tasks to many individual mappers in the context of emergency or other humanitarian mapping scenario. It also allows monitoring of the overall project progress and helps improve the consistency of the mapping (e.g., elements to cover, specific tags to use, etc.).' | translate }}
                 </p>
                 <p>
-                    {{'All of this work is done through'| translate }} <a href="https://www.openstreetmap.org/" target="_top">OpenStreetMap</a>. {{'OpenStreetMap is the community-driven free and editable map of the world, supported by the not-for-profit '| translate }}<a
-                        href="http://wiki.osmfoundation.org/wiki/Main_Page" target="_top">{{'OpenStreetMap Foundation'| translate }}</a>. {{'Read more on the'| translate }} <a href="https://wiki.openstreetmap.org/wiki/Main_Page">{{'OSM Wiki'| translate }}</a>{{' or join the discussion with your '| translate }}<a
+                    {{'All of this work is done through'| translate }} <a href="https://www.openstreetmap.org/" target="_top">OpenStreetMap</a>. {{'OpenStreetMap is the community-driven free and editable map of the world, supported by the not-for-profit '| translate }} <a
+                        href="http://wiki.osmfoundation.org/wiki/Main_Page" target="_top">{{'OpenStreetMap Foundation'| translate }}</a>. {{'Read more on the'| translate }} <a href="https://wiki.openstreetmap.org/wiki/Main_Page">{{'OSM Wiki'| translate }}</a> {{' or join the discussion with your '| translate }} <a
                         href="http://wiki.openstreetmap.org/wiki/Mailing_lists#Country-Specific_Lists">{{'local OSM community'| translate }}</a>.
                 </p>
             </div>

--- a/client/app/about/faq.html
+++ b/client/app/about/faq.html
@@ -16,7 +16,7 @@
                 <div class="inner">
                     <h3>{{'What is Tasking Manager 3 (TM3)?'| translate }}</h3>
                     <p>
-                        {{'A new and improved version of the Tasking Manager was developed by HOT with support by USAID and DFAT during 2017. More information about what’s new in TM3 can be found here: '| translate }}<a
+                        {{'A new and improved version of the Tasking Manager was developed by HOT with support by USAID and DFAT during 2017. More information about what’s new in TM3 can be found here: '| translate }} <a
                             href="http://tm3.hotosm.org/what-is-new">http://tm3.hotosm.org/what-is-new</a>.
                     </p>
                     <h3>{{'When will TM3 be launched?'| translate }}</h3>
@@ -38,7 +38,7 @@
                     <h3>{{'Where can I learn more about how TM3 works?'| translate }}</h3>
                     <p>
                         {{'Detailed user documentation is available on LearnOSM:'| translate }} <a href="http://learnosm.org/en/coordination/tasking-manager3/">http://learnosm.org/en/coordination/tasking-manager3/</a>.
-                        {{'Videos have also been created:'| translate }} <a href="https://youtu.be/tWbaxdQrZSo">https://youtu.be/tWbaxdQrZSo</a> {{'(What’s new for mappers), '| translate }}<a href="https://youtu.be/yLTubyUePG8">https://youtu.be/yLTubyUePG8</a>
+                        {{'Videos have also been created:'| translate }} <a href="https://youtu.be/tWbaxdQrZSo">https://youtu.be/tWbaxdQrZSo</a> {{'(What’s new for mappers), '| translate }} <a href="https://youtu.be/yLTubyUePG8">https://youtu.be/yLTubyUePG8</a>
                         {{'(What’s new for validators).'| translate }}
                     </p>
                     <h3>{{'When should project manager stop creating new projects in TM2?'| translate }}</h3>
@@ -47,16 +47,16 @@
                     </p>
                     <h3>{{'What happens to projects that I created on the test TM3 instance?'| translate }}</h3>
                     <p>
-                        {{'All projects that were created during the test phase at '| translate }}<a href="http://tm3.hotosm.org/">http://tm3.hotosm.org</a> {{'will be deleted right before launch. All data will be replaced with existing TM2 projects as soon as the switch happens.'| translate }}
+                        {{'All projects that were created during the test phase at '| translate }} <a href="http://tm3.hotosm.org/">http://tm3.hotosm.org</a> {{'will be deleted right before launch. All data will be replaced with existing TM2 projects as soon as the switch happens.'| translate }}
                     </p>
                     <h3>{{'How can I get some help if something doesn’t work after the switch?'| translate }}</h3>
                     <p>
-                        {{'You can report any issue at'| translate }} <a href="https://github.com/hotosm/tasking-manager/issues">https://github.com/hotosm/tasking-manager/issues</a> {{'or join us on the '| translate }}<a
-                            href="https://slack.hotosm.org/">{{'Slack #tasking_manager_3 channel'| translate }}</a> {{'with any question.'| translate }}
+                        {{'You can report any issue at'| translate }} <a href="https://github.com/hotosm/tasking-manager/issues">https://github.com/hotosm/tasking-manager/issues</a> {{'or join us on the '| translate }} <a
+                            href="https://slack.hotosm.org/">{{'Slack #tasking_manager_3 channel'| translate }}</a> {{'with any questions.'| translate }}
                     </p>
                     <h3>{{'What if I run my own TM2?'| translate }}</h3>
-                    <p>{{'The code and community around Tasking Manager v2 will still exist. If you have questions about the older version, reach out via the '| translate }}<a href="https://github.com/hotosm/osm-tasking-manager2/issues">{{'GitHub issues page'| translate }}</a>.
-                        {{'If you want to upgrade to TM3, '| translate }}<a href="https://github.com/hotosm/tasking-manager/blob/develop/README.md">{{'get started with the README'| translate }}</a>.</p>
+                    <p>{{'The code and community around Tasking Manager v2 will still exist. If you have questions about the older version, reach out via the '| translate }} <a href="https://github.com/hotosm/osm-tasking-manager2/issues">{{'GitHub issues page'| translate }}</a>.
+                        {{'If you want to upgrade to TM3, '| translate }} <a href="https://github.com/hotosm/tasking-manager/blob/develop/README.md">{{'get started with the README'| translate }}</a>.</p>
                 </div>
                 <div class="inner">
                 </div>


### PR DESCRIPTION
UPDATED TO ONLY INCLUDE RELEVANT COMMITS:

Fixes some spacing issues noted in #1292 

cc @smit1678 @ethan-nelson 

Once approved and merged, we can finish that release. 