### PR TITLE
Optimize gulp watch 

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -32,8 +32,8 @@ gulp.task('browser-sync', function () {
 
         // Specify list of files to watch for changes, apparently reload method doesn't work on Windows */
     var filesToWatch = [
-            './**/*.html',
-            './**/*.js'
+            './app/**/*.html',
+            './app/**/*.js'
         ];
 
     // Create a rewrite rule that redirects to index.html to let Angular handle the routing


### PR DESCRIPTION
Optimize gulp watch to only track files inside our project and not the whole node_modules dir, it uses less CPU this way.