### PR TITLE
Quick fix for [#1438] - Prevent blocked users from posting messages

### DIFF
--- a/server/api/messaging/project_chat_apis.py
+++ b/server/api/messaging/project_chat_apis.py
@@ -4,6 +4,7 @@ from schematics.exceptions import DataError
 from server.models.dtos.message_dto import ChatMessageDTO
 from server.models.postgis.utils import NotFound
 from server.services.messaging.chat_service import ChatService
+from server.services.users.user_service import UserService
 from server.services.users.authentication_service import token_auth, tm
 
 
@@ -49,11 +50,15 @@ class ProjectChatAPI(Resource):
             500:
                 description: Internal Server Error
         """
+
+        if UserService.is_user_blocked(tm.authenticated_user_id):
+            return 'User is on read only mode', 403
+
         try:
-            chat_dto = ChatMessageDTO(request.get_json())
-            chat_dto.user_id = tm.authenticated_user_id
-            chat_dto.project_id = project_id
-            chat_dto.validate()
+              chat_dto = ChatMessageDTO(request.get_json())
+              chat_dto.user_id = tm.authenticated_user_id
+              chat_dto.project_id = project_id
+              chat_dto.validate()
         except DataError as e:
             current_app.logger.error(f'Error validating request: {str(e)}')
             return str(e), 400

--- a/server/services/messaging/chat_service.py
+++ b/server/services/messaging/chat_service.py
@@ -3,6 +3,7 @@ from cachetools import TTLCache, cached
 from server.models.dtos.message_dto import ChatMessageDTO, ProjectChatDTO
 from server.models.postgis.project_chat import ProjectChat
 from server.services.messaging.message_service import MessageService
+from server.services.users.user_service import UserService
 from server import db
 
 
@@ -15,6 +16,9 @@ class ChatService:
     def post_message(chat_dto: ChatMessageDTO) -> ProjectChatDTO:
         """ Save message to DB and return latest chat"""
         current_app.logger.debug('Posting Chat Message')
+        if UserService.is_user_blocked(tm.authenticated_user_id):
+            return 'User is on read only mode', 403
+
         chat_message = ProjectChat.create_from_dto(chat_dto)
         MessageService.send_message_after_chat(chat_dto.user_id, chat_message.message, chat_dto.project_id)
         db.session.commit()


### PR DESCRIPTION
@willemarcel & I paired on to get a quick fix at the backend that prevents blocked users to post messages in project chat.

![image](https://user-images.githubusercontent.com/12103383/55876207-4242ca80-5bc1-11e9-97cc-7297015d0268.png)


We would still rely on https://github.com/hotosm/tasking-manager/pull/1431 from @uwaiszaki for a holistic implementation.

cc @xamanu 