### PR TITLE
Keep task history when task is validated

### DIFF
--- a/client/app/project/project.controller.js
+++ b/client/app/project/project.controller.js
@@ -1145,6 +1145,8 @@
                 updateMappedTaskPerUser(projectId);
                 vm.mappingStep = 'selecting';
                 vm.validatingStep = 'selecting';
+                vm.selectedTaskData = data[0];
+                formatHistoryComments(vm.selectedTaskData.taskHistory);
             }, function (error) {
                 onUnLockError(projectId, error);
             });


### PR DESCRIPTION
This Pull request modifies the `unlockTaskValidation` function within the client with the purpose of keeping the task history after it is validated.

**How to test**
- Create a project.
- Select a task and select as bad imagery or mapped.
- Go to validation tab.
- Mark as valid or invalid

The reviewer should see the task history, without additional action.

![invalid](https://user-images.githubusercontent.com/3285923/58261794-9bfcef80-7d3e-11e9-9787-7f3304b544ab.gif)
