### PR TITLE
Allow only HTTPS access to the tasking manager

### DIFF
--- a/cloudformation/tasking-manager.template.js
+++ b/cloudformation/tasking-manager.template.js
@@ -202,18 +202,6 @@ const Resources = {
       Protocol: 'HTTPS'
     }
   },
-  TaskingManagerLoadBalancerHTTPListener: {
-    Type: 'AWS::ElasticLoadBalancingV2::Listener',
-    Properties: {
-      DefaultActions: [{
-        Type: 'forward',
-        TargetGroupArn: cf.ref('TaskingManagerTargetGroup')
-      }],
-      LoadBalancerArn: cf.ref('TaskingManagerLoadBalancer'),
-      Port: 80,
-      Protocol: 'HTTP'
-    }
-  },
   TaskingManagerRDS: {
     Type: 'AWS::RDS::DBInstance',
     Condition: 'UseASnapshot',

--- a/cloudformation/tasking-manager.template.js
+++ b/cloudformation/tasking-manager.template.js
@@ -202,6 +202,25 @@ const Resources = {
       Protocol: 'HTTPS'
     }
   },
+  TaskingManagerLoadBalancerHTTPListener: {
+    Type: 'AWS::ElasticLoadBalancingV2::Listener',
+    Properties: {
+      DefaultActions: [{
+        Type: 'redirect',
+        RedirectConfig: {
+          Protocol: 'HTTPS',
+          Port: '443',
+          Host: '#{host}',
+          Path: '/#{path}',
+          Query: '#{query}',
+          StatusCode: 'HTTP_301'
+        }
+      }],
+      LoadBalancerArn: cf.ref('TaskingManagerLoadBalancer'),
+      Port: 80,
+      Protocol: 'HTTP'
+    }
+  },
   TaskingManagerRDS: {
     Type: 'AWS::RDS::DBInstance',
     Condition: 'UseASnapshot',


### PR DESCRIPTION
Currently, the tasking manager does not enforce the use of https. This PR enforces https use - the stack is currently set up at https://tasks-secure.hotosm.org/. You can see that `http://tasks-secure.hotosm.org/` does not work, while `https://tasks-secure.hotosm.org/` does. 

Fixes https://github.com/hotosm/tasking-manager/issues/1457

<img width="1280" alt="Screen Shot 2019-04-09 at 3 47 12 PM" src="https://user-images.githubusercontent.com/3166852/55793182-f0764380-5adf-11e9-85a5-b5ca0ded292a.png">
<img width="1280" alt="Screen Shot 2019-04-09 at 3 47 23 PM" src="https://user-images.githubusercontent.com/3166852/55793183-f0764380-5adf-11e9-8235-acacd0c331ee.png">


cc/ @dakotabenjamin @willemarcel @xamanu @smit1678 @russdeffner @ethan-nelson 