### PR TITLE
Explicitly check that db-snapshot creation was complete

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
     - checkout
     - setup_remote_docker
-    - run: 
+    - run:
         name: Set Environment Variables
         command: |
           echo "export JSON_CONFIG='{\"GitSha\":\"$CIRCLE_SHA1\", \"Environment\":\"staging\", \"DBSnapshot\":\"tm3-staging-deployment-snapshot-latest\", \"DatabaseDump\":\"\", \"NewRelicLicense\":\"$NEW_RELIC_LICENSE\", \"PostgresDB\":\"$POSTGRES_DB_STAGING\", \"PostgresEndpoint\":\"\", \"PostgresPassword\":\"$POSTGRES_PASSWORD_STAGING\", \"PostgresUser\":\"$POSTGRES_USER_STAGING\", \"TaskingManagerAppBaseUrl\":\"$TM_APP_BASE_URL_STAGING\", \"TaskingManagerConsumerKey\":\"$TM_CONSUMER_KEY_STAGING\", \"TaskingManagerConsumerSecret\":\"$TM_CONSUMER_SECRET_STAGING\", \"TaskingManagerSecret\":\"$TM_SECRET_STAGING\", \"TaskingManagerEmailFromAddress\":\"$TM_EMAIL_FROM_ADDRESS_STAGING\", \"TaskingManagerSMTPHost\":\"$TM_SMTP_HOST_STAGING\", \"TaskingManagerSMTPPassword\":\"$TM_SMTP_PASSWORD_STAGING\", \"TaskingManagerSMTPUser\":\"$TM_SMTP_USER_STAGING\", \"TaskingManagerSMTPPort\":\"$TM_SMTP_PORT_STAGING\", \"TaskingManagerLogDirectory\":\"$TM_LOG_DIR_STAGING\",  \"DatabaseSize\":\"$DATABASE_SIZE_STAGING\",\"ELBSubnets\":\"$ELB_SUBNETS_STAGING\", \"SSLCertificateIdentifier\":\"$SSL_CERTIFICATE_ID_STAGING\"}'" >> $BASH_ENV
@@ -130,7 +130,11 @@ jobs:
           fi
           # create new aws rds snapshot
           aws rds create-db-snapshot --db-snapshot-identifier tm3-staging-deployment-snapshot-latest --db-instance-identifier $RDS_ID
-          sleep 2m
+          aws rds wait db-snapshot-completed --db-snapshot-identifier tm3-staging-deployment-snapshot-latest --db-instance-identifier $RDS_ID
+          if [[ $? -eq 255 ]]; then
+            echo "Staging snapshot creation failed. Exiting with exit-code 125"
+            exit 125
+          fi
     - run:
         name: Create config file
         command: |
@@ -158,7 +162,7 @@ jobs:
     steps:
     - checkout
     - setup_remote_docker
-    - run: 
+    - run:
         name: Set Environment Variables
         command: |
           echo "export JSON_CONFIG='{\"GitSha\":\"$CIRCLE_SHA1\", \"Environment\":\"production\", \"DBSnapshot\":\"tm3-production-deployment-snapshot-latest\", \"DatabaseDump\":\"\", \"NewRelicLicense\":\"$NEW_RELIC_LICENSE\", \"PostgresDB\":\"$POSTGRES_DB_PRODUCTION\", \"PostgresEndpoint\":\"\", \"PostgresPassword\":\"$POSTGRES_PASSWORD_PRODUCTION\", \"PostgresUser\":\"$POSTGRES_USER_PRODUCTION\", \"TaskingManagerAppBaseUrl\":\"$TM_APP_BASE_URL_PRODUCTION\", \"TaskingManagerConsumerKey\":\"$TM_CONSUMER_KEY_PRODUCTION\", \"TaskingManagerConsumerSecret\":\"$TM_CONSUMER_SECRET_PRODUCTION\", \"TaskingManagerSecret\":\"$TM_SECRET_PRODUCTION\", \"TaskingManagerEmailFromAddress\":\"$TM_EMAIL_FROM_ADDRESS_PRODUCTION\", \"TaskingManagerSMTPHost\":\"$TM_SMTP_HOST_PRODUCTION\", \"TaskingManagerSMTPPassword\":\"$TM_SMTP_PASSWORD_PRODUCTION\", \"TaskingManagerSMTPUser\":\"$TM_SMTP_USER_PRODUCTION\", \"TaskingManagerSMTPPort\":\"$TM_SMTP_PORT_PRODUCTION\", \"TaskingManagerLogDirectory\":\"$TM_LOG_DIR_PRODUCTION\",  \"DatabaseSize\":\"$DATABASE_SIZE_PRODUCTION\",\"ELBSubnets\":\"$ELB_SUBNETS_PRODUCTION\", \"SSLCertificateIdentifier\":\"$SSL_CERTIFICATE_ID_PRODUCTION\"}'" >> $BASH_ENV
@@ -208,7 +212,11 @@ jobs:
           fi
           # create new aws rds snapshot
           aws rds create-db-snapshot --db-snapshot-identifier tm3-production-deployment-snapshot-latest --db-instance-identifier $RDS_ID
-          sleep 2m
+          aws rds wait db-snapshot-completed --db-snapshot-identifier tm3-production-deployment-snapshot-latest --db-instance-identifier $RDS_ID
+          if [[ $? -eq 255 ]]; then
+            echo "Production snapshot creation failed. Exiting with exit-code 125"
+            exit 125
+          fi
     - run:
         name: Create config file
         command: |
@@ -244,7 +252,7 @@ workflows:
     - deploy-production:
         filters:
           branches:
-            only: 
+            only:
               - master
               - cloudformation
         requires:


### PR DESCRIPTION
https://docs.aws.amazon.com/cli/latest/reference/rds/wait/db-snapshot-completed.html

Used db-snapshot-completed instead of `sleep 2m`. Throws an error and exits if snapshot does not exist.

cc/ @dakotabenjamin 