### PR TITLE
Message users on level upgrade

### DIFF
--- a/server/services/messaging/templates/level_upgrade_message_en.txt
+++ b/server/services/messaging/templates/level_upgrade_message_en.txt
@@ -1,0 +1,9 @@
+Hi [USERNAME],<br />
+<br />
+Congratulations! Your'e now an [LEVEL] mapper.<br />
+Thank you very much for mapping!<br />
+We encourage you to continue your contribution to HOT.<br />
+You can now begin validating tasks across projects. <br />
+<br />
+Many thanks <br />
+HOT Mapping Team

--- a/tests/server/integration/services/users/test_user_service.py
+++ b/tests/server/integration/services/users/test_user_service.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from server import create_app
 from server.services.users.user_service import UserService, MappingLevel, User, OSMService, UserOSMDTO
 from tests.server.helpers.test_helpers import create_canned_project
+from server.models.postgis.message import Message
 
 
 class TestAuthenticationService(unittest.TestCase):
@@ -71,12 +72,14 @@ class TestAuthenticationService(unittest.TestCase):
         # Assert
         self.assertEqual(test_user.mapping_level, MappingLevel.INTERMEDIATE.value)
 
+    @patch.object(Message, 'save')
     @patch.object(User, 'save')
     @patch.object(OSMService, 'get_osm_details_for_user')
     @patch.object(UserService, 'get_user_by_id')
-    def test_mapper_level_updates_correctly(self, mock_user, mock_osm, mock_save):
+    def test_mapper_level_updates_correctly(self, mock_user, mock_osm, mock_save, mock_message):
         # Arrange
         test_user = User()
+        test_user.username = 'Test User'
         test_user.mapping_level = MappingLevel.BEGINNER.value
         mock_user.return_value = test_user
 
@@ -85,7 +88,7 @@ class TestAuthenticationService(unittest.TestCase):
         mock_osm.return_value = test_osm
 
         # Act
-        UserService.check_and_update_mapper_level(123)
+        UserService.check_and_update_mapper_level(12)
 
         #Assert
         self.assertTrue(test_user.mapping_level, MappingLevel.INTERMEDIATE.value)


### PR DESCRIPTION
Per conversation in https://github.com/hotosm/tasking-manager/issues/796, 
- [x] Added a messaging functionality to `check_and_update_mapper_level` function. I
- [x] Included a template for the level upgrade


Snapshot of the message
![image](https://user-images.githubusercontent.com/12103383/47462915-615fc280-d802-11e8-85d0-58bbec0dd635.png)
