### PR TITLE
Fix login for users without project activity

### DIFF
--- a/server/models/postgis/user.py
+++ b/server/models/postgis/user.py
@@ -248,7 +248,11 @@ class User(db.Model):
         user_dto.mapping_level = MappingLevel(self.mapping_level).name
         user_dto.is_expert = self.is_expert or False
         user_dto.date_registered = str(self.date_registered)
-        user_dto.projects_mapped = len(self.projects_mapped)
+        try:
+            user_dto.projects_mapped = len(self.projects_mapped)
+        # Handle users that haven't touched a project yet.
+        except:
+            user_dto.projects_mapped = 0
         user_dto.tasks_mapped = self.tasks_mapped
         user_dto.tasks_validated = self.tasks_validated
         user_dto.tasks_invalidated = self.tasks_invalidated


### PR DESCRIPTION
#1348 made it impossible for users without any involvement in any projects to login. The following error is was thrown:

```
User GET - unhandled error: object of type 'NoneType' has no len() [in /home/user/Code/HOT/tasking-manager/server/api/users/user_apis.py:48]
```

This was caused by a `len()` calculation. This PR introduces a basic test and allows the login to proceed.

