### PR TITLE
Task diff update

### DIFF
--- a/client/app/project/project.controller.js
+++ b/client/app/project/project.controller.js
@@ -131,7 +131,7 @@
 
             //start up a timer for autorefreshing the project.
             autoRefresh = $interval(function () {
-                refreshProject(vm.id);
+                refreshAbbreviatedProject(vm.id);
                 updateMappedTaskPerUser(vm.id);
                 //TODO do a selected task refresh too
             }, 10000);
@@ -437,7 +437,7 @@
          */
         function initialiseProject(id) {
             vm.errorGetProject = false;
-            var resultsPromise = projectService.getProject(id);
+            var resultsPromise = projectService.getProject(id, false);
             resultsPromise.then(function (data) {
                 //project returned successfully
                 vm.loaded = true;
@@ -492,7 +492,7 @@
          */
         function updateDescriptionAndInstructions(id) {
             vm.errorGetProject = false;
-            var resultsPromise = projectService.getProject(id);
+            var resultsPromise = projectService.getProject(id, false);
             resultsPromise.then(function (data) {
                 vm.projectData = data;
             }, function () {
@@ -506,7 +506,8 @@
          * @param id - id of project to be refreshed
          */
         function refreshProject(id) {
-            var resultsPromise = projectService.getProject(id);
+            vm.errorGetProject = false;
+            var resultsPromise = projectService.getProject(id, false);
             resultsPromise.then(function (data) {
                 //project returned successfully
                 vm.errorGetProject = false;
@@ -534,6 +535,32 @@
             }, function () {
                 // project not returned successfully
                 vm.errorGetProject = true;
+            });
+        }
+
+        /**
+         * Gets abbreviated project data from server and updates the map
+         * @param id - id of project to be refreshed
+         */
+        function refreshAbbreviatedProject(id) {
+            vm.errorGetProject = false;
+            var resultsPromise = projectService.getProject(id, true);
+            resultsPromise.then(function (data) {
+                //project returned successfully
+                if (vm.projectData.tasks.features.length == data.tasks.features.length) {
+                    // length of tasks is the same; we can assume only states changed
+                    var source = vm.taskVectorLayer.getSource();
+                    var features = source.getFeatures();
+                    updateProjectTasksOnMap(features, data.tasks);
+                } else {
+                    // length of tasks has changed since last update; likely a split occurred.
+                    // fall back to full update
+                    refreshProject(id);
+                }
+
+            }, function () {
+               // project not returned successfully
+               vm.errorGetProject = true;
             });
         }
 
@@ -595,6 +622,21 @@
             if (fitToProject) {
                 vm.map.getView().fit(source.getExtent());
             }
+        }
+
+        /**
+         * Updates the map task properties (colors, locked status)
+         * @param oldTasks
+         * @param newTasks
+         */
+        function updateProjectTasksOnMap(oldTasks, newTasks) {
+            var newFeatures = geospatialService.getFeaturesFromGeoJSON(newTasks);
+
+            for (var i=0; i < newFeatures.length; i++) {
+                var feature = taskService.getTaskFeatureById(oldTasks, newFeatures[i].getProperties()['taskId']);
+                feature.setProperties({"taskStatus": newFeatures[i].getProperties()['taskStatus']});
+            }
+            // for each task in features, update source
         }
 
         /**

--- a/client/app/services/project.service.js
+++ b/client/app/services/project.service.js
@@ -385,16 +385,17 @@
         /**
          * Get a project JSON
          * @param id - project id
+         * @param abbreviated - abbreviated project info or not
          * @returns {!jQuery.Promise|*|!jQuery.deferred|!jQuery.jqXHR}
          */
-        function getProject(id) {
+        function getProject(id, abbreviated) {
 
             var preferredLanguage = languageService.getLanguageCode();
 
             // Returns a promise
             return $http({
                 method: 'GET',
-                url: configService.tmAPI + '/project/' + id,
+                url: configService.tmAPI + '/project/' + id + '?abbreviated=' + abbreviated,
                 headers: {
                     'Content-Type': 'application/json; charset=UTF-8',
                     'Accept-Language': preferredLanguage

--- a/server/api/project_apis.py
+++ b/server/api/project_apis.py
@@ -37,6 +37,11 @@ class ProjectAPI(Resource):
               type: boolean
               description: Set to true if file download is preferred
               default: False
+            - in: query
+              name: abbreviated
+              type: boolean
+              description: Set to true if only state information is desired
+              default: False
         responses:
             200:
                 description: Project found
@@ -49,9 +54,10 @@ class ProjectAPI(Resource):
         """
         try:
             as_file = strtobool(request.args.get('as_file')) if request.args.get('as_file') else False
+            abbreviated = strtobool(request.args.get('abbreviated')) if request.args.get('abbreviated') else False
 
             project_dto = ProjectService.get_project_dto_for_mapper(project_id,
-                                                                    request.environ.get('HTTP_ACCEPT_LANGUAGE'))
+                                                                    request.environ.get('HTTP_ACCEPT_LANGUAGE'), abbreviated)
             project_dto = project_dto.to_primitive()
 
             if as_file:

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -503,11 +503,14 @@ class Project(db.Model):
 
         return self, base_dto
 
-    def as_dto_for_mapping(self, locale: str) -> Optional[ProjectDTO]:
+    def as_dto_for_mapping(self, locale: str, abbrev: bool) -> Optional[ProjectDTO]:
         """ Creates a Project DTO suitable for transmitting to mapper users """
         project, project_dto = self._get_project_and_base_dto()
 
-        project_dto.tasks = Task.get_tasks_as_geojson_feature_collection(self.id)
+        if abbrev == False:
+            project_dto.tasks = Task.get_tasks_as_geojson_feature_collection(self.id)
+        else:
+            project_dto.tasks = Task.get_tasks_as_geojson_feature_collection_no_geom(self.id)
         project_dto.project_info = ProjectInfo.get_dto_for_locale(self.id, locale, project.default_locale)
 
         return project_dto

--- a/server/models/postgis/task.py
+++ b/server/models/postgis/task.py
@@ -582,6 +582,27 @@ class Task(db.Model):
         return geojson.FeatureCollection(tasks_features)
 
     @staticmethod
+    def get_tasks_as_geojson_feature_collection_no_geom(project_id):
+        """
+        Creates a geoJson.FeatureCollection object for all tasks related to the supplied project ID without geometry
+        :param project_id: Owning project ID
+        :return: geojson.FeatureCollection
+        """
+        project_tasks = \
+            db.session.query(Task.id, Task.x, Task.y, Task.zoom, Task.is_square, Task.task_status) \
+                             .filter(Task.project_id == project_id).all()
+
+        tasks_features = []
+        for task in project_tasks:
+            task_properties = dict(taskId=task.id, taskX=task.x, taskY=task.y, taskZoom=task.zoom,
+                                   taskIsSquare=task.is_square, taskStatus=TaskStatus(task.task_status).name)
+
+            feature = geojson.Feature(properties=task_properties)
+            tasks_features.append(feature)
+
+        return geojson.FeatureCollection(tasks_features)
+
+    @staticmethod
     def get_mapped_tasks_by_user(project_id: int):
         """ Gets all mapped tasks for supplied project grouped by user"""
 

--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -35,7 +35,7 @@ class ProjectService:
         Task.auto_unlock_tasks(project_id)
 
     @staticmethod
-    def get_project_dto_for_mapper(project_id, locale='en') -> ProjectDTO:
+    def get_project_dto_for_mapper(project_id, locale='en', abbrev=False) -> ProjectDTO:
         """
         Get the project DTO for mappers
         :param project_id: ID of the Project mapper has requested
@@ -43,7 +43,7 @@ class ProjectService:
         :raises ProjectServiceError, NotFound
         """
         project = ProjectService.get_project_by_id(project_id)
-        return project.as_dto_for_mapping(locale)
+        return project.as_dto_for_mapping(locale, abbrev)
 
     @staticmethod
     def get_project_tasks(project_id):


### PR DESCRIPTION
Add abbreviated project API. Rerolled PR by @ethan-nelson from #1368 on a local branch, squashed commit messages and based on latest `develop`.

> Please see #1153 for full background
> 
> This PR implements an "abbreviated" project API endpoint that does not contain geometry for the individual tasks and updates to the frontend to handle this. This behavior is only used for routine refreshing (the ~10 second idling refresh when a user is viewing the project screen without any interaction).
> 
> For routine refreshing, this is sufficient to change the states of tasks on a user's screen as they change state in the database. The core exception to this is when tasks are split, which is handled on the frontend by checking the length of the task layer currently loaded versus that sent by the server; if they are not equal, more tasks exist on the server (precisely 3 if a square is split) and it falls back to the original refresh behavior.
> 
> For all other refreshing, i.e. when a user performs an action on a task, the original refresh behavior is retained for that user at that point. This is a pretty conservative approach as it's not probably necessary, but I rather minimize the number of things changed at once. We can always phase in other places where we add this optimization.
> 
> Note this is complementary to possibly other methods of streaming updates between the client and the server, assuming those can fall back to this if that method is not enabled.
> 
> Beyond whether it works or not (I have tested this locally with multiple users doing different actions including splitting), I'm looking for feedback on the frontend code and how it can/whether it should be refactored.

-----

> Update: I did refactor some of the frontend code after I had slept overnight. The changes are now much more minimal. Now, we substitute the function for the 10 second refresh with a new one that tries to do the abbreviated update, and if there's any issue, that function falls back on calling the original. Hopefully this makes it much more straightforward.

