### PR TITLE
Fix Elastic Beanstalk deployment

### DIFF
--- a/.ebextensions/environment.config
+++ b/.ebextensions/environment.config
@@ -1,7 +1,3 @@
-# Environment settings
-option_settings:
-  - option_name: TM_ENV
-    value: Staging
 files:
   "/tmp/45_nginx_https_rw.sh":
     owner: root

--- a/.ebextensions/https.config
+++ b/.ebextensions/https.config
@@ -1,7 +1,3 @@
-# Environment settings
-option_settings:
-  - option_name: TASKING_MANAGER_ENV
-    value: Staging
 # Below will configure nginx to force HTTPS and keep health-check working as expected
 files:
   "/tmp/46_nginx_https_rw.sh":

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,26 @@
-# Base on Python on Debian stable
 FROM python:3-stretch
 
-EXPOSE 8000
-
-# Install dependencies
+# Install dependencies for shapely
 RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y libgeos-dev \
-  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ && apt-get upgrade -y \
+ && apt-get install -y libgeos-dev \
+ && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir /usr/src/app
-WORKDIR /usr/src/app
+
+# Uncomment and set with valid connection string for use locally
+#ENV TM_DB=postgresql://user:pass@host/db
+
+WORKDIR /src
 
 # Add and install Python modules
-COPY requirements.txt ./
-RUN pip install -r requirements.txt
+ADD requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
-## Install required dependencies
-RUN apt-get install -y python3 libgeos-dev
-RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - \ 
-  && apt-get install -y nodejs
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ADD . .
 
-# Build front-end
-RUN npm i gulp-cli -g
+# Expose
+EXPOSE 8000
 
-# Build front-end
-COPY client/package.json /tmp/package.json
-RUN cd /tmp && npm install acorn ajv
-RUN mkdir -p /usr/src/app/client && cp -a /tmp/node_modules /usr/src/app/client
-
-RUN npm link gulp
-RUN npm i closure-util --save
-RUN npm i openlayers --save
-
-# Add code base of Tasking Manager
-COPY . . 
-
-# Assamble the tasking manager front-end interface
-# RUN cd client && gulp build
-
-# Serve application (be aware this runs on port 5000)
-# CMD python manage.py runserver -h 0.0.0.0
-#
-# Alternative command to serve the application
-# Gunicorn has been configured for single-core machine, if more cores available 
-# you mayb increase the workers (-w) by using the formula ((cores x 2) + 1))
+# Gunicorn configured for single-core machine, if more cores available increase workers using formula ((cores x 2) + 1))
 CMD NEW_RELIC_CONFIG_FILE=newrelic.ini newrelic-admin run-program gunicorn -b 0.0.0.0:8000 -w 5 --timeout 179 manage:application
+

--- a/devops/docker/tasking-manager/Dockerfile
+++ b/devops/docker/tasking-manager/Dockerfile
@@ -1,0 +1,31 @@
+# Base on Python on Debian stable
+FROM python:3-stretch
+
+EXPOSE 5000
+
+# Install dependencies
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y libgeos-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - \ 
+  && apt-get install -y nodejs
+
+RUN npm i gulp-cli -g && npm link gulp
+
+# Add code base of the Tasking Manager
+ARG defined_branch=develop
+RUN git clone --single-branch --branch $defined_branch https://github.com/hotosm/tasking-manager /usr/src/app
+WORKDIR /usr/src/app
+
+# Add and install Python modules for back-end
+RUN pip install -r requirements.txt
+
+# Build front-end
+RUN cd client && \
+  npm install browser-sync closure-util openlayers --save && \
+  npm install && gulp build
+
+# Serve application (be aware this runs on port 5000)
+CMD python manage.py runserver -h 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
 
   # Main application
   app:
-    build: .
+    build: devops/docker/tasking-manager
     env_file: tasking-manager.env
     depends_on:
       - postgresql
@@ -21,7 +21,7 @@ services:
 
   # Migration service
   migration:
-    build: .
+    build: devops/docker/tasking-manager
     env_file: tasking-manager.env
     depends_on:
       - postgresql


### PR DESCRIPTION
This PR fixes the issues we were having with the AWS Elastic Beanstalk deployment. It has been tested [in another branch](https://github.com/hotosm/tasking-manager/commits/modify/Dockerfile), which contains some temporal configuration on top of this PR to get the deployment testing going.

Please make sure the (new) environment variables are set for the staging and live site. Particularly these two:

* `TM_APP_BASE_URL`=`https://tasks.hotosm.org` (or similar)
* `TM_LOG_DIR`=`/var/log/tasking-manager-logs`
