### PR TITLE
Reset status to ready when map has been previously validated

### DIFF
--- a/server/models/postgis/task.py
+++ b/server/models/postgis/task.py
@@ -261,6 +261,10 @@ class TaskHistory(db.Model):
             # We're looking for the previous status, however, there isn't any so we'll return Ready
             return TaskStatus.READY
 
+        if for_undo and result[0][0] in [TaskStatus.MAPPED.name, TaskStatus.BADIMAGERY.name]:
+            # We need to return a READY when last status of the task is badimagery or mapped.
+            return TaskStatus.READY
+
         if for_undo:
             # Return the second last status which was status the task was previously set to
             return TaskStatus[result[1][0]]


### PR DESCRIPTION
This Pull request fixes the following issue:

When a project task has been previously validated, it becomes impossible to reset the task status to READY, because the current method returns the second-last status that the task has. 

The commit checks on an un-mark request to return a READY when the current status of the task is set to BADIMAGERY or MAPPED

**Steps:**
1. Create a project.
2. Set a task status to MAPPED or BADIMAGERY.
3. Unmark the task. You will see on history that the the task has now a status of READY.
4. Map a task and validate it.
5. Unmark the task. It will now have a MAPPED or BADIMAGERY status.
6. Unmark again the task. It will now have a ready status.

![to_ready](https://user-images.githubusercontent.com/3285923/58435789-e0aec080-8087-11e9-9495-94b2f52c6c03.gif)


