### PR TITLE
Update debian version for the circleci environment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /app
     docker:
-      - image: python:3.6-jessie
+      - image: python:3.6-stretch
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
Currently our continous integrations [failes]https://circleci.com/gh/hotosm/tasking-manager/1454?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link() with
```
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/main/binary-amd64/Packages  404  Not Found
```

In the container for circle ci we were relying on Debian 8  codename Jessie. This PR updates to Debian 9 codename Stretch.
