### PR TITLE
Include postgres port as configuration parameter

### DIFF
--- a/example.env
+++ b/example.env
@@ -17,6 +17,7 @@ POSTGRES_DB=tasking-manager
 POSTGRES_USER=tm
 POSTGRES_PASSWORD=tm
 # POSTGRES_ENDPOINT=localhost
+# POSTGRES_PORT=5432
 
 
 # Secret (required)

--- a/server/config.py
+++ b/server/config.py
@@ -26,6 +26,7 @@ class EnvironmentConfig:
     POSTGRES_PASSWORD = os.getenv('POSTGRES_PASSWORD', None)
     POSTGRES_ENDPOINT = os.getenv('POSTGRES_ENDPOINT', 'postgresql')
     POSTGRES_DB = os.getenv('POSTGRES_DB', None)
+    POSTGRES_PORT = os.getenv('POSTGRES_PORT', '5432')
 
     # Assamble the database uri
     if os.getenv('TM_DB', False):
@@ -33,8 +34,9 @@ class EnvironmentConfig:
     else:
         SQLALCHEMY_DATABASE_URI = f'postgresql://{POSTGRES_USER}' +  \
                                         f':{POSTGRES_PASSWORD}' + \
-                                            f'@{POSTGRES_ENDPOINT}' + \
-                                                f'/{POSTGRES_DB}'
+                                            f'@{POSTGRES_ENDPOINT}:' + \
+                                                f'{POSTGRES_PORT}' + \
+                                                    f'/{POSTGRES_DB}'
    
     # Logging settings
     LOG_LEVEL = os.getenv('TM_LOG_LEVEL', logging.DEBUG)


### PR DESCRIPTION
## Problem statement
The project configuration file does not define the postgres port as parameter to establish connection with the database and sets by default the port 5432.

## Changes
This PR includes within the **config.py** file, the variable POSTGRES_PORT, which could be read as environment variable. This parameter was also set in the _example.env_ template file