### PR TITLE
resets banner to mobile only, keeps button hover color

### DIFF
--- a/client/assets/styles/sass/_mobile.scss
+++ b/client/assets/styles/sass/_mobile.scss
@@ -11,7 +11,7 @@
   .button--outline--white:hover {
     color: #d34143;
   }
-  .modal__button-dismiss {
-    top: 1rem;
+  @include media(large-up) {
+  	display: none;
   }
 }

--- a/client/index.html
+++ b/client/index.html
@@ -116,9 +116,9 @@
 <div class="mob-disclaimer" ng-show="!hideMobileMessage">
     <p class="centered">
         <i class="modal__button-dismiss pull-right pointer" ng-click="hideMobileMessage = true"></i>
-        {{ '#MAPTHEDIFFERENCE for Local Leaders. Join our end of the year Microgrants Giving Campaign and help us get to 150 donors by December 25.' | translate }}
+        {{ 'In order to make full use of the many features in the Tasking Manager, please use a desktop or laptop computer rather than a mobile device. If you would like to contribute on a mobile device, please use MapSwipe instead.' | translate }}
     </p>
-    <a href="https://donate.hotosm.org" class="button button--outline--white">{{ 'Help us get to 150 donors today' | translate }}</a>
+    <a href="https://mapswipe.org" class="button button--outline--white">{{ 'Go to MapSwipe' | translate }}</a>
 </div>
 <!--/ mobile message -->
 


### PR DESCRIPTION
This resets the end of year banner from https://github.com/hotosm/tasking-manager/pull/1301 to only show for small and mobile screens only. One color adjustment is kept: fixes the orange text color on hover by changing to white. This looks better. 

cc @dakotabenjamin @ethan-nelson 