### PR TITLE
Pending stats for home-page endpoint

### DIFF
--- a/client/app/services/stats.service.js
+++ b/client/app/services/stats.service.js
@@ -96,7 +96,7 @@
             console.log('In service');
             return $http({
                 method: 'GET',
-                url: configService.tmAPI + '/stats/home-page'
+                url: configService.tmAPI + '/stats/summary'
             }).then(function successCallback(response) {
                 // this callback will be called asynchronously
                 // when the response is available

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,5 @@ Unidecode==1.0.23
 urllib3==1.23
 webencodings==0.5.1
 Werkzeug==0.12.2
+newrelic==3.2.0.91
+pyproject==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,4 +50,4 @@ urllib3==1.23
 webencodings==0.5.1
 Werkzeug==0.12.2
 newrelic==3.2.0.91
-pyproject==1.3.1
+pyproj==1.9.6

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -162,7 +162,7 @@ def init_flask_restful_routes(app):
     api.add_resource(StatsActivityAPI,              '/api/v1/stats/project/<int:project_id>/activity')
     api.add_resource(StatsProjectAPI,               '/api/v1/stats/project/<int:project_id>')
     api.add_resource(StatsUserAPI,                  '/api/v1/stats/user/<string:username>')
-    api.add_resource(HomePageStatsAPI,              '/api/v1/stats/home-page')
+    api.add_resource(HomePageStatsAPI,              '/api/v1/stats/summary')
     api.add_resource(CampaignsTagsAPI,              '/api/v1/tags/campaigns')
     api.add_resource(OrganisationTagsAPI,           '/api/v1/tags/organisations')
     api.add_resource(UserSearchAllAPI,              '/api/v1/user/search-all')

--- a/server/models/dtos/stats_dto.py
+++ b/server/models/dtos/stats_dto.py
@@ -85,6 +85,7 @@ class HomePageStatsDTO(Model):
     tasks_validated = IntType(serialized_name='tasksValidated')
     total_mappers = IntType(serialized_name='totalMappers')
     total_validators = IntType(serialized_name='totalValidators')
+    total_projects = IntType(serialized_name='totalProjects')
     total_area = FloatType(serialized_name='totalArea')
     total_organizations = IntType(serialized_name='totalOrganizations')
     total_campaigns = IntType(serialized_name='totalCampaigns')

--- a/server/models/dtos/stats_dto.py
+++ b/server/models/dtos/stats_dto.py
@@ -86,7 +86,7 @@ class HomePageStatsDTO(Model):
     total_mappers = IntType(serialized_name='totalMappers')
     total_validators = IntType(serialized_name='totalValidators')
     total_projects = IntType(serialized_name='totalProjects')
-    total_area = FloatType(serialized_name='totalArea')
+    # total_area = FloatType(serialized_name='totalArea')
     total_mapped_area = FloatType(serialized_name='totalMappedArea')
     total_validated_area = FloatType(serialized_name='totalValidatedArea')
     total_organizations = IntType(serialized_name='totalOrganizations')

--- a/server/models/dtos/stats_dto.py
+++ b/server/models/dtos/stats_dto.py
@@ -1,5 +1,5 @@
 from schematics import Model
-from schematics.types import StringType, IntType, BooleanType
+from schematics.types import StringType, IntType, FloatType, BooleanType
 from schematics.types.compound import ListType, ModelType
 from server.models.dtos.mapping_dto import TaskHistoryDTO
 
@@ -64,17 +64,31 @@ class OrganizationStatsDTO(Model):
     tag = StringType()
     projects_created = IntType(serialized_name='projectsCreated')
 
+class CampaignStatsDTO(Model):
+    def __init__(self, tup):
+        super().__init__()
+        self.tag = tup[0]
+        self.projects_created = tup[1]
+    
+    tag = StringType()
+    projects_created = IntType(serialized_name='projectsCreated')
 
 class HomePageStatsDTO(Model):
     """ DTO for stats we want to display on the homepage """
     def __init__(self):
         super().__init__()
         self.organizations = []
+        self.campaigns = []
 
     mappers_online = IntType(serialized_name='mappersOnline')
     tasks_mapped = IntType(serialized_name='tasksMapped')
     tasks_validated = IntType(serialized_name='tasksValidated')
     total_mappers = IntType(serialized_name='totalMappers')
     total_validators = IntType(serialized_name='totalValidators')
+    total_area = FloatType(serialized_name='totalArea')
+    total_organizations = IntType(serialized_name='totalOrganizations')
+    total_campaigns = IntType(serialized_name='totalCampaigns')
     # avg_completion_time = IntType(serialized_name='averageCompletionTime')
     organizations = ListType(ModelType(OrganizationStatsDTO))
+    campaigns = ListType(ModelType(CampaignStatsDTO))
+    

--- a/server/models/dtos/stats_dto.py
+++ b/server/models/dtos/stats_dto.py
@@ -87,6 +87,8 @@ class HomePageStatsDTO(Model):
     total_validators = IntType(serialized_name='totalValidators')
     total_projects = IntType(serialized_name='totalProjects')
     total_area = FloatType(serialized_name='totalArea')
+    total_mapped_area = FloatType(serialized_name='totalMappedArea')
+    total_validated_area = FloatType(serialized_name='totalValidatedArea')
     total_organizations = IntType(serialized_name='totalOrganizations')
     total_campaigns = IntType(serialized_name='totalCampaigns')
     # avg_completion_time = IntType(serialized_name='averageCompletionTime')

--- a/server/services/stats_service.py
+++ b/server/services/stats_service.py
@@ -185,7 +185,7 @@ class StatsService:
     def get_homepage_stats() -> HomePageStatsDTO:
         """ Get overall TM stats to give community a feel for progress that's being made """
         dto = HomePageStatsDTO()
-        total_area = 0
+        # total_area = 0
         dto.mappers_online = Task.query.filter(Task.locked_by != None).distinct(Task.locked_by).count()
         dto.total_mappers = User.query.count()
         dto.total_projects = Project.query.count()
@@ -194,18 +194,18 @@ class StatsService:
         dto.tasks_mapped = Task.query\
             .filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value))).count()
         dto.tasks_validated = Task.query.filter(Task.task_status == TaskStatus.VALIDATED.value).count()
-        dto.total_area = 0
+        # dto.total_area = 0
         
-        total_area_sql = """select sum(ST_Area(geometry)) from public.projects as area"""
+        # total_area_sql = """select sum(ST_Area(geometry)) from public.projects as area"""
 
-        total_area_result = db.engine.execute(total_area_sql)
-        current_app.logger.debug(total_area_result)
-        for rowproxy in total_area_result:
+        # total_area_result = db.engine.execute(total_area_sql)
+        # current_app.logger.debug(total_area_result)
+        # for rowproxy in total_area_result:
             # rowproxy.items() returns an array like [(key0, value0), (key1, value1)]
-            for tup in rowproxy.items():
-                total_area += tup[1]
-                current_app.logger.debug(total_area)
-        dto.total_area = total_area
+            # for tup in rowproxy.items():
+                # total_area += tup[1]
+                # current_app.logger.debug(total_area)
+        # dto.total_area = total_area
 
         tasks_mapped_area = 0
         tasks_mapped_sql = """select sum(ST_Area(geometry)) from public.tasks where task_status = 2"""

--- a/server/services/stats_service.py
+++ b/server/services/stats_service.py
@@ -209,19 +209,22 @@ class StatsService:
 
         tasks_mapped_area = 0
         tasks_mapped_sql = """select sum(ST_Area(geometry)) from public.tasks where task_status = 2"""
-        tasks_mapped_result = db.engine.execute(tasks_mapped_result)
+        tasks_mapped_result = db.engine.execute(tasks_mapped_sql)
+        current_app.logger.debug(tasks_mapped_result)
         for rowproxy in tasks_mapped_result:
             for tup in rowproxy:
-                tasks_mapped_area += tup[1]
+                current_app.logger.debug(tup)
+                tasks_mapped_area += tup
                 current_app.logger.debug(tasks_mapped_area)
         dto.total_mapped_area = tasks_mapped_area
 
         tasks_validated_area = 0
-        tasks_validated_sql = """select sum(ST_Area(geometry)) from public.tasks where task_status = 3"""
-        tasks_validated_result = db.engine.execute(tasks_validated_result)
+        tasks_validated_sql = """select sum(ST_Area(geometry)) from public.tasks where task_status = 4"""
+        tasks_validated_result = db.engine.execute(tasks_validated_sql)
+        current_app.logger.debug(tasks_validated_result)
         for rowproxy in tasks_validated_result:
             for tup in rowproxy:
-                tasks_validated_area += tup[1]
+                tasks_validated_area += tup
                 current_app.logger.debug(tasks_validated_area)
         dto.total_validated_area = tasks_validated_area
     

--- a/server/services/stats_service.py
+++ b/server/services/stats_service.py
@@ -196,16 +196,34 @@ class StatsService:
         dto.tasks_validated = Task.query.filter(Task.task_status == TaskStatus.VALIDATED.value).count()
         dto.total_area = 0
         
-        sql = """select sum(ST_Area(geometry)) from public.projects as area"""
+        total_area_sql = """select sum(ST_Area(geometry)) from public.projects as area"""
 
-        resultproxy = db.engine.execute(sql)
-        current_app.logger.debug(resultproxy)
-        for rowproxy in resultproxy:
+        total_area_result = db.engine.execute(total_area_sql)
+        current_app.logger.debug(total_area_result)
+        for rowproxy in total_area_result:
             # rowproxy.items() returns an array like [(key0, value0), (key1, value1)]
             for tup in rowproxy.items():
                 total_area += tup[1]
                 current_app.logger.debug(total_area)
         dto.total_area = total_area
+
+        tasks_mapped_area = 0
+        tasks_mapped_sql = """select sum(ST_Area(geometry)) from public.tasks where task_status = 2"""
+        tasks_mapped_result = db.engine.execute(tasks_mapped_result)
+        for rowproxy in tasks_mapped_result:
+            for tup in rowproxy:
+                tasks_mapped_area += tup[1]
+                current_app.logger.debug(tasks_mapped_area)
+        dto.total_mapped_area = tasks_mapped_area
+
+        tasks_validated_area = 0
+        tasks_validated_sql = """select sum(ST_Area(geometry)) from public.tasks where task_status = 3"""
+        tasks_validated_result = db.engine.execute(tasks_validated_result)
+        for rowproxy in tasks_validated_result:
+            for tup in rowproxy:
+                tasks_validated_area += tup[1]
+                current_app.logger.debug(tasks_validated_area)
+        dto.total_validated_area = tasks_validated_area
     
         campaign_count = db.session.query(Project.campaign_tag, func.count(Project.campaign_tag))\
             .group_by(Project.campaign_tag).all()

--- a/server/services/stats_service.py
+++ b/server/services/stats_service.py
@@ -1,5 +1,6 @@
 from cachetools import TTLCache, cached
 from sqlalchemy import func
+from geoalchemy2.shape import to_shape
 import dateutil.parser
 import datetime
 
@@ -181,13 +182,13 @@ class StatsService:
 
         dto.mappers_online = Task.query.filter(Task.locked_by != None).distinct(Task.locked_by).count()
         dto.total_mappers = User.query.count()
+        dto.total_projects = Project.query.count()
         dto.total_validators = Task.query.filter(Task.task_status == TaskStatus.VALIDATED.value)\
             .distinct(Task.validated_by).count()
         dto.tasks_mapped = Task.query\
             .filter(Task.task_status.in_((TaskStatus.MAPPED.value, TaskStatus.VALIDATED.value))).count()
         dto.tasks_validated = Task.query.filter(Task.task_status == TaskStatus.VALIDATED.value).count()
-    
-        
+      
         campaign_count = db.session.query(Project.campaign_tag, func.count(Project.campaign_tag))\
             .group_by(Project.campaign_tag).all()
         no_campaign_count = 0


### PR DESCRIPTION
From #1147 - developing on @sunidhiraheja's work to add more home page stats. Similar to organisation summary, added 
- [x] campaign summary
- [x] Total number of campaigns
- [x] Total number of organisations
- [x] Updated organisation stats logic to [count untagged elements](https://github.com/hotosm/tasking-manager/blob/40ff291ef439f6e04b17a1e7843c21326c40b7e1/server/services/stats_service.py#L219) - current logic increments count by 1 everytime an empty tag is detected. Instead summed up counts from such untagged elements. Followed the same logic for campaigns as well
- [x] Total projects
- [x] stats/home-page -> stats/summary
- [x] ~~Total area from all projects~~
- [x] Total mapped area
- [x] Total validated area

Pending:
- [ ] Average task completion time
- [ ] Enable querying by date

cc @smit1678 @ethan-nelson 