### PR TITLE
Get project aoi from service in overpass function

### DIFF
--- a/client/app/profile/profile.controller.js
+++ b/client/app/profile/profile.controller.js
@@ -7,9 +7,9 @@
      */
     angular
         .module('taskingManager')
-        .controller('profileController', ['$routeParams', '$location', '$window', 'NgTableParams', 'accountService','authService','mapService','projectMapService','userService', 'taskService', 'geospatialService', 'messageService','settingsService', profileController]);
+        .controller('profileController', ['$routeParams', '$location', '$window', 'NgTableParams', 'accountService','authService','mapService', 'projectService', 'projectMapService','userService', 'taskService', 'geospatialService', 'messageService','settingsService', profileController]);
 
-    function profileController($routeParams, $location, $window, NgTableParams, accountService, authService, mapService, projectMapService, userService, taskService, geospatialService, messageService, settingsService) {
+    function profileController($routeParams, $location, $window, NgTableParams, accountService, authService, mapService, projectService, projectMapService, userService, taskService, geospatialService, messageService, settingsService) {
 
         var vm = this;
         vm.username = '';
@@ -249,18 +249,24 @@
          * View project for user and bounding box in Overpass Turbo
          * @param aoi
          */
-        vm.viewOverpassTurbo = function (aoi) {
-            var feature = geospatialService.getFeatureFromGeoJSON(aoi);
-            var olExtent = feature.getGeometry().getExtent();
-            var bboxArray = geospatialService.transformExtentToLatLonArray(olExtent);
-            var bbox = 'w="' + bboxArray[0] + '" s="' + bboxArray[1] + '" e="' + bboxArray[2] + '" n="' + bboxArray[3] + '"';
-            var queryPrefix = '<osm-script output="json" timeout="25"><union>';
-            var querySuffix = '</union><print mode="body"/><recurse type="down"/><print mode="skeleton" order="quadtile"/></osm-script>';
-            var queryMiddle = '<query type="node"><user name="' + vm.username + '"/><bbox-query ' + bbox + '/></query>' +
-                '<query type="way"><user name="' + vm.username + '"/><bbox-query ' + bbox + '/></query>' +
-                '<query type="relation"><user name="' + vm.username + '"/><bbox-query ' + bbox + '/></query>';
-            var query = queryPrefix + queryMiddle + querySuffix;
-            $window.open('http://overpass-turbo.eu/map.html?Q=' + encodeURIComponent(query));
+        vm.viewOverpassTurbo = function (project_id) {
+            var promise = projectService.getAOIServer(project_id);
+            var tabWindow = $window.open('', '_blank');
+            promise.then(function(aoi) {
+
+                var feature = geospatialService.getFeatureFromGeoJSON(aoi);
+                var olExtent = feature.getGeometry().getExtent();
+                var bboxArray = geospatialService.transformExtentToLatLonArray(olExtent);
+                var bbox = 'w="' + bboxArray[0] + '" s="' + bboxArray[1] + '" e="' + bboxArray[2] + '" n="' + bboxArray[3] + '"';
+                var queryPrefix = '<osm-script output="json" timeout="25"><union>';
+                var querySuffix = '</union><print mode="body"/><recurse type="down"/><print mode="skeleton" order="quadtile"/></osm-script>';
+                var queryMiddle = '<query type="node"><user name="' + vm.username + '"/><bbox-query ' + bbox + '/></query>' +
+                    '<query type="way"><user name="' + vm.username + '"/><bbox-query ' + bbox + '/></query>' +
+                    '<query type="relation"><user name="' + vm.username + '"/><bbox-query ' + bbox + '/></query>';
+
+                var query = queryPrefix + queryMiddle + querySuffix;
+                tabWindow.location.href = 'http://overpass-turbo.eu/map.html?Q=' + encodeURIComponent(query);
+            });
         };
 
 

--- a/client/app/profile/profile.html
+++ b/client/app/profile/profile.html
@@ -310,7 +310,7 @@
                                 <td>{{ project.tasksMapped }}</td>
                                 <td>{{ project.tasksValidated }}</td>
                                 <td>{{ project.status }}</td>
-                                <td><a href="" ng-click="profileCtrl.viewOverpassTurbo(project.aoi)">{{ 'View in Overpass Turbo' | translate }}</a></td>
+                                <td><a href="" ng-click="profileCtrl.viewOverpassTurbo(project.projectId)">{{ 'View in Overpass Turbo' | translate }}</a></td>
                             </tr>
                             </tbody>
                         </table>

--- a/client/app/services/project.service.js
+++ b/client/app/services/project.service.js
@@ -39,6 +39,7 @@
             createProject: createProject,
             setAOI: setAOI,
             getAOI: getAOI,
+            getAOIServer: getAOIServer,
             splitTasks: splitTasks,
             getProject: getProject,
             getProjectMetadata: getProjectMetadata,
@@ -212,6 +213,27 @@
          */
         function getAOI() {
             return aoi;
+        }
+
+        function getAOIServer(id) {
+
+            // Returns a promise
+            return $http({
+                method: 'GET',
+                url: configService.tmAPI + '/project/' + id + '/aoi?as_file=false',
+                headers: {
+                    'Content-Type': 'application/json; charset=UTF-8'
+                }
+            }).then(function successCallback(response) {
+                // this callback will be called asynchronously
+                // when the response is available
+                return response.data;
+            }, function errorCallback() {
+                // called asynchronously if an error occurs
+                // or server returns response with an error status.
+                return $q.reject("error");
+            });
+
         }
 
         /**


### PR DESCRIPTION
This PR fixes #1529. In the profile view, when the overpass function is executed for a given project, there will be a call to the server to get the project aoi. Then this information is used to create the overpass turbo url