### PR TITLE
Update python version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-jessie
+FROM python:3-stretch
 
 # Install dependencies for shapely
 RUN apt-get update \


### PR DESCRIPTION
For some reason, #1393 refuses to build on CircleCI...even though #1394 is. Testing out a fresh branch PR to see if this can resolve it.