### PR TITLE
Improve cloning process

### DIFF
--- a/client/app/admin/create-project/create-project.html
+++ b/client/app/admin/create-project/create-project.html
@@ -259,11 +259,12 @@
                     <h4>{{ 'Step 5: Review' | translate }}</h4>
                     <form class="form" name="createProjectCtrl.projectNameForm">
                         <p>{{ 'Project has' | translate }} {{ createProjectCtrl.numberOfTasks }} {{ 'tasks.' | translate }}</p>
-                        <div>
+                        <div ng-hide="createProjectCtrl.isCloneProject">
                             <label class="form__label" for="projectName">{{ 'Project name' | translate }}</label>
                             <input type="text" class="form__control form__control--medium" id="projectName"
                                    name="projectName"
-                                   ng-class="{ 'ng-touched': createProjectCtrl.projectNameForm.submitted }" required
+                                   ng-class="{ 'ng-touched': createProjectCtrl.projectNameForm.submitted }"
+                                   ng-required="!createProjectCtrl.isCloneProject"
                                    ng-model="createProjectCtrl.projectName"
                             />
                         </div>

--- a/client/app/admin/edit-project/edit-project.html
+++ b/client/app/admin/edit-project/edit-project.html
@@ -511,7 +511,7 @@
                                 </div>
                                 <div class="form__group form__group--section">
                                     <label class="form__label">{{ 'Clone project' | translate }}</label>
-                                    <p>{{ 'This will clone all descriptions, instructions, metadata etc. The Area of Interest, the changeset comments, the tasks, and the priority areas will not be cloned. You will have to redraw/import these. Your newly cloned project will be in draft status.' | translate }}</p>
+                                    <p>{{ 'This will clone all descriptions, instructions, metadata etc. The Area of Interest, the tasks and the priority areas will not be cloned. You will have to redraw/import these. Your newly cloned project will be in draft status.' | translate }}</p>
                                     <button class="button button--secondary" type="button"
                                             ng-click="editProjectCtrl.cloneProject()">
                                         {{ 'Clone project' | translate }}

--- a/client/app/admin/edit-project/edit-project.html
+++ b/client/app/admin/edit-project/edit-project.html
@@ -511,7 +511,7 @@
                                 </div>
                                 <div class="form__group form__group--section">
                                     <label class="form__label">{{ 'Clone project' | translate }}</label>
-                                    <p>{{ 'This will clone all descriptions, instructions, metadata etc. The Area of Interest, the tasks and the priority areas will not be cloned. You will have to redraw/import these. Your newly cloned project will be in draft status.' | translate }}</p>
+                                    <p>{{ 'This will clone all descriptions, instructions, metadata etc. The Area of Interest, the changeset comments, the tasks, and the priority areas will not be cloned. You will have to redraw/import these. Your newly cloned project will be in draft status.' | translate }}</p>
                                     <button class="button button--secondary" type="button"
                                             ng-click="editProjectCtrl.cloneProject()">
                                         {{ 'Clone project' | translate }}

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -154,6 +154,23 @@ class Project(db.Model):
         for user in original_project.allowed_users:
             cloned_project.allowed_users.append(user)
 
+        # Add other project metadata
+        # We ignore changeset comment because that is reinitialized after creation
+        cloned_project.priority = original_project.priority
+        cloned_project.default_locale = original_project.default_locale
+        cloned_project.mapper_level = original_project.mapper_level
+        cloned_project.enforce_mapper_level = original_project.enforce_mapper_level
+        cloned_project.enforce_validator_role = original_project.enforce_validator_role
+        cloned_project.private = original_project.private
+        cloned_project.entities_to_map = original_project.entities_to_map
+        cloned_project.due_date = original_project.due_date
+        cloned_project.imagery = original_project.imagery
+        cloned_project.josm_preset = original_project.josm_preset
+        cloned_project.license_id = original_project.license_id
+        cloned_project.mapping_types = original_project.mapping_types
+        cloned_project.organisation_tag = original_project.organisation_tag
+        cloned_project.campaign_tag = original_project.campaign_tag
+
         db.session.add(cloned_project)
         db.session.commit()
 


### PR DESCRIPTION
Despite the instructions saying so, project metadata was not cloned during the cloning process. Additionally, users were required to add a title to submit the clone project form that was not actually copied to the cloned project. This PR solves those problems.

Fixes #1061 and fixes #1046 

Note the changeset comment is really difficult to handle in this situation. If a TM host changes the default changeset comment from when the original project was created to when the new project is cloned, we cannot easily remove that statement. But, for most intents and purposes (when the TM host does not change the default changeset comment often), the best effort attempt of searching for the default changeset comment with the old project id should be okay.