### PR TITLE
Keep task selection when changes applied

### DIFF
--- a/client/app/project/project.controller.js
+++ b/client/app/project/project.controller.js
@@ -1008,12 +1008,11 @@
                 //A fundamental refactor of this controller should be considered at some stage.
                 vm.resetErrors();
                 vm.resetStatusFlags();
-                vm.resetTaskData();
                 refreshProject(projectId);
                 updateMappedTaskPerUser(projectId);
-                vm.clearCurrentSelection();
                 vm.mappingStep = 'selecting';
                 vm.validatingStep = 'selecting';
+                setUpSelectedTask(data);
 
             }, function (error) {
                 onUnLockError(projectId, error);
@@ -1075,7 +1074,6 @@
                 vm.resetTaskData();
                 refreshProject(projectId);
                 updateMappedTaskPerUser(projectId);
-                vm.clearCurrentSelection();
                 vm.mappingStep = 'selecting';
                 vm.validatingStep = 'selecting';
             }, function (error) {


### PR DESCRIPTION
This Pull request fixes issue #924: When a task is marked as bad imagery, mapped, validated or invalidated, the selection mark of the task is lost.

**Steps for testing**
- Create a project.
- Select task to map.
- Mark task as mapped or bad imagery with or without comments.
- Validate task as valid or invalid

![task_selection](https://user-images.githubusercontent.com/3285923/57105445-61c8a100-6cf0-11e9-9197-ac67b32cc315.gif)


