### PR TITLE
Refactor ci config for multiple branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     working_directory: /home/circleci/app
@@ -74,7 +74,50 @@ jobs:
         paths:
         - client/node_modules
         - env
-  deploy-staging:
+  deploy:
+    parameters:
+      stack_name:
+        description: "the name of the stack for cfn-config"
+        type: string
+      environment_name: 
+        description: "The environment (staging or production) on AWS"
+        type: enum
+        enum: ["staging", "production"]
+      new_relic_license:
+        type: env_var_name
+        default: NEW_RELIC_LICENSE
+      postgres_db: 
+        type: env_var_name
+      postgres_password:
+        type: env_var_name
+      postgres_user:
+        type: env_var_name
+      base_url:
+        type: env_var_name
+      consumer_key:
+        type: env_var_name
+      consumer_secret:
+        type: env_var_name
+      tm_secret:
+        type: env_var_name
+      email_from_address:
+        type: env_var_name
+      smtp_host:
+        type: env_var_name
+      smtp_password:
+        type: env_var_name
+      smtp_user:
+        type: env_var_name
+      smtp_port:
+        type: env_var_name
+      log_dir:
+        type: env_var_name
+      db_size:
+        type: env_var_name
+      elb_subnets:
+        type: env_var_name
+      ssl_cert: 
+        type: env_var_name
     working_directory: /home/circleci/tasking-manager
     docker:
     - image: circleci/python:3-stretch
@@ -84,7 +127,7 @@ jobs:
     - run:
         name: Set Environment Variables
         command: |
-          echo "export JSON_CONFIG='{\"GitSha\":\"$CIRCLE_SHA1\", \"Environment\":\"staging\", \"DBSnapshot\":\"\", \"DatabaseDump\":\"\", \"NewRelicLicense\":\"$NEW_RELIC_LICENSE\", \"PostgresDB\":\"$POSTGRES_DB_STAGING\", \"PostgresPassword\":\"$POSTGRES_PASSWORD_STAGING\", \"PostgresUser\":\"$POSTGRES_USER_STAGING\", \"TaskingManagerAppBaseUrl\":\"$TM_APP_BASE_URL_STAGING\", \"TaskingManagerConsumerKey\":\"$TM_CONSUMER_KEY_STAGING\", \"TaskingManagerConsumerSecret\":\"$TM_CONSUMER_SECRET_STAGING\", \"TaskingManagerSecret\":\"$TM_SECRET_STAGING\", \"TaskingManagerEmailFromAddress\":\"$TM_EMAIL_FROM_ADDRESS_STAGING\", \"TaskingManagerSMTPHost\":\"$TM_SMTP_HOST_STAGING\", \"TaskingManagerSMTPPassword\":\"$TM_SMTP_PASSWORD_STAGING\", \"TaskingManagerSMTPUser\":\"$TM_SMTP_USER_STAGING\", \"TaskingManagerSMTPPort\":\"$TM_SMTP_PORT_STAGING\", \"TaskingManagerLogDirectory\":\"$TM_LOG_DIR_STAGING\",  \"DatabaseSize\":\"$DATABASE_SIZE_STAGING\",\"ELBSubnets\":\"$ELB_SUBNETS_STAGING\", \"SSLCertificateIdentifier\":\"$SSL_CERTIFICATE_ID_STAGING\"}'" >> $BASH_ENV
+          echo "export JSON_CONFIG='{\"GitSha\":\"$CIRCLE_SHA1\", \"Environment\":\"<< parameters.environment_name >>\", \"DBSnapshot\":\"\", \"DatabaseDump\":\"\", \"NewRelicLicense\":\"${<< parameters.new_relic_license >>}\", \"PostgresDB\":\"${<< parameters.postgres_db >>}\", \"PostgresEndpoint\":\"\", \"PostgresPassword\":\"${<< parameters.postgres_password >>}\", \"PostgresUser\":\"${<< parameters.postgres_user >>}\", \"TaskingManagerAppBaseUrl\":\"${<< parameters.base_url >>}\", \"TaskingManagerConsumerKey\":\"${<< parameters.consumer_key >>}\", \"TaskingManagerConsumerSecret\":\"${<< parameters.consumer_secret >>}\", \"TaskingManagerSecret\":\"${<< parameters.tm_secret >>}\", \"TaskingManagerEmailFromAddress\":\"${<< parameters.email_from_address >>}\", \"TaskingManagerSMTPHost\":\"${<< parameters.smtp_host >>}\", \"TaskingManagerSMTPPassword\":\"${<< parameters.smtp_password >>}\", \"TaskingManagerSMTPUser\":\"${<< parameters.smtp_user >>}\", \"TaskingManagerSMTPPort\":\"${<< parameters.smtp_port >>}\", \"TaskingManagerLogDirectory\":\"${<< parameters.log_dir >>}\",  \"DatabaseSize\":\"${<< parameters.db_size >>}\",\"ELBSubnets\":\"${<< parameters.elb_subnets >>}\", \"SSLCertificateIdentifier\":\"${<< parameters.ssl_cert >>}\"}'" >> $BASH_ENV
     - run:
         name: Install Node and modules
         command: |
@@ -115,108 +158,23 @@ jobs:
         name: Get RDS Instance ID
         command: |
           chmod +x .circleci/rdsid.sh
-          RDS_ID=$(./.circleci/rdsid.sh '{"aws:cloudformation:stack-name": "tasking-manager-staging"}')
+          RDS_ID=$(./.circleci/rdsid.sh '{"aws:cloudformation:stack-name": "tasking-manager-<< parameters.stack_name >>"}')
           echo "export RDS_ID=$RDS_ID" >> $BASH_ENV
     - run:
         name: Remove last snapshot and backup database
         command: |
-          DESCRIBE_SNAPSHOT=`aws rds describe-db-snapshots --query "DBSnapshots[? DBSnapshotIdentifier=='tm3-staging-deployment-snapshot-latest']" --output text`
+          DESCRIBE_SNAPSHOT=`aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-deployment-snapshot-latest --db-instance-identifier $RDS_ID --output text`
           # Copy old snapshot to temporary
           if [ -z "$DESCRIBE_SNAPSHOT" ]
           then
               echo "Snapshot does not exist, creating one now."
           else
-              aws rds copy-db-snapshot --source-db-snapshot tm3-staging-deployment-snapshot-latest --target-db-snapshot tm3-staging-deployment-snapshot-temp
-              aws rds delete-db-snapshot --db-snapshot-identifier tm3-staging-deployment-snapshot-latest
+              aws rds copy-db-snapshot --source-db-snapshot tm3-<< parameters.stack_name >>-deployment-snapshot-latest --target-db-snapshot tm3-<< parameters.stack_name >>-deployment-snapshot-temp
+              aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-deployment-snapshot-latest
           fi
           # create new aws rds snapshot
-          aws rds create-db-snapshot --db-snapshot-identifier tm3-staging-deployment-snapshot-latest --db-instance-identifier $RDS_ID
-          aws rds wait db-snapshot-completed --db-snapshot-identifier tm3-staging-deployment-snapshot-latest --db-instance-identifier $RDS_ID
-          if [[ $? -eq 255 ]]; then
-            echo "Staging snapshot creation failed. Exiting with exit-code 125"
-            exit 125
-          fi
-    - run:
-        name: Create config file
-        command: |
-          touch $CIRCLE_WORKING_DIRECTORY/cfn-config-staging.json
-          echo $JSON_CONFIG > $CIRCLE_WORKING_DIRECTORY/cfn-config-staging.json
-    - run:
-        name: S3 Copy $CIRCLE_WORKING_DIRECTORY/cfn-config-staging.json -> s3://hot-cfn-config/tasking-manager/tasking-manager-staging-us-east-1.cfn.json
-        command: aws s3 cp $CIRCLE_WORKING_DIRECTORY/cfn-config-staging.json s3://hot-cfn-config/tasking-manager/tasking-manager-staging-us-east-1.cfn.json
-    - deploy:
-        name: Deploy to staging
-        command: echo $JSON_CONFIG & cfn-config update staging $CIRCLE_WORKING_DIRECTORY/devops/cloudformation/tasking-manager.template.js -f -c hot-cfn-config -t hot-cfn-config -r $AWS_REGION -p "$JSON_CONFIG"
-    - run:
-        name: Cleanup
-        when: always
-        command: |
-          DESCRIBE_SNAPSHOT=`aws rds describe-db-snapshots --query "DBSnapshots[? DBSnapshotIdentifier=='tm3-staging-deployment-snapshot-temp']" --output text`
-          # Copy old snapshot to temporary
-          if [ -z "$DESCRIBE_SNAPSHOT" ]
-          then
-            echo "temporary snapshot doesn't exist, nothing to cleanup."
-          else
-            aws rds delete-db-snapshot --db-snapshot-identifier tm3-staging-deployment-snapshot-temp
-          fi
-  deploy-production:
-    working_directory: /home/circleci/tasking-manager
-    docker:
-    - image: circleci/python:3-stretch
-    steps:
-    - checkout
-    - setup_remote_docker
-    - run:
-        name: Set Environment Variables
-        command: |
-          echo "export JSON_CONFIG='{\"GitSha\":\"$CIRCLE_SHA1\", \"Environment\":\"production\", \"DBSnapshot\":\"\", \"DatabaseDump\":\"\", \"NewRelicLicense\":\"$NEW_RELIC_LICENSE\", \"PostgresDB\":\"$POSTGRES_DB_PRODUCTION\", \"PostgresEndpoint\":\"\", \"PostgresPassword\":\"$POSTGRES_PASSWORD_PRODUCTION\", \"PostgresUser\":\"$POSTGRES_USER_PRODUCTION\", \"TaskingManagerAppBaseUrl\":\"$TM_APP_BASE_URL_PRODUCTION\", \"TaskingManagerConsumerKey\":\"$TM_CONSUMER_KEY_PRODUCTION\", \"TaskingManagerConsumerSecret\":\"$TM_CONSUMER_SECRET_PRODUCTION\", \"TaskingManagerSecret\":\"$TM_SECRET_PRODUCTION\", \"TaskingManagerEmailFromAddress\":\"$TM_EMAIL_FROM_ADDRESS_PRODUCTION\", \"TaskingManagerSMTPHost\":\"$TM_SMTP_HOST_PRODUCTION\", \"TaskingManagerSMTPPassword\":\"$TM_SMTP_PASSWORD_PRODUCTION\", \"TaskingManagerSMTPUser\":\"$TM_SMTP_USER_PRODUCTION\", \"TaskingManagerSMTPPort\":\"$TM_SMTP_PORT_PRODUCTION\", \"TaskingManagerLogDirectory\":\"$TM_LOG_DIR_PRODUCTION\",  \"DatabaseSize\":\"$DATABASE_SIZE_PRODUCTION\",\"ELBSubnets\":\"$ELB_SUBNETS_PRODUCTION\", \"SSLCertificateIdentifier\":\"$SSL_CERTIFICATE_ID_PRODUCTION\"}'" >> $BASH_ENV
-    - run:
-        name: Install Node and modules
-        command: |
-          sudo apt-get update
-          curl -sL https://deb.nodesource.com/setup_10.x | sudo bash -
-          sudo apt-get install -y nodejs libgeos-dev # Required for shapely
-          sudo npm install -g @mapbox/cfn-config @mapbox/cloudfriend
-          npm install
-          sudo pip3 install awscli --upgrade
-    - run:
-        name: Configure AWS Access Key ID
-        command: |
-          aws configure set aws_access_key_id \
-          $AWS_ACCESS_KEY_ID \
-          --profile default
-    - run:
-        name: Configure AWS Secret Access Key
-        command: |
-          aws configure set aws_secret_access_key \
-          $AWS_SECRET_ACCESS_KEY \
-          --profile default
-    - run:
-        name: Configure AWS default region
-        command: |
-          aws configure set region $AWS_REGION \
-          --profile default
-    - run:
-        name: Get RDS Instance ID
-        command: |
-          chmod +x .circleci/rdsid.sh
-          RDS_ID=$(./.circleci/rdsid.sh '{"aws:cloudformation:stack-name": "tasking-manager-production"}')
-          echo "export RDS_ID=$RDS_ID" >> $BASH_ENV
-    - run:
-        name: Remove last snapshot and backup database
-        command: |
-          DESCRIBE_SNAPSHOT=`aws rds describe-db-snapshots --query "DBSnapshots[? DBSnapshotIdentifier=='tm3-production-deployment-snapshot-latest']" --output text`
-          # Copy old snapshot to temporary
-          if [ -z "$DESCRIBE_SNAPSHOT" ]
-          then
-              echo "Snapshot does not exist, creating one now."
-          else
-              aws rds copy-db-snapshot --source-db-snapshot tm3-production-deployment-snapshot-latest --target-db-snapshot tm3-production-deployment-snapshot-temp
-              aws rds delete-db-snapshot --db-snapshot-identifier tm3-production-deployment-snapshot-latest
-          fi
-          # create new aws rds snapshot
-          aws rds create-db-snapshot --db-snapshot-identifier tm3-production-deployment-snapshot-latest --db-instance-identifier $RDS_ID
-          aws rds wait db-snapshot-completed --db-snapshot-identifier tm3-production-deployment-snapshot-latest --db-instance-identifier $RDS_ID
+          aws rds create-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-deployment-snapshot-latest --db-instance-identifier $RDS_ID
+          aws rds wait db-snapshot-completed --db-snapshot-identifier tm3-<< parameters.stack_name >>-deployment-snapshot-latest --db-instance-identifier $RDS_ID
           if [[ $? -eq 255 ]]; then
             echo "Production snapshot creation failed. Exiting with exit-code 125"
             exit 125
@@ -224,42 +182,129 @@ jobs:
     - run:
         name: Create config file
         command: |
-          touch $CIRCLE_WORKING_DIRECTORY/cfn-config-production.json
-          echo $JSON_CONFIG > $CIRCLE_WORKING_DIRECTORY/cfn-config-production.json
-    - run:
-        name: S3 Copy $CIRCLE_WORKING_DIRECTORY/cfn-config-production.json -> s3://hot-cfn-config/tasking-manager/tasking-manager-production-us-east-1.cfn.json
-        command: aws s3 cp $CIRCLE_WORKING_DIRECTORY/cfn-config-production.json s3://hot-cfn-config/tasking-manager/tasking-manager-production-us-east-1.cfn.json
+          touch $CIRCLE_WORKING_DIRECTORY/cfn-config-<< parameters.stack_name >>.json
+          echo $JSON_CONFIG > $CIRCLE_WORKING_DIRECTORY/cfn-config-<< parameters.stack_name >>.json
     - deploy:
-        name: Deploy to production
-        command: echo $JSON_CONFIG & cfn-config update production $CIRCLE_WORKING_DIRECTORY/devops/cloudformation/tasking-manager.template.js -f -c hot-cfn-config -t hot-cfn-config -r $AWS_REGION -p "$JSON_CONFIG"
+        name: Deploy to << parameters.stack_name >>
+        command: echo $JSON_CONFIG & cfn-config update << parameters.stack_name >> $CIRCLE_WORKING_DIRECTORY/devops/cloudformation/tasking-manager.template.js -f -c hot-cfn-config -t hot-cfn-config -r $AWS_REGION -p "$JSON_CONFIG"
     - run:
         name: Cleanup
         when: always
         command: |
-          DESCRIBE_SNAPSHOT=`aws rds describe-db-snapshots --query "DBSnapshots[? DBSnapshotIdentifier=='tm3-production-deployment-snapshot-temp']" --output text`
+          DESCRIBE_SNAPSHOT=`aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-deployment-snapshot-temp --db-instance-identifier $RDS_ID --output text`
           # Copy old snapshot to temporary
           if [ -z "$DESCRIBE_SNAPSHOT" ]
           then
             echo "temporary snapshot doesn't exist, nothing to cleanup."
           else
-            aws rds delete-db-snapshot --db-snapshot-identifier tm3-production-deployment-snapshot-temp
+            aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-deployment-snapshot-temp
           fi
 workflows:
   version: 2
   build-deploy:
     jobs:
     - build
-    - deploy-staging:
+    - deploy:
+        name: staging
         filters:
           branches:
             only:
             - develop
         requires:
         - build
-    - deploy-production:
+        stack_name: "staging"
+        environment_name: "staging"
+        postgres_db: POSTGRES_DB_STAGING
+        postgres_password: POSTGRES_PASSWORD_STAGING
+        postgres_user: POSTGRES_USER_STAGING
+        base_url: TM_APP_BASE_URL_STAGING
+        consumer_key: TM_CONSUMER_KEY_STAGING
+        consumer_secret: TM_CONSUMER_SECRET_STAGING
+        tm_secret: TM_SECRET_STAGING
+        email_from_address: TM_EMAIL_FROM_ADDRESS_STAGING
+        smtp_host: TM_SMTP_HOST_STAGING
+        smtp_password: TM_SMTP_PASSWORD_STAGING
+        smtp_user: TM_SMTP_USER_STAGING
+        smtp_port: TM_SMTP_PORT_STAGING
+        log_dir: TM_LOG_DIR_STAGING
+        db_size: DATABASE_SIZE_STAGING
+        elb_subnets: ELB_SUBNETS_STAGING
+        ssl_cert: SSL_CERTIFICATE_ID_STAGING
+    - deploy:
+        name: production
         filters:
           branches:
             only:
               - master
         requires:
-        - build
+          - build
+        stack_name: "production"
+        environment_name: "production"
+        postgres_db: POSTGRES_DB_PRODUCTION
+        postgres_password: POSTGRES_PASSWORD_PRODUCTION
+        postgres_user: POSTGRES_USER_PRODUCTION
+        base_url: TM_APP_BASE_URL_PRODUCTION
+        consumer_key: TM_CONSUMER_KEY_PRODUCTION
+        consumer_secret: TM_CONSUMER_SECRET_PRODUCTION
+        tm_secret: TM_SECRET_PRODUCTION
+        email_from_address: TM_EMAIL_FROM_ADDRESS_PRODUCTION
+        smtp_host: TM_SMTP_HOST_PRODUCTION
+        smtp_password: TM_SMTP_PASSWORD_PRODUCTION
+        smtp_user: TM_SMTP_USER_PRODUCTION
+        smtp_port: TM_SMTP_PORT_PRODUCTION
+        log_dir: TM_LOG_DIR_PRODUCTION
+        db_size: DATABASE_SIZE_PRODUCTION
+        elb_subnets: ELB_SUBNETS_PRODUCTION
+        ssl_cert: SSL_CERTIFICATE_ID_PRODUCTION
+    - deploy:
+        name: teachosm
+        filters:
+          branches:
+            only:
+              - teachosm
+        requires:
+          - build
+        stack_name: "teachosm"
+        environment_name: "production"
+        postgres_db: POSTGRES_DB_TEACHOSM
+        postgres_password: POSTGRES_PASSWORD_TEACHOSM
+        postgres_user: POSTGRES_USER_TEACHOSM
+        base_url: TM_APP_BASE_URL_TEACHOSM
+        consumer_key: TM_CONSUMER_KEY_TEACHOSM
+        consumer_secret: TM_CONSUMER_SECRET_TEACHOSM
+        tm_secret: TM_SECRET_TEACHOSM
+        email_from_address: TM_EMAIL_FROM_ADDRESS_TEACHOSM
+        smtp_host: TM_SMTP_HOST_TEACHOSM
+        smtp_password: TM_SMTP_PASSWORD_TEACHOSM
+        smtp_user: TM_SMTP_USER_TEACHOSM
+        smtp_port: TM_SMTP_PORT_TEACHOSM
+        log_dir: TM_LOG_DIR_TEACHOSM
+        db_size: DATABASE_SIZE_TEACHOSM
+        elb_subnets: ELB_SUBNETS_TEACHOSM
+        ssl_cert: SSL_CERTIFICATE_ID_TEACHOSM
+    - deploy:
+        name: assisted
+        filters:
+          branches:
+            only:
+              - machine-learning
+        requires:
+          - build
+        stack_name: "assisted"
+        environment_name: "staging"
+        postgres_db: POSTGRES_DB_ASSISTED
+        postgres_password: POSTGRES_PASSWORD_ASSISTED
+        postgres_user: POSTGRES_USER_ASSISTED
+        base_url: TM_APP_BASE_URL_ASSISTED
+        consumer_key: TM_CONSUMER_KEY_ASSISTED
+        consumer_secret: TM_CONSUMER_SECRET_ASSISTED
+        tm_secret: TM_SECRET_ASSISTED
+        email_from_address: TM_EMAIL_FROM_ADDRESS_ASSISTED
+        smtp_host: TM_SMTP_HOST_ASSISTED
+        smtp_password: TM_SMTP_PASSWORD_ASSISTED
+        smtp_user: TM_SMTP_USER_ASSISTED
+        smtp_port: TM_SMTP_PORT_ASSISTED
+        log_dir: TM_LOG_DIR_ASSISTED
+        db_size: DATABASE_SIZE_ASSISTED
+        elb_subnets: ELB_SUBNETS_ASSISTED
+        ssl_cert: SSL_CERTIFICATE_ID_ASSISTED


### PR DESCRIPTION
This refactor does use CircleCI version 2.1, but that enables the reuse of parameters across multiple branches. This has been tested with a `circleci local execute` after processing the config file using `circleci config process`.

It's quite elegant because now there is only one job called `deploy` and it's quite simple to add more branches by simply creating a new workflow job and renaming the parameters. 

Before rebasing the `machine-learning` and `assisted` branches we should make sure the variables are all set correctly in CircleCI. 