### PR TITLE
v3.1.2

### DIFF
--- a/.ebextensions/aws.config
+++ b/.ebextensions/aws.config
@@ -9,4 +9,4 @@ files:
     group: root
     content: |
         #!/usr/bin/env bash
-        docker exec $(docker ps -q) sh -c "cd /src && python3.6 manage.py db upgrade"
+        docker exec $(docker ps -q) sh -c "cd /src && python3 manage.py db upgrade"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-jessie
+FROM python:3-stretch
 
 # Install dependencies for shapely
 RUN apt-get update \

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /app
     docker:
-      - image: python:3.6-jessie
+      - image: python:3.6-stretch
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
This is an urgent release to fix problems that occurred on building and running the Tasking Manager with the Docker setup and the integrated continuos integration pipeline. It updates all related Docker instructions to build based on Debian Stretch (9) instead of Debian Jessie (8) and it abstracts the AWS setup to use the more general `python3` executable.