### PR TITLE
Define cascade relation between task history and task invalidation hi…

### DIFF
--- a/server/models/postgis/task.py
+++ b/server/models/postgis/task.py
@@ -111,6 +111,7 @@ class TaskHistory(db.Model):
     action_text = db.Column(db.String)
     action_date = db.Column(db.DateTime, nullable=False, default=timestamp)
     user_id = db.Column(db.BigInteger, db.ForeignKey('users.id', name='fk_users'), nullable=False)
+    invalidation_history = db.relationship(TaskInvalidationHistory, lazy='dynamic', cascade='all')
 
     actioned_by = db.relationship(User)
 


### PR DESCRIPTION
…story

This PR closes #1533. The issue is handled by establishing the relationship between `task_history` and `task_invalidation_history` tables. Thanks to @zlavergne to creating the issue and the solution.

**How to test**
- Create a project.
- On a given task, mark as valid.
- Invalid the mapped task.
- Split the invalid task.

**Quick preview**

![invalid](https://user-images.githubusercontent.com/3285923/57018090-9ac91e80-6be7-11e9-9704-ec62d6666fdd.gif)



