### PR TITLE
add "cursor: pointer" to buttons and remove unneeded blank lines

### DIFF
--- a/client/assets/styles/sass/_base.scss
+++ b/client/assets/styles/sass/_base.scss
@@ -110,6 +110,10 @@ a:active {
  * https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile
  */
 
+ button {
+   cursor: pointer;
+ }
+
  .button, .button:visited {
    -webkit-border-radius: 4px;
    -moz-border-radius: 4px;
@@ -121,6 +125,7 @@ a:active {
    display: inline-block;
    font-weight: 600;
    border: 2px solid $link-color;
+   cursor: pointer;
    &:hover {
      transition: all 0.3s ease 0s;
      -webkit-transition: all 0.3s;
@@ -247,21 +252,17 @@ a:active {
   padding-left: 0;
 }
 
-#split-task-btn:hover #split-task
-{ 
+#split-task-btn:hover #split-task {
   fill: $warm-grey;
 }
-#bad-imagery-btn:hover #bad-imagery
-{ 
+#bad-imagery-btn:hover #bad-imagery {
   fill: $warm-grey;
 }
-#stop-mapping-btn:hover #stop-mapping
-{ 
+#stop-mapping-btn:hover #stop-mapping {
   fill: $warm-grey;
 }
 
-#complete-mapping-btn:hover #complete-mapping
-{ 
+#complete-mapping-btn:hover #complete-mapping {
   fill: $orange;
 }
 
@@ -277,8 +278,6 @@ a:active {
     fill:$link-color;
   }
 }
-
-
 
 .icon-split {
   background-image: url("../../icons/split.svg");
@@ -350,7 +349,6 @@ input, textarea {
   }
   li {
     margin-bottom: 1.3em;
-
   }
 }
 
@@ -439,7 +437,6 @@ table {
     .paging--next {
       margin-left: 1em;
     }
-
     .paging--previous {
       margin-right: 1em;
     }


### PR DESCRIPTION
A lot of buttons like those below didn't have the `cursor:pointer` css property


![captura de tela de 2019-01-27 13-23-00](https://user-images.githubusercontent.com/666291/51804084-faa3d800-223a-11e9-8967-72666009d37d.png)
