### PR TITLE
Cfn ci snapshot ids

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,18 +163,18 @@ jobs:
     - run:
         name: Remove last snapshot and backup database
         command: |
-          DESCRIBE_SNAPSHOT=`aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-deployment-snapshot-latest --db-instance-identifier $RDS_ID --output text`
+          DESCRIBE_SNAPSHOT=`aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest --db-instance-identifier $RDS_ID --output text`
           # Copy old snapshot to temporary
           if [ -z "$DESCRIBE_SNAPSHOT" ]
           then
               echo "Snapshot does not exist, creating one now."
           else
-              aws rds copy-db-snapshot --source-db-snapshot tm3-<< parameters.stack_name >>-deployment-snapshot-latest --target-db-snapshot tm3-<< parameters.stack_name >>-deployment-snapshot-temp
-              aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-deployment-snapshot-latest
+              aws rds copy-db-snapshot --source-db-snapshot tm3-<< parameters.stack_name >>-$RDS_ID-latest --target-db-snapshot tm3-<< parameters.stack_name >>-$RDS_ID-temp
+              aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest
           fi
           # create new aws rds snapshot
-          aws rds create-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-deployment-snapshot-latest --db-instance-identifier $RDS_ID
-          aws rds wait db-snapshot-completed --db-snapshot-identifier tm3-<< parameters.stack_name >>-deployment-snapshot-latest --db-instance-identifier $RDS_ID
+          aws rds create-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest --db-instance-identifier $RDS_ID
+          aws rds wait db-snapshot-completed --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest --db-instance-identifier $RDS_ID
           if [[ $? -eq 255 ]]; then
             echo "Production snapshot creation failed. Exiting with exit-code 125"
             exit 125
@@ -191,13 +191,13 @@ jobs:
         name: Cleanup
         when: always
         command: |
-          DESCRIBE_SNAPSHOT=`aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-deployment-snapshot-temp --db-instance-identifier $RDS_ID --output text`
+          DESCRIBE_SNAPSHOT=`aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-temp --db-instance-identifier $RDS_ID --output text`
           # Copy old snapshot to temporary
           if [ -z "$DESCRIBE_SNAPSHOT" ]
           then
             echo "temporary snapshot doesn't exist, nothing to cleanup."
           else
-            aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-deployment-snapshot-temp
+            aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-temp
           fi
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,7 @@ jobs:
           echo "export RDS_ID=$RDS_ID" >> $BASH_ENV
     - run:
         name: Remove last snapshot and backup database
+        no_output_timeout: 15m
         command: |
           DESCRIBE_SNAPSHOT=`aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest --db-instance-identifier $RDS_ID --output text`
           # Copy old snapshot to temporary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,12 @@ jobs:
           else
             aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-temp
           fi
+          # Delete manual snapshot if database ID changed
+          RDS_ID_NEW=$(./.circleci/rdsid.sh '{"aws:cloudformation:stack-name": "tasking-manager-<< parameters.stack_name >>"}')
+          if [ "$RDS_ID" != "$RDS_ID_NEW" ]
+          then
+            aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest
+          fi
 workflows:
   version: 2
   build-deploy:


### PR DESCRIPTION
This PR solves a deployment issue where the RDS instance has changed (thus has a new ID), but the manual snapshots of the old RDS instance have not been deleted. This caused the deployment to fail because the snapshot names were not unique to the database instance. The script checks for a snapshot for the new database, finds none, and attempts to make a new snapshot with the same name as the old snapshot. Snapshot IDs have to be unique, so the command fails. 

In this PR, I make snapshot names unique to avoid that issue. I also check in the cleanup step if the database instance has been changed, and delete the manual snapshot `tm3-<< parameters.stack_name >>-$RDS_ID-latest`