### PR TITLE
Expand project activity query

### DIFF
--- a/server/services/stats_service.py
+++ b/server/services/stats_service.py
@@ -114,7 +114,8 @@ class StatsService:
     def get_latest_activity(project_id: int, page: int) -> ProjectActivityDTO:
         """ Gets all the activity on a project """
 
-        results = db.session.query(TaskHistory.action, TaskHistory.action_date, TaskHistory.action_text, User.username) \
+        results = db.session.query(TaskHistory.action, TaskHistory.action_date, TaskHistory.action_text,
+            TaskHistory.id, TaskHistory.task_id, User.username) \
             .join(User).filter(TaskHistory.project_id == project_id, TaskHistory.action != 'COMMENT')\
             .order_by(TaskHistory.action_date.desc())\
             .paginate(page, 10, True)


### PR DESCRIPTION
The DTO to handle task history included the history id and task_id
so those could be displayed on the project activity page. However,
those did not make it into the query that is used to populate the
DTO when the activity page is loaded.