### PR TITLE
Fix posting message when commenting

### DIFF
--- a/server/services/messaging/chat_service.py
+++ b/server/services/messaging/chat_service.py
@@ -3,6 +3,7 @@ from cachetools import TTLCache, cached
 from server.models.dtos.message_dto import ChatMessageDTO, ProjectChatDTO
 from server.models.postgis.project_chat import ProjectChat
 from server.services.messaging.message_service import MessageService
+from server.services.users.authentication_service import tm
 from server.services.users.user_service import UserService
 from server import db
 


### PR DESCRIPTION
When posting a comment on a project an error message is presented that the comment was not added.

![image](https://user-images.githubusercontent.com/97706/56081894-b53a8400-5e01-11e9-8962-7ac91a56afd6.png)

The log file presented:

```
CRITICAL: Chat PUT - unhandled error: name 'tm' is not defined [in /home/user/Code/HOT/tasking-manager/server/api/messaging/project_chat_apis.py:71]
```

This PR includes a necessary dependency declaration in order to fix this error.