### PR TITLE
Make the demo branch push to the correct EB env

### DIFF
--- a/devops/ci/circleci_deploy.sh
+++ b/devops/ci/circleci_deploy.sh
@@ -6,7 +6,7 @@ set -xev # halt script on error
 # STAGE_BRANCH="develop"
 PROD_BRANCH="master"
 
-DEMO_ENV="taskingmanager-demo"
+DEMO_ENV="taskingmanager-test"
 STAGE_ENV="taskingmanager-stage"
 PROD_ENV="taskingmanager-prod"
 


### PR DESCRIPTION
The new demo/testing environment is called `taskingmanager-test`. We must update this in order for CircleCI to deploy the `tm4ml` branch to tasks-test.hotosm.org