### PR TITLE
Generalize python version in db aws upgrade

### DIFF
--- a/.ebextensions/aws.config
+++ b/.ebextensions/aws.config
@@ -9,4 +9,4 @@ files:
     group: root
     content: |
         #!/usr/bin/env bash
-        docker exec $(docker ps -q) sh -c "cd /src && python3.6 manage.py db upgrade"
+        docker exec $(docker ps -q) sh -c "cd /src && python3 manage.py db upgrade"


### PR DESCRIPTION
Synopsis so far:

* We have been experiencing latency issues on the main TM instance. (I still think this is because docker image builds are failing when EBS tries to scale up since the Dockerfile and circleci.yml files use Debian jessie on master at the moment.)
* Based on failing builds for other PRs that were cropping up around the time of the issues, @xamanu determined we need to update the debian version. That was done for the CircleCI deployment in #1411.
* Updates to the debian version in the Dockerfile were also made by him in #1393. However, CircleCI would refuse to build this PR even when using a fresh cache. That is despite #1394 building just fine with a very similar Dockerfile (one may be picking up the CircleCI config changes while the other isn't?? Not sure)
* In any case, I went ahead and made a fresh PR to update the Dockerfile from jessie to stretch (#1413). We had discussed and chosen to move to a more general `python3` instead of `python3.6` for the latest python version. This PR built fine and was merged into develop. However, it failed to actually deploy to develop.
* The deployment failure stems from the deployment script that migrates the database (https://github.com/hotosm/tasking-manager/blob/develop/.ebextensions/aws.config). That script uses the `python3.6` executable directly instead of the symbolic link `python3`.

Therefore, this new PR addresses that issue by using `python3` in that deploy script.

It's difficult for me to test this since it's very specific to deployment (perhaps someone can at least check on their docker image if `python3` exists in the user's bin directory), but hoping someone either concurs with this or has some experience. 

If this solves the problem, we will need to urgently get three things to master:

https://github.com/hotosm/tasking-manager/pull/1411/commits/231ec65c1e0bff4fc26696b922d17d10f6bc6d58
https://github.com/hotosm/tasking-manager/pull/1413/commits/0f4284fb65919cb05567bb453ec237f59aa8dd1f
https://github.com/hotosm/tasking-manager/commit/250ddbf19fef6b1938e802c39eccf999355e5039
