### PR TITLE
fix when Invalidating badimagery tasks

### DIFF
--- a/server/models/postgis/task.py
+++ b/server/models/postgis/task.py
@@ -299,7 +299,7 @@ class TaskHistory(db.Model):
             .filter(TaskHistory.project_id == project_id,
                     TaskHistory.task_id == task_id,
                     TaskHistory.action == TaskAction.STATE_CHANGE.name,
-                    TaskHistory.action_text == TaskStatus.MAPPED.name) \
+                    TaskHistory.action_text.in_([TaskStatus.BADIMAGERY.name, TaskStatus.MAPPED.name])) \
             .order_by(TaskHistory.action_date.desc()).first()
 
 class Task(db.Model):


### PR DESCRIPTION
This pull request fixes issue #1552. The **get_last_mapped_action** method from TaskHistory class returned only tasks with MAPPED status, making the error defined in the issue for BADIMAGERY ones.

**How to test:**
- Create a project.
- Map some tasks as bad imagery.
- When validating mark task as invalid.

![invalid](https://user-images.githubusercontent.com/3285923/57421381-2424b600-71d1-11e9-969c-dcb9b3d3df2e.gif)

