### PR TITLE
Activity & Stats page enhancements

### DIFF
--- a/client/app/components/account-nav/account-nav.directive.js
+++ b/client/app/components/account-nav/account-nav.directive.js
@@ -129,6 +129,14 @@
         };
 
         /**
+         * Navigate to the activity page for all projects
+         */
+        vm.goToAllActivity = function () {
+            $location.path('projects/activity');
+            vm.showDropdown = false;
+        };
+
+        /**
          * Navigate to the user list page
          */
         vm.goToUserList = function () {

--- a/client/app/components/account-nav/account-nav.html
+++ b/client/app/components/account-nav/account-nav.html
@@ -60,6 +60,11 @@
                         {{ 'Project dashboard' | translate }}
                     </a>
                 </li>
+                <li ng-show="accountNavCtrl.account.role === 'VALIDATOR' || accountNavCtrl.account.role === 'PROJECT_MANAGER' || accountNavCtrl.account.role === 'ADMIN'">
+                    <a title="{{ 'Activity accross all projects' | translate }}" class="drop__menu-item" ng-click="accountNavCtrl.goToAllActivity()">
+                        {{ 'All Activity' | translate }}
+                    </a>
+                </li>
                 <li ng-show="accountNavCtrl.account.role === 'PROJECT_MANAGER' || accountNavCtrl.account.role === 'ADMIN'">
                     <a title="{{ 'New project' | translate }}" class="drop__menu-item" ng-click="accountNavCtrl.goToCreateNewProject()">
                         {{ 'Create new Project' | translate }}

--- a/client/app/project/project-dashboard.controller.js
+++ b/client/app/project/project-dashboard.controller.js
@@ -7,11 +7,11 @@
      */
     angular
         .module('taskingManager')
-        .controller('projectDashboardController', ['$scope', '$routeParams', 'NgTableParams', 'mapService', 'projectMapService', 'projectService', 'statsService', 'configService', 'TaskStatus', projectDashboardController]);
+        .controller('projectDashboardController', ['$scope', '$routeParams', 'NgTableParams', 'projectService', 'statsService', 'configService', 'TaskStatus', projectDashboardController]);
 
 
 
-    function projectDashboardController($scope, $routeParams, NgTableParams, mapService, projectMapService, projectService, statsService, configService, TaskStatus) {
+    function projectDashboardController($scope, $routeParams, NgTableParams, projectService, statsService, configService, TaskStatus) {
         var vm = this;
         $scope.TaskStatus = TaskStatus;
         $scope.tmAPI = configService.tmAPI;
@@ -107,13 +107,9 @@
             vm.singleProject = vm.projectId > 0;
 
             if (vm.singleProject) {
-              mapService.createOSMMap('map');
-              vm.map = mapService.getOSMMap();
-
               getProjectStats(vm.projectId);
               getComments(vm.projectId);
               getProjectContributions(vm.projectId);
-              projectMapService.initialise(vm.map);
             }
         }
 
@@ -127,7 +123,6 @@
                 vm.project = data;
                 var customColours = false;
                 var zoomToProject = true;
-                projectMapService.showProjectOnMap(vm.project, vm.project.aoiCentroid, customColours, zoomToProject);
                 vm.statusStats = taskStatusStats();
             }, function(data){
                // TODO

--- a/client/app/project/project-dashboard.html
+++ b/client/app/project/project-dashboard.html
@@ -6,97 +6,44 @@
                     <h1 class="section__title">
                     {{ 'Activity and Stats' | translate }}
                     </h1>
-                    <a
+                    <a ng-if="projectDashboardCtrl.singleProject"
                         class="heading-alt">#{{ projectDashboardCtrl.projectId }} - {{ projectDashboardCtrl.project.name }}
                     </a>
+                    <h3 ng-if="!projectDashboardCtrl.singleProject">
+                        {{ 'All Published Projects' | translate }}
+                    </h3>
                 </div>
-                <a class="button button--outline pull-right" ng-href="/project/{{ projectDashboardCtrl.projectId }}">
+                <a ng-if="projectDashboardCtrl.singleProject"
+                   class="button button--outline pull-right" ng-href="/project/{{ projectDashboardCtrl.projectId }}">
                      {{ 'Return to project' | translate }}
                 </a>
             </div>
         </header>
-        <div class="section-container">
+        <div ng-if="projectDashboardCtrl.singleProject" class="section-container">
             <div class="section__body">
                 <div class="inner">
                     <div class="dashboard-container">
-                        <div class="left">
-                            <h2>{{ 'Last activity' | translate }}</h2>
-                            <div class="content">
-                                <p ng-show="!projectDashboardCtrl.projectActivity.length > 0">{{ 'No activity (yet).' | translate }}</p>
-                                <table ng-show="projectDashboardCtrl.projectActivity.length > 0" class="table table-dashboard-project-activity">
-                                    <thead>
-                                        <tr>
-                                            <th>{{ 'Action' | translate }}</th>
-                                            <th>{{ 'User' | translate }}</th>
-                                            <th>{{ 'When' | translate }}</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <tr ng-repeat="item in projectDashboardCtrl.projectActivity">
-                                            <td>
-                                                <span class="status-marker-locked-for-mapping" ng-show="item.action === 'LOCKED_FOR_MAPPING'">{{ 'Task locked for mapping' | translate }}</span>
-                                                <span class="status-marker-locked-for-validation" ng-show="item.action === 'LOCKED_FOR_VALIDATION'">{{ 'Task locked for validation' | translate }}</span>
-                                                <span class="status-marker-auto-unlocked-for-mapping" ng-show="item.action === 'AUTO_UNLOCKED_FOR_MAPPING'">{{ 'Task automatically unlocked for mapping' | translate }}</span>
-                                                <span class="status-marker-auto-unlocked-for-validation" ng-show="item.action === 'AUTO_UNLOCKED_FOR_VALIDATION'">{{ 'Task automatically unlocked for validation' | translate }}</span>
-                                                <span class="status-marker-badimagery" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'BADIMAGERY'">{{ 'Task marked as bad imagery' | translate }}</span>
-                                                <span class="status-marker-mapped" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'MAPPED'">{{ 'Task mapped' | translate }}</span>
-                                                <span class="status-marker-validated" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'VALIDATED'">{{ 'Task validated' | translate }}</span>
-                                                <span class="status-marker-invalidated" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'INVALIDATED'">{{ 'Task invalidated' | translate }}</span>
-                                                <span class="status-marker-split" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'SPLIT'">{{ 'Task split' | translate }}</span>
-                                                <span class="status-marker-ready" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'READY'">{{ 'Task marked as ready' | translate }}</span>
-                                            </td>
-                                            <td>
-                                                <a href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a>
-                                            </td>
-                                            <td>
-                                                <span tm-timestamp="item.actionDate"></span>
-                                            </td>
-                                        </tr>
-                                  </tbody>
-                                </table>
-                                <button class="button button--achromic"
-                                    ng-class="!projectDashboardCtrl.projectActivityPagination.hasPrev ? 'disabled' : ''"
-                                    ng-click="projectDashboardCtrl.getLastActivity(projectDashboardCtrl.projectActivityPagination.prevNum)">
-                                    {{ 'Newer' | translate }}
-                                </button>
-                                <button class="button button--achromic"
-                                    ng-class="!projectDashboardCtrl.projectActivityPagination.hasNext ? 'disabled' : ''"
-                                    ng-click="projectDashboardCtrl.getLastActivity(projectDashboardCtrl.projectActivityPagination.nextNum)">
-                                    {{ 'Older' | translate }}
-                                </button>
-                            </div>
-                        </div>
-                        <div class="right">
-                            <h2>{{ 'Contributions' | translate }}</h2>
-                            <div class="content">
-                                <p ng-show="!projectDashboardCtrl.projectContributions.length > 0">{{ 'No contributions (yet).' | translate }}</p>
-                                <table ng-show="projectDashboardCtrl.projectContributions.length > 0" class="table table-dashboard-comments">
-                                    <thead>
-                                        <tr>
-                                            <th>{{ 'User' | translate }}</th>
-                                            <th>{{ 'Mapped' | translate }}</th>
-                                            <th>{{ 'Validated' | translate }}</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <tr ng-repeat="item in projectDashboardCtrl.projectContributions | orderBy: '-mapped'">
-                                            <td><a ng-href="/user/{{ item.username }}">{{ item.username }}</a></td>
-                                            <td>{{ item.mapped }}</td>
-                                            <td>{{ item.validated }}</td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="section-container">
-            <div class="section__body">
-                <div class="inner">
-                    <div class="dashboard-container">
+                        <a ng-href="{{ tmAPI }}/stats/project/{{ projectDashboardCtrl.projectId }}?as_csv=true"
+                           target="_blank"
+                           class="button button--sm button--outline--secondary pull-right">
+                            {{ 'Export CSV' | translate }}
+                        </a>
                         <h2>{{ 'Stats' | translate }}</h2>
+                        <div class="clearfix"></div>
+
+                        <p class="metadata">
+                            {{ "Note: stats may be up to 10 minutes old" | translate }}
+                        </p>
+
+                        <ul class="list-type--none">
+                            <li>
+                                <strong>{{ "Total Tasks:" | translate }} {{ projectDashboardCtrl.project.totalTasks }}</strong>
+                            </li>
+                            <li>
+                                {{ "Tasks Removed:" | translate }} {{ projectDashboardCtrl.project.tasksDeleted }}
+                            </li>
+                        </ul>
+
                         <div class="left">
                             <div class="section__project-dashboard--stats">
                                 <span class="label">{{ projectDashboardCtrl.project.percentMapped }}{{ '% Mapped' | translate }}</span>
@@ -107,12 +54,144 @@
                         </div>
                         <div class="right">
                             <div id="map" class="map-container"></div>
+
+                        </div>
+
+                        <div class="content">
+                            <table class="table table-dashboard-comments">
+                                <thead>
+                                    <tr>
+                                        <th>{{ 'Current Status' | translate }}</th>
+                                        <th>{{ 'Count' | translate }}</th>
+                                        <th>{{ 'Percent' | translate }}</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr ng-repeat="statusStats in projectDashboardCtrl.statusStats">
+                                        <td>{{ statusStats.title | translate }}</td>
+                                        <td>{{ statusStats.count }}</td>
+                                        <td>{{ statusStats.percent === null ? '--' : statusStats.percent }}%</td>
+                                    </tr>
+                                </tbody>
+                            </table>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
         <div class="section-container">
+            <div class="section__body">
+                <div class="inner">
+                    <div class="dashboard-container">
+                        <a ng-href="{{ tmAPI }}/stats/project/{{ projectDashboardCtrl.singleProject ? projectDashboardCtrl.projectId : 'all' }}/overview?as_csv=true"
+                           target="_blank"
+                           class="button button--sm button--outline--secondary pull-right">
+                            {{ 'Export CSV' | translate }}
+                        </a>
+                        <h2>{{ 'Status Overview' | translate }}</h2>
+                        <div class="clearfix"></div>
+
+                        <table ng-table="projectDashboardCtrl.overviewTableSettings" class="table table-dashboard-status-overview">
+                            <tr ng-repeat="item in $data">
+                              <td ng-if="!projectDashboardCtrl.singleProject" title="'Project' | translate" filter="{projectTitle: 'text'}">
+                                  <a ng-href="/project/{{ item.projectId }}?tab=chat">{{ item.projectTitle }}</a>
+                              </td>
+                              <td title="'Status' | translate" filter="projectDashboardCtrl.statusFilterDefinition" filter-data="projectDashboardCtrl.statusFilterLabels">
+                                <span class="status-marker-locked-for-mapping" ng-show="item.taskStatus === TaskStatus.LOCKED_FOR_MAPPING.value">{{ TaskStatus.LOCKED_FOR_MAPPING.title | translate }}</span>
+                                <span class="status-marker-locked-for-validation" ng-show="item.taskStatus === TaskStatus.LOCKED_FOR_VALIDATION.value">{{ TaskStatus.LOCKED_FOR_VALIDATION.title | translate }}</span>
+                                <span class="status-marker-badimagery" ng-show="item.taskStatus === TaskStatus.BADIMAGERY.value">{{ TaskStatus.BADIMAGERY.title | translate }}</span>
+                                <span class="status-marker-mapped"ng-show="item.taskStatus === TaskStatus.MAPPED.value">{{ TaskStatus.MAPPED.title | translate }}</span>
+                                <span class="status-marker-validated" ng-show="item.taskStatus === TaskStatus.VALIDATED.value">{{ TaskStatus.VALIDATED.title | translate }}</span>
+                                <span class="status-marker-invalidated" ng-show="item.taskStatus === TaskStatus.INVALIDATED.value">{{ TaskStatus.INVALIDATED.title | translate }}</span>
+                                  <span class="status-marker-ready" ng-show="item.taskStatus === TaskStatus.READY.value">{{ TaskStatus.READY.title | translate }}</span>
+                                  <span class="status-marker-split" ng-show="item.taskStatus === TaskStatus.SPLIT.value">{{ TaskStatus.SPLIT.title | translate }}</span>
+                              </td>
+                              <td title="'Mapper' | translate" filter="{mapperName: 'text'}">
+                                <a href="/user/{{ item.mapperName }}">{{ item.mapperName }}</a>
+                              </td>
+                              <td title="'Validator' | translate" filter="{validatorName: 'text'}">
+                                  <a href="/user/{{ item.validatorName }}">{{ item.validatorName }}</a>
+                              </td>
+                              <td title="'Updated' | translate" sortable="'updatedDate'">
+                                  <span ng-show="item.updatedDate !== null" am-time-ago="item.updatedDate | amUtc | amLocal" />
+                              </td>
+                              <td title="'Task Link' | translate" sortable="'taskId'">
+                                  <a href="/project/{{ item.projectId }}?task={{ item.taskId}}" target="_blank" rel="noopener">Task {{ item.taskId }}</a>
+                              </td>
+                            </tr>
+                        </table>
+                        <p ng-show="!projectDashboardCtrl.projectOverview.length > 0">{{ 'No tasks.' | translate }}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="section-container">
+            <div class="section__body">
+                <div class="inner">
+                    <div class="dashboard-container">
+                        <h2>{{ 'Last activity' | translate }}</h2>
+                        <table ng-table="projectDashboardCtrl.activityTableSettings" class="table table-dashboard-project-activity">
+                            <tr ng-repeat="item in $data">
+                              <td ng-if="!projectDashboardCtrl.singleProject" title="'Project' | translate" filter="{projectTitle: 'text'}">
+                                  <a ng-href="/project/{{ item.projectId }}?tab=chat">{{ item.projectTitle }}</a>
+                              </td>
+                              <td title="'Action' | translate" filter="projectDashboardCtrl.statusFilterDefinition" filter-data="projectDashboardCtrl.statusFilterLabels">
+                                  <span class="status-marker-locked-for-mapping" ng-show="item.action === 'LOCKED_FOR_MAPPING'">{{ 'Task locked for mapping' | translate }}</span>
+                                  <span class="status-marker-locked-for-validation" ng-show="item.action === 'LOCKED_FOR_VALIDATION'">{{ 'Task locked for validation' | translate }}</span>
+                                      <span class="status-marker-auto-unlocked-for-mapping" ng-show="item.action === 'AUTO_UNLOCKED_FOR_MAPPING'">{{ 'Task automatically unlocked for mapping' | translate }}</span>
+                                      <span class="status-marker-auto-unlocked-for-validation" ng-show="item.action === 'AUTO_UNLOCKED_FOR_VALIDATION'">{{ 'Task automatically unlocked for validation' | translate }}</span>
+                                  <span class="status-marker-badimagery" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'BADIMAGERY'">{{ 'Task marked as bad imagery' | translate }}</span>
+                                  <span class="status-marker-mapped"ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'MAPPED'">{{ 'Task mapped' | translate }}</span>
+                                  <span class="status-marker-validated" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'VALIDATED'">{{ 'Task validated' | translate }}</span>
+                                  <span class="status-marker-invalidated" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'INVALIDATED'">{{ 'Task invalidated' | translate }}</span>
+                                  <span class="status-marker-ready" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'READY'">{{ 'Task marked as ready' | translate }}</span>
+                                  <span class="status-marker-split" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'SPLIT'">{{ 'Task created via split' | translate }}</span>
+                              </td>
+                              <td title="'By User' | translate" filter="{actionBy: 'text'}">
+                                  <a href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a>
+                              </td>
+                              <td title="'When' | translate" sortable="'actionDate'">
+                                  <span am-time-ago="item.actionDate | amUtc | amLocal" />
+                              </td>
+                              <td title="'Task Link' | translate">
+                                  <a href="/project/{{ item.projectId }}?task={{ item.taskId}}" target="_blank" rel="noopener">Task {{ item.taskId }}</a>
+                              </td>
+                            </tr>
+                        </table>
+                        <p ng-show="!projectDashboardCtrl.projectActivity.length > 0">{{ 'No activity.' | translate }}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div ng-if="projectDashboardCtrl.singleProject" class="section-container">
+            <div class="section__body">
+                <div class="inner">
+                    <div class="dashboard-container">
+                        <h2>{{ 'Contributions' | translate }}</h2>
+                        <div class="content">
+                            <p ng-show="!projectDashboardCtrl.projectContributions.length > 0">{{ 'No contributions (yet).' | translate }}</p>
+                            <table ng-show="projectDashboardCtrl.projectContributions.length > 0" class="table table-dashboard-comments">
+                                <thead>
+                                    <tr>
+                                        <th>{{ 'User' | translate }}</th>
+                                        <th>{{ 'Mapped' | translate }}</th>
+                                        <th>{{ 'Validated' | translate }}</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr ng-repeat="item in projectDashboardCtrl.projectContributions | orderBy: '-mapped'">
+                                        <td><a ng-href="/user/{{ item.username }}">{{ item.username }}</a></td>
+                                        <td>{{ item.mapped }}</td>
+                                        <td>{{ item.validated }}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div ng-if="projectDashboardCtrl.singleProject" class="section-container">
             <div class="section__body">
                 <div class="inner">
                     <h2>{{ 'Comments by users' | translate }}</h2>

--- a/client/app/project/project-dashboard.html
+++ b/client/app/project/project-dashboard.html
@@ -44,17 +44,11 @@
                             </li>
                         </ul>
 
-                        <div class="left">
-                            <div class="section__project-dashboard--stats">
+                        <div class="section__project-dashboard--stats">
                                 <span class="label">{{ projectDashboardCtrl.project.percentMapped }}{{ '% Mapped' | translate }}</span>
                                 <uib-progressbar value="projectDashboardCtrl.project.percentMapped"></uib-progressbar>
                                 <span class="label">{{ projectDashboardCtrl.project.percentValidated }}{{ '% Validated' | translate }}</span>
                                 <uib-progressbar value="projectDashboardCtrl.project.percentValidated"></uib-progressbar>
-                            </div>
-                        </div>
-                        <div class="right">
-                            <div id="map" class="map-container"></div>
-
                         </div>
 
                         <div class="content">

--- a/client/app/services/stats.service.js
+++ b/client/app/services/stats.service.js
@@ -6,13 +6,14 @@
 
     angular
         .module('taskingManager')
-        .service('statsService', ['$http', '$q','configService', statsService]);
+        .service('statsService', ['$http', '$q','configService', 'authService', statsService]);
 
-    function statsService($http, $q, configService) {
+    function statsService($http, $q, configService, authService) {
 
         var service = {
             getProjectContributions: getProjectContributions,
             getProjectActivity: getProjectActivity,
+            getProjectOverview: getProjectOverview,
             getProjectStats: getProjectStats,
             getHomePageStats: getHomePageStats
         };
@@ -41,21 +42,115 @@
         }
 
         /**
-         * Get the project activity
+         * Get the latest project overview. This method performs double-duty,
+         * handling both single project and all-project overview (with optional
+         * project filter)
          * @param projectId
          * @param page - optional
          * @returns {!jQuery.deferred|!jQuery.jqXHR|*|!jQuery.Promise}
          */
-        function getProjectActivity(projectId, page){
-            var pageToGet = '';
+        function getProjectOverview(projectId, page, pageSize, sortBy, sortDirection, mapperNameFilter, validatorNameFilter, statusFilter, projectFilter){
+            var params = '?pageSize=' + (pageSize ? pageSize : '10');
             if (page) {
-                pageToGet = '?page=' + page;
+                params += '&page=' + page;
+            }
+
+            if (mapperNameFilter) {
+                params += "&mapperName=" + encodeURIComponent(mapperNameFilter);
+            }
+
+            if (validatorNameFilter) {
+                params += "&validatorName=" + encodeURIComponent(validatorNameFilter);
+            }
+
+            if (typeof statusFilter === 'number') {
+                params += "&status=" + statusFilter;
+            }
+
+            // project filter for all-projects activity
+            if (projectFilter) {
+                params += "&projectTitle=" + encodeURIComponent(projectFilter);
+            }
+
+            if (sortBy) {
+                switch(sortBy) {
+                    case "updatedDate":
+                        params += "&sortBy=action_date";
+                        break;
+                    case "taskId":
+                        params += "&sortBy=id";
+                        break;
+                }
+            }
+
+            if (sortDirection) {
+                params += '&sortDirection=' + sortDirection;
             }
 
             // Returns a promise
             return $http({
                 method: 'GET',
-                url: configService.tmAPI + '/stats/project/' + projectId + '/activity' + pageToGet
+                url: configService.tmAPI + '/stats/project/' + (projectId > 0 ? projectId : 'all') + '/overview' + params,
+                headers: authService.getAuthenticatedHeader(),
+            }).then(function successCallback(response) {
+                // this callback will be called asynchronously
+                // when the response is available
+                return response.data;
+            }, function errorCallback() {
+                // called asynchronously if an error occurs
+                // or server returns response with an error status.
+                return $q.reject("error");
+            });
+        }
+
+        /**
+         * Get the project activity. This method performs double-duty, handling both single
+         * project stats and all-project stats (with optional project filter).
+         * @param projectId
+         * @param page - optional
+         * @returns {!jQuery.deferred|!jQuery.jqXHR|*|!jQuery.Promise}
+         */
+        function getProjectActivity(projectId, page, pageSize, sortBy, sortDirection, usernameFilter, statusFilter, projectFilter){
+            var params = '?pageSize=' + (pageSize ? pageSize : '10');
+            if (page) {
+                params += '&page=' + page;
+            }
+
+            if (usernameFilter) {
+                params += "&username=" + encodeURIComponent(usernameFilter);
+            }
+
+            if (typeof statusFilter === 'number') {
+                params += "&status=" + statusFilter;
+            }
+
+            // project filter for all-projects activity
+            if (projectFilter) {
+                params += "&projectTitle=" + encodeURIComponent(projectFilter);
+            }
+
+            if (sortBy) {
+                switch(sortBy) {
+                    case "actionDate":
+                    case "action_date":
+                        params += "&sortBy=task_history_action_date";
+                        break;
+                    case "actionBy":
+                    case "username":
+                        params += "&sortBy=username";
+                        break;
+                }
+            }
+
+            if (sortDirection) {
+                params += '&sortDirection=' + sortDirection;
+            }
+
+            // Returns a promise
+            return $http({
+                method: 'GET',
+                url: configService.tmAPI + '/stats/project/' + (projectId > 0 ? projectId : 'all') + '/activity' + params,
+                headers: authService.getAuthenticatedHeader(),
             }).then(function successCallback(response) {
                 // this callback will be called asynchronously
                 // when the response is available
@@ -93,7 +188,6 @@
          * @returns {*|!jQuery.deferred|!jQuery.Promise|!jQuery.jqXHR}
          */
         function getHomePageStats(){
-            console.log('In service');
             return $http({
                 method: 'GET',
                 url: configService.tmAPI + '/stats/summary'

--- a/client/app/services/task.service.js
+++ b/client/app/services/task.service.js
@@ -4,6 +4,18 @@
      * @fileoverview This file provides a service for task operations.
      */
 
+    // TaskStatus constants; values match the constants on the server
+    angular.module('taskingManager').constant('TaskStatus', {
+        READY: { value: 0, title: "Ready" },
+        LOCKED_FOR_MAPPING: { value: 1, title: "Locked For Mapping" },
+        MAPPED: { value: 2, title: "Mapped" },
+        LOCKED_FOR_VALIDATION: { value: 3, title: "Locked For Validation" },
+        VALIDATED: { value: 4, title: "Validated" },
+        INVALIDATED: { value: 5, title: "Invalidated" },
+        BADIMAGERY: { value: 6, title: "Bad Imagery" },
+        SPLIT: { value: 7, title: "Split" },
+    });
+
     angular
         .module('taskingManager')
         .service('taskService', ['$http', '$httpParamSerializer', '$q', 'configService', 'authService', taskService]);

--- a/client/app/taskingmanager.app.js
+++ b/client/app/taskingmanager.app.js
@@ -179,6 +179,12 @@
                     title: 'Dashboard'
                 })
 
+                .when('/projects/activity', {
+                    templateUrl: 'app/project/project-dashboard.html',
+                    controller: 'projectDashboardController',
+                    controllerAs: 'projectDashboardCtrl'
+                })
+
                 .when('/project/:id/dashboard', {
                     templateUrl: 'app/project/project-dashboard.html',
                     controller: 'projectDashboardController',

--- a/migrations/versions/6ae2a7d54b50_.py
+++ b/migrations/versions/6ae2a7d54b50_.py
@@ -1,0 +1,51 @@
+"""empty message
+
+Revision ID: 6ae2a7d54b50
+Revises: e36f1d0c4947
+Create Date: 2019-05-29 10:43:42.104432
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6ae2a7d54b50'
+down_revision = 'e36f1d0c4947'
+branch_labels = None
+depends_on = None
+
+def state_change_user(conn, task, action_text):
+  query = "select user_id from task_history where project_id=" + str(task['project_id']) + " " + \
+          "and task_id=" + str(task['id']) + " and action='STATE_CHANGE' and " + \
+          "action_text='" + action_text + "' order by action_date desc limit 1"
+
+  return conn.execute(query).fetchone()
+
+def upgrade():
+    op.create_index('idx_action_action_text_composite', 'task_history', ['action', 'action_text'], unique=False)
+    op.create_index(op.f('ix_tasks_task_status'), 'tasks', ['task_status'], unique=False)
+
+    conn = op.get_bind()
+    invalidated_tasks = conn.execute('select * from tasks where task_status = 5')
+    for task in invalidated_tasks:
+        validated_by = state_change_user(conn, task, "INVALIDATED")
+        mapped_by = state_change_user(conn, task, "MAPPED")
+
+        if not validated_by or not mapped_by:
+            print("Project " + str(task['project_id']) + ": skipping invalidated task " + \
+                   str(task['id']) + " due to missing or unexpected task history")
+            continue
+
+        conn.execute("update tasks set validated_by=" + str(validated_by['user_id']) + ", " + \
+                     "mapped_by=" + str(mapped_by['user_id']) + " " + \
+                     "where project_id=" + str(task['project_id']) + " " + \
+                     "and id=" + str(task['id']))
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    conn = op.get_bind()
+    conn.execute("update tasks set validated_by=NULL, mapped_by=NULL where task_status = 5")
+    op.drop_index(op.f('ix_tasks_task_status'), table_name='tasks')
+    op.drop_index('idx_action_action_text_composite', table_name='task_history')

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -107,7 +107,7 @@ def init_flask_restful_routes(app):
     from server.api.project_apis import ProjectAPI, ProjectAOIAPI, ProjectSearchAPI, HasUserTaskOnProject,\
         HasUserTaskOnProjectDetails, ProjectSearchBBoxAPI, ProjectSummaryAPI, TaskAnnotationsAPI
     from server.api.swagger_docs_api import SwaggerDocsAPI
-    from server.api.stats_api import StatsContributionsAPI, StatsActivityAPI, StatsProjectAPI, HomePageStatsAPI, StatsUserAPI
+    from server.api.stats_api import StatsContributionsAPI, StatsActivityAPI, StatsActivityAllProjectsAPI, StatsProjectAPI, HomePageStatsAPI, StatsUserAPI, StatsOverviewAPI
     from server.api.tags_apis import CampaignsTagsAPI, OrganisationTagsAPI
     from server.api.mapping_issues_apis import MappingIssueCategoryAPI, MappingIssueCategoriesAPI
     from server.api.users.user_apis import UserAPI, UserIdAPI, UserOSMAPI, UserMappedProjects, UserSetRole, UserSetLevel,\
@@ -168,7 +168,9 @@ def init_flask_restful_routes(app):
     api.add_resource(StopValidatingAPI,             '/api/v1/project/<int:project_id>/stop-validating')
     api.add_resource(StatsContributionsAPI,         '/api/v1/stats/project/<int:project_id>/contributions')
     api.add_resource(TaskAnnotationsAPI, '/api/v1/project/<int:project_id>/task-annotations/<string:annotation_type>', '/api/v1/project/<int:project_id>/task-annotations', methods=['GET', 'POST'])
+    api.add_resource(StatsActivityAllProjectsAPI,   '/api/v1/stats/project/all/activity')
     api.add_resource(StatsActivityAPI,              '/api/v1/stats/project/<int:project_id>/activity')
+    api.add_resource(StatsOverviewAPI,              '/api/v1/stats/project/<project>/overview')
     api.add_resource(StatsProjectAPI,               '/api/v1/stats/project/<int:project_id>')
     api.add_resource(StatsUserAPI,                  '/api/v1/stats/user/<string:username>')
     api.add_resource(HomePageStatsAPI,              '/api/v1/stats/summary')

--- a/server/api/stats_api.py
+++ b/server/api/stats_api.py
@@ -1,7 +1,12 @@
+import io
+import csv
+from distutils.util import strtobool
+from flask import send_file
 from flask_restful import Resource, current_app, request
 from server.services.stats_service import StatsService, NotFound
 from server.services.project_service import ProjectService
 from server.services.users.user_service import UserService
+from server.services.users.authentication_service import token_auth, tm
 
 
 class StatsContributionsAPI(Resource):
@@ -56,8 +61,28 @@ class StatsActivityAPI(Resource):
               type: integer
               default: 1
             - in: query
+              name: username
+              description: Optional username filter
+              type: string
+            - in: query
+              name: status
+              description: Optional task status filter
+              type: number
+            - in: query
+              name: sortBy
+              description: field to sort by, defaults to action_date
+              type: string
+            - in: query
+              name: sortDirection
+              description: direction of sort, defaults to desc
+              type: string
+            - in: query
               name: page
               description: Page of results user requested
+              type: integer
+            - in: query
+              name: pageSize
+              description: Size of page, defaults to 10
               type: integer
         responses:
             200:
@@ -68,13 +93,191 @@ class StatsActivityAPI(Resource):
                 description: Internal Server Error
         """
         try:
+            preferred_locale = request.environ.get('HTTP_ACCEPT_LANGUAGE')
             page = int(request.args.get('page')) if request.args.get('page') else 1
-            activity = StatsService.get_latest_activity(project_id, page)
+            page_size = int(request.args.get('pageSize')) if request.args.get('pageSize') else 10
+            sort_by = request.args.get('sortBy')
+            sort_direction = request.args.get('sortDirection')
+            username = request.args.get('username')
+            status = request.args.get('status', None, type=int)
+            activity = StatsService.get_latest_activity(project_id, preferred_locale, page, page_size, sort_by, sort_direction, username, status)
             return activity.to_primitive(), 200
         except NotFound:
             return {"Error": "No activity on project"}, 404
         except Exception as e:
             error_msg = f'User GET - unhandled error: {str(e)}'
+            current_app.logger.critical(error_msg)
+            return {"error": error_msg}, 500
+
+
+class StatsOverviewAPI(Resource):
+
+    def get(self, project):
+        """
+        Get latest overview of project tasks
+        ---
+        tags:
+          - stats
+        produces:
+          - application/json
+        parameters:
+            - name: project_id
+              in: path
+              required: true
+              type: integer
+              default: 1
+            - in: query
+              name: mapper
+              description: Optional username filter for mapper
+              type: string
+            - in: query
+              name: validator
+              description: Optional username filter for validator
+              type: string
+            - in: query
+              name: status
+              description: Optional task status filter
+              type: number
+            - in: query
+              name: projectTitle
+              description: Optional project name filter for multi-project overview
+              type: string
+            - in: query
+              name: sortBy
+              description: field to sort by, defaults to action_date
+              type: string
+            - in: query
+              name: sortDirection
+              description: direction of sort, defaults to desc
+              type: string
+            - in: query
+              name: page
+              description: Page of results user requested
+              type: integer
+            - in: query
+              name: pageSize
+              description: Size of page, defaults to 10
+              type: integer
+        responses:
+            200:
+                description: Project overview
+            404:
+                description: No matching tasks found
+            500:
+                description: Internal Server Error
+        """
+        try:
+            single_project = project.isdigit()  # given a specific project id
+            project_id = project if single_project else None
+            preferred_locale = request.environ.get('HTTP_ACCEPT_LANGUAGE')
+            as_csv = strtobool(request.args.get('as_csv', 'false', str))
+
+            page = request.args.get('page', 1, type=int)
+            page_size = request.args.get('pageSize', 10, type=int)
+            sort_by = request.args.get('sortBy')
+            sort_direction = request.args.get('sortDirection')
+            mapper_name = request.args.get('mapperName')
+            validator_name = request.args.get('validatorName')
+            status = request.args.get('status', None, type=int)
+            project_name = None if single_project else request.args.get('projectTitle', None, str)
+            overview = StatsService.get_latest_overview(project_id, preferred_locale, page, page_size, sort_by, sort_direction, mapper_name, validator_name, status, project_name, as_csv)
+
+            if as_csv:
+                export_role = 'csv-single' if single_project else 'csv-multi'
+                task_dicts = [task.to_primitive(role=export_role) for task in overview.tasks]
+                out = io.StringIO()
+                csv_writer = csv.DictWriter(out, task_dicts[0].keys())
+                csv_writer.writeheader()
+                csv_writer.writerows(task_dicts)
+
+                # Convert StringIO to BytesIO for flask send_file
+                bytes_out = io.BytesIO()
+                bytes_out.write(out.getvalue().encode('utf-8'))
+                bytes_out.seek(0)
+                out.close()
+
+                return send_file(bytes_out, mimetype='text/csv', as_attachment=True,
+                                 attachment_filename=f'project-{str(project_id) if single_project else "multi"}-overview.csv')
+
+            return overview.to_primitive(), 200
+        except NotFound:
+            return {"Error": "No matching tasks"}, 404
+        except Exception as e:
+            error_msg = f'User GET - unhandled error: {str(e)}'
+            current_app.logger.critical(error_msg)
+            return {"error": error_msg}, 500
+
+
+class StatsActivityAllProjectsAPI(Resource):
+
+    @token_auth.login_required
+    def get(self):
+        """
+        Get user actvity on all projects
+        ---
+        tags:
+          - stats
+        produces:
+          - application/json
+        parameters:
+            - in: query
+              name: username
+              description: Optional username filter
+              type: string
+            - in: query
+              name: projectId
+              description: Optional project filter
+              type: integer
+            - in: query
+              name: status
+              description: Optional task status filter
+              type: number
+            - in: query
+              name: sortBy
+              description: field to sort by, defaults to action_date
+              type: string
+            - in: query
+              name: sortDirection
+              description: direction of sort, defaults to desc
+              type: string
+            - in: query
+              name: page
+              description: Page of results user requested
+              type: integer
+            - in: query
+              name: pageSize
+              description: Size of page, defaults to 10
+              type: integer
+        responses:
+            200:
+                description: Project activity
+            403:
+                description: Forbidden
+            404:
+                description: No activity
+            500:
+                description: Internal Server Error
+        """
+        try:
+            # User must possess at least Validator role
+            if not UserService.is_user_validator(tm.authenticated_user_id):
+                return {"Error": "User not permitted to view stats for all projects."}, 403
+
+            preferred_locale = request.environ.get('HTTP_ACCEPT_LANGUAGE')
+            project_id = request.args.get('projectId', None, int)
+            page = request.args.get('page', 1, int)
+            page_size = request.args.get('pageSize', 10, int)
+            sort_by = request.args.get('sortBy')
+            sort_direction = request.args.get('sortDirection')
+            username = request.args.get('username')
+            status = request.args.get('status', None, int)
+            project_name = request.args.get('projectTitle', None, str)
+            activity = StatsService.get_latest_activity(project_id, preferred_locale, page, page_size, sort_by, sort_direction, username, status, project_name)
+            return activity.to_primitive(), 200
+        except NotFound:
+            return {"Error": "No activity"}, 404
+        except Exception as e:
+            error_msg = f'Activity for All Projects GET - unhandled error: {str(e)}'
             current_app.logger.critical(error_msg)
             return {"error": error_msg}, 500
 
@@ -111,7 +314,25 @@ class StatsProjectAPI(Resource):
         """
         try:
             preferred_locale = request.environ.get('HTTP_ACCEPT_LANGUAGE')
+            as_csv = strtobool(request.args.get('as_csv', 'false', str))
             summary = ProjectService.get_project_summary(project_id, preferred_locale)
+
+            if as_csv:
+                summary_dict = summary.to_primitive(role='csv')
+                out = io.StringIO()
+                csv_writer = csv.DictWriter(out, summary_dict.keys())
+                csv_writer.writeheader()
+                csv_writer.writerow(summary_dict)
+
+                # Convert StringIO to BytesIO for flask send_file
+                bytes_out = io.BytesIO()
+                bytes_out.write(out.getvalue().encode('utf-8'))
+                bytes_out.seek(0)
+                out.close()
+
+                return send_file(bytes_out, mimetype='text/csv', as_attachment=True,
+                                 attachment_filename=f'project-{str(project_id)}-summary-stats.csv')
+
             return summary.to_primitive(), 200
         except NotFound:
             return {"Error": "Project not found"}, 404

--- a/server/models/dtos/mapping_dto.py
+++ b/server/models/dtos/mapping_dto.py
@@ -50,7 +50,9 @@ class StopMappingTaskDTO(Model):
 class TaskHistoryDTO(Model):
     """ Describes an individual action that was performed on a mapping task"""
     history_id = IntType(serialized_name='historyId')
-    task_id = StringType(serialized_name='taskId')
+    project_id = IntType(serialized_name='projectId')
+    project_title = StringType(serialized_name='projectTitle')
+    task_id = IntType(serialized_name='taskId')
     action = StringType()
     action_text = StringType(serialized_name='actionText')
     action_date = DateTimeType(serialized_name='actionDate')

--- a/server/models/dtos/project_dto.py
+++ b/server/models/dtos/project_dto.py
@@ -2,9 +2,10 @@ from schematics import Model
 from schematics.exceptions import ValidationError
 from schematics.types import StringType, BaseType, IntType, BooleanType, DateTimeType, FloatType
 from schematics.types.compound import ListType, ModelType, DictType
-from server.models.dtos.task_annotation_dto import TaskAnnotationDTO
+from schematics.transforms import whitelist
 from server.models.dtos.user_dto import is_known_mapping_level
 from server.models.dtos.stats_dto import Pagination
+from server.models.dtos.task_annotation_dto import TaskAnnotationDTO
 from server.models.postgis.statuses import ProjectStatus, ProjectPriority, MappingTypes, TaskCreationMode, Editors
 
 
@@ -233,6 +234,20 @@ class ProjectSummary(Model):
     last_updated = DateTimeType(serialized_name='lastUpdated')
     priority = StringType(serialized_name='projectPriority')
     campaign_tag = StringType(serialized_name='campaignTag')
+    total_tasks = IntType(serialized_name='totalTasks')
+    percent_mapped = IntType(serialized_name='percentMapped')
+    percent_validated = IntType(serialized_name='percentValidated')
+    tasks_ready = IntType(serialized_name='tasksReady', default=0)
+    tasks_mapped = IntType(serialized_name='tasksMapped', default=0)
+    tasks_validated = IntType(serialized_name='tasksValidated', default=0)
+    tasks_invalidated = IntType(serialized_name='tasksInvalidated', default=0)
+    tasks_partially_mapped = IntType(serialized_name='tasksPartiallyMapped', default=0)
+    tasks_review_requested = IntType(serialized_name='tasksReviewRequested', default=0)
+    tasks_badimagery = IntType(serialized_name='tasksBadImagery', default=0)
+    tasks_locked_for_mapping = IntType(serialized_name='tasksLockedForMapping', default=0)
+    tasks_locked_for_validation = IntType(serialized_name='tasksLockedForValidation', default=0)
+    created = DateTimeType()
+    last_updated = DateTimeType(serialized_name='lastUpdated')
     organisation_tag = StringType(serialized_name='organisationTag')
     entities_to_map = StringType(serialized_name='entitiesToMap')
     changeset_comment = StringType(serialized_name='changesetComment')
@@ -253,6 +268,14 @@ class ProjectSummary(Model):
     average_mapping_time = IntType(serialized_name='averageMappingTime')
     average_validation_time = IntType(serialized_name='averageValidationTime')
     status = StringType()
+
+    class Options:
+        roles = {
+            'csv': whitelist('project_id', 'total_tasks', 'percent_mapped', 'percent_validated', \
+                             'tasks_ready', 'tasks_mapped', 'tasks_partially_mapped', 'tasks_review_requested', \
+                             'tasks_validated', 'tasks_invalidated', 'tasks_badimagery', \
+                             'tasks_locked_for_mapping', 'tasks_locked_for_validation'),
+        }
 
 
 class PMDashboardDTO(Model):

--- a/server/models/dtos/stats_dto.py
+++ b/server/models/dtos/stats_dto.py
@@ -1,6 +1,7 @@
 from schematics import Model
-from schematics.types import StringType, IntType, FloatType, BooleanType
+from schematics.types import StringType, IntType, FloatType, BooleanType, DateTimeType
 from schematics.types.compound import ListType, ModelType
+from schematics.transforms import blacklist
 from server.models.dtos.mapping_dto import TaskHistoryDTO
 
 
@@ -57,6 +58,31 @@ class ProjectActivityDTO(Model):
     pagination = ModelType(Pagination)
     activity = ListType(ModelType(TaskHistoryDTO))
 
+class TaskOverviewDTO(Model):
+    """ DTO that provides an overview of a task """
+    project_title = StringType(serialized_name='projectTitle')
+    project_id = IntType(serialized_name='projectId')
+    task_id = IntType(serialized_name='taskId')
+    task_status = StringType(serialized_name='taskStatus')
+    status_name = StringType(serialized_name='statusName')
+    mapper_name = StringType(serialized_name='mapperName')
+    validator_name = StringType(serialized_name='validatorName')
+    updated_date = DateTimeType(serialized_name='updatedDate')
+
+    class Options:
+        roles = {
+            'csv-single': blacklist('project_title', 'task_status'),
+            'csv-multi': blacklist('task_status')
+        }
+
+class ProjectOverviewDTO(Model):
+    """ DTO for the overview of project tasks """
+    def __init__(self):
+        super().__init__()
+        self.tasks = []
+
+    pagination = ModelType(Pagination)
+    tasks = ListType(ModelType(TaskOverviewDTO))
 
 class OrganizationStatsDTO(Model):
     def __init__(self, tup):
@@ -98,4 +124,3 @@ class HomePageStatsDTO(Model):
     # avg_completion_time = IntType(serialized_name='averageCompletionTime')
     organizations = ListType(ModelType(OrganizationStatsDTO))
     campaigns = ListType(ModelType(CampaignStatsDTO))
-    

--- a/server/services/stats_service.py
+++ b/server/services/stats_service.py
@@ -1,5 +1,6 @@
 from cachetools import TTLCache, cached
-from sqlalchemy import func, text
+from sqlalchemy import func, text, or_
+from sqlalchemy.orm import aliased
 from geoalchemy2.shape import to_shape
 from shapely.geometry import Polygon
 from shapely.ops import transform
@@ -13,13 +14,14 @@ from flask import current_app
 from server import db
 from server.models.dtos.stats_dto import (
     ProjectContributionsDTO, UserContribution, Pagination, TaskHistoryDTO,
-    ProjectActivityDTO, HomePageStatsDTO, OrganizationStatsDTO,
-    CampaignStatsDTO
+    ProjectActivityDTO, ProjectOverviewDTO, TaskOverviewDTO, HomePageStatsDTO,
+    OrganizationStatsDTO, CampaignStatsDTO
     )
 
 from server.models.postgis.project import Project
-from server.models.postgis.statuses import TaskStatus
-from server.models.postgis.task import TaskHistory, User, Task
+from server.models.postgis.statuses import ProjectStatus, TaskStatus
+from server.models.postgis.task import TaskHistory, User, Task, TaskAction
+from server.models.postgis.project_info import ProjectInfo
 from server.models.postgis.utils import timestamp, NotFound
 from server.services.project_service import ProjectService
 from server.services.users.user_service import UserService
@@ -43,7 +45,7 @@ class StatsService:
         elif new_state == TaskStatus.INVALIDATED:
             StatsService._set_counters_after_invalidated(task_id, project, user)
         elif new_state == TaskStatus.VALIDATED:
-            StatsService._set_counters_after_validated(project, user)
+            StatsService._set_counters_after_validated(task_id, project, user)
         elif new_state == TaskStatus.BADIMAGERY:
             StatsService._set_counters_after_bad_imagery(project)
 
@@ -60,11 +62,19 @@ class StatsService:
         user.tasks_mapped += 1
 
     @staticmethod
-    def _set_counters_after_validated(project: Project, user: User):
+    def _set_counters_after_validated(task_id: int, project: Project, user: User):
         """ Set counters after user has validated a task """
-        # TODO - There is a potential problem with the counters if people mark bad imagery tasks validated
         project.tasks_validated += 1
         user.tasks_validated += 1
+
+        # If user is setting a task that wasn't fully mapped to valid, we need to also give
+        # mapping credit since we wouldn't have before. Otherwise, if this validation is
+        # undone or subsequently invalidated, the stats will be skewed as mapping credit will
+        # be taken away despite never being awarded
+        last_state = TaskHistory.get_last_status(project.id, task_id)
+        if last_state == TaskStatus.BADIMAGERY:
+            project.tasks_mapped += 1
+            project.tasks_bad_imagery -= 1
 
     @staticmethod
     def _set_counters_after_bad_imagery(project: Project):
@@ -92,18 +102,25 @@ class StatsService:
             project.tasks_bad_imagery -= 1
         elif current_state == TaskStatus.BADIMAGERY and undo_state == TaskStatus.INVALIDATED:
             project.tasks_bad_imagery -= 1
+        elif current_state == TaskStatus.BADIMAGERY and undo_state == TaskStatus.VALIDATED:
+            project.tasks_bad_imagery -= 1
+            project.tasks_validated += 1
+            project.tasks_mapped += 1 # award mapping credit if validated
         elif current_state == TaskStatus.INVALIDATED and undo_state == TaskStatus.MAPPED:
             user.tasks_invalidated -= 1
             project.tasks_mapped += 1
         elif current_state == TaskStatus.INVALIDATED and undo_state == TaskStatus.VALIDATED:
             user.tasks_invalidated -= 1
             project.tasks_validated += 1
+            project.tasks_mapped += 1
         elif current_state == TaskStatus.VALIDATED and undo_state == TaskStatus.MAPPED:
             user.tasks_validated -= 1
             project.tasks_validated -= 1
         elif current_state == TaskStatus.VALIDATED and undo_state == TaskStatus.BADIMAGERY:
             user.tasks_validated -= 1
             project.tasks_validated -= 1
+            project.tasks_mapped -= 1
+            project.tasks_bad_imagery += 1
 
     @staticmethod
     def _set_counters_after_invalidated(task_id: int, project: Project, user: User):
@@ -122,19 +139,151 @@ class StatsService:
         user.tasks_invalidated += 1
 
     @staticmethod
-    def get_latest_activity(project_id: int, page: int) -> ProjectActivityDTO:
+    def get_latest_overview(project_id: int, locale='en', page=1, page_size=10, sort_by=None, sort_direction=None, mapper_name=None, validator_name=None, status=None, project_name=None, all_results=False) -> ProjectOverviewDTO:
+        """ Gets the latest overview of project tasks status """
+        sort_column = None if not sort_by else Task.__table__.columns.get(sort_by)
+        if sort_column is None:
+            sort_column = TaskHistory.action_date
+
+        if sort_direction is not None and sort_direction.lower() == "asc":
+            sort_column = sort_column.asc()
+        else:
+            sort_column = sort_column.desc()
+        sort_column = sort_column.nullslast()
+
+        mapper = aliased(User, name="mapper")
+        lock_holder = aliased(User, name="lock_holder")
+        validator = aliased(User, name="validator")
+        latest_history = aliased(TaskHistory, name='latest')
+        latest_history_id = (db.session.query(latest_history.id) \
+                                       .filter(latest_history.task_id == Task.id) \
+                                       .filter(latest_history.project_id == Task.project_id) \
+                                       .order_by(latest_history.action_date.desc()) \
+                                       .order_by(latest_history.id.desc()) \
+                                       .limit(1) \
+                                       .correlate(Task) \
+                                       .as_scalar())
+
+        query = db.session.query(Task.id, Task.project_id, Task.task_status, \
+                                 mapper.username.label("mapper_name"), validator.username.label("validator_name"), \
+                                 lock_holder.username.label("lock_holder_name"), TaskHistory.action_date) \
+                          .outerjoin(TaskHistory, Task.task_history) \
+                          .filter(or_(TaskHistory.id == latest_history_id, TaskHistory.id.is_(None))) \
+                          .outerjoin((mapper, Task.mapper), (validator, Task.validator), (lock_holder, Task.lock_holder))
+
+        if project_id is not None:
+            query = query.filter(Task.project_id == project_id)
+        else:
+            # Include project name. Ignore draft and archived projects
+            query = query.join(Project, Task.project_id == Project.id) \
+                         .filter(Project.status == ProjectStatus.PUBLISHED.value) \
+                         .add_columns(ProjectInfo.name.label('project_title')) \
+                         .filter(Project.id == ProjectInfo.project_id) \
+                         .filter(ProjectInfo.locale.in_([locale, 'en'])) \
+
+            if project_name is not None:
+                query = query.filter(ProjectInfo.name.ilike('%' + project_name.lower() + '%'))
+
+        if status is not None:
+            query = query.filter(Task.task_status == status)
+
+        if mapper_name is not None:
+            # Filter on mapper, but also include lock holder if task is locked for mapping
+            query = query.filter((mapper.username.ilike(mapper_name.lower() + '%')) | \
+                                 ((Task.task_status == TaskStatus.LOCKED_FOR_MAPPING.value) & \
+                                  (lock_holder.username.ilike(mapper_name.lower() + '%'))))
+
+        if validator_name is not None:
+            # Filter on validator, but also include lock holder if task is locked for validation
+            query = query.filter((validator.username.ilike(validator_name.lower() + '%')) | \
+                                 ((Task.task_status == TaskStatus.LOCKED_FOR_VALIDATION.value) & \
+                                  (lock_holder.username.ilike(validator_name.lower() + '%'))))
+
+        query = query.order_by(sort_column)
+        paginated_results = query.paginate(page, page_size, True) if not all_results else None
+        items = paginated_results.items if paginated_results else query.all()
+        if len(items) == 0:
+            raise NotFound()
+
+        overview_dto = ProjectOverviewDTO()
+        for item in items:
+            task = TaskOverviewDTO()
+            if 'project_title' in item.keys():
+                task.project_title = item.project_title
+            task.project_id = item.project_id
+            task.task_id = item.id
+
+            task.task_status = item.task_status
+            task.status_name = TaskStatus(item.task_status).name
+            task.updated_date = item.action_date
+
+            if item.task_status == TaskStatus.LOCKED_FOR_MAPPING.value:
+                task.mapper_name = item.lock_holder_name
+            else:
+                task.mapper_name = item.mapper_name
+
+            if item.task_status == TaskStatus.LOCKED_FOR_VALIDATION.value:
+                task.validator_name = item.lock_holder_name
+            else:
+                task.validator_name = item.validator_name
+
+            overview_dto.tasks.append(task)
+
+        overview_dto.pagination = Pagination(paginated_results) if paginated_results else None
+        return overview_dto
+
+
+    @staticmethod
+    def get_latest_activity(project_id: int, locale='en', page=1, page_size=10, sort_by=None, sort_direction=None, username=None, status=None, project_name=None) -> ProjectActivityDTO:
         """ Gets all the activity on a project """
+        sort_column = None if not sort_by else TaskHistory.__table__.columns.get(sort_by)
+        if sort_column is None:
+            sort_column = TaskHistory.action_date
 
-        results = db.session.query(
-                TaskHistory.id, TaskHistory.task_id, TaskHistory.action, TaskHistory.action_date,
-                TaskHistory.action_text, User.username
-            ).join(User).filter(
-                TaskHistory.project_id == project_id,
-                TaskHistory.action != 'COMMENT'
-            ).order_by(
-                TaskHistory.action_date.desc()
-            ).paginate(page, 10, True)
+        if sort_direction is not None and sort_direction.lower() == "asc":
+            sort_column = sort_column.asc()
+        else:
+            sort_column = sort_column.desc()
+        sort_column = sort_column.nullslast()
 
+        relevant_actions = ('STATE_CHANGE', 'LOCKED_FOR_MAPPING', 'LOCKED_FOR_VALIDATION')
+
+        query = db.session.query(TaskHistory.id, TaskHistory.project_id, TaskHistory.task_id, TaskHistory.action,
+                                 TaskHistory.action_date, TaskHistory.action_text, User.username) \
+                          .join(User) \
+                          .filter(TaskHistory.action.in_(relevant_actions))
+
+        if project_id is not None:
+            query = query.filter(TaskHistory.project_id == project_id)
+        else:
+            # Include project name. Ignore draft and archived projects
+            query = query.join(Project, TaskHistory.project_id == Project.id) \
+                         .filter(Project.status == ProjectStatus.PUBLISHED.value) \
+                         .add_columns(ProjectInfo.name.label('project_title')) \
+                         .filter(Project.id == ProjectInfo.project_id) \
+                         .filter(ProjectInfo.locale.in_([locale, 'en'])) \
+
+            if project_name is not None:
+                query = query.filter(ProjectInfo.name.ilike('%' + project_name.lower() + '%'))
+
+        if username is not None:
+            query = query.filter(User.username.ilike(username.lower() + '%'))
+
+        if status is not None:
+            if status == TaskStatus.LOCKED_FOR_MAPPING.value:
+                query = query.filter(TaskHistory.action == 'LOCKED_FOR_MAPPING')
+            elif status == TaskStatus.LOCKED_FOR_VALIDATION.value:
+                query = query.filter(TaskHistory.action == 'LOCKED_FOR_VALIDATION')
+            elif status == TaskStatus.MAPPED.value:
+                query = query.filter(TaskHistory.action == 'STATE_CHANGE', TaskHistory.action_text == 'MAPPED')
+            elif status == TaskStatus.VALIDATED.value:
+                query = query.filter(TaskHistory.action == 'STATE_CHANGE', TaskHistory.action_text == 'VALIDATED')
+            elif status == TaskStatus.INVALIDATED.value:
+                query = query.filter(TaskHistory.action == 'STATE_CHANGE', TaskHistory.action_text == 'INVALIDATED')
+            elif status == TaskStatus.BADIMAGERY.value:
+                query = query.filter(TaskHistory.action == 'STATE_CHANGE', TaskHistory.action_text == 'BADIMAGERY')
+
+        results = query.order_by(sort_column).paginate(page, page_size, True)
         if results.total == 0:
             raise NotFound()
 
@@ -142,6 +291,10 @@ class StatsService:
         for item in results.items:
             history = TaskHistoryDTO()
             history.history_id = item.id
+            history.project_id = item.project_id
+            if 'project_title' in item.keys():
+                history.project_title = item.project_title
+
             history.task_id = item.task_id
             history.action = item.action
             history.action_text = item.action_text

--- a/server/services/stats_service.py
+++ b/server/services/stats_service.py
@@ -1,14 +1,6 @@
 from cachetools import TTLCache, cached
 from sqlalchemy import func, text, or_
 from sqlalchemy.orm import aliased
-from geoalchemy2.shape import to_shape
-from shapely.geometry import Polygon
-from shapely.ops import transform
-from functools import partial
-import pyproj
-import dateutil.parser
-import datetime
-import math
 from flask import current_app
 
 from server import db
@@ -20,7 +12,7 @@ from server.models.dtos.stats_dto import (
 
 from server.models.postgis.project import Project
 from server.models.postgis.statuses import ProjectStatus, TaskStatus
-from server.models.postgis.task import TaskHistory, User, Task, TaskAction
+from server.models.postgis.task import TaskHistory, User, Task
 from server.models.postgis.project_info import ProjectInfo
 from server.models.postgis.utils import timestamp, NotFound
 from server.services.project_service import ProjectService

--- a/tests/server/integration/services/test_validation_service.py
+++ b/tests/server/integration/services/test_validation_service.py
@@ -59,17 +59,6 @@ class TestValidationService(unittest.TestCase):
         self.assertEqual(0, self.test_project.tasks_mapped)
         self.assertEqual(0, self.test_project.tasks_validated)
 
-    def test_mapped_by_and_validated_by_are_null_after_invalidating_all(self):
-        if self.skip_tests:
-            return
-
-        ValidatorService.validate_all_tasks(self.test_project.id, self.test_user.id)
-        ValidatorService.invalidate_all_tasks(self.test_project.id, self.test_user.id)
-
-        for task in self.test_project.tasks:
-            self.assertIsNone(task.mapped_by)
-            self.assertIsNone(task.validated_by)
-
     def test_mapped_by_and_validated_by_is_set_after_validating_all(self):
         if self.skip_tests:
             return

--- a/tests/server/unit/services/test_stats_service.py
+++ b/tests/server/unit/services/test_stats_service.py
@@ -22,7 +22,8 @@ class TestStatsService(unittest.TestCase):
         self.assertEqual(test_project.tasks_mapped, 1)
         self.assertEqual(test_user.tasks_mapped, 1)
 
-    def test_update_after_validating_increments_counter(self):
+    @patch.object(TaskHistory, 'get_last_status')
+    def test_update_after_validating_increments_counter(self, last_status):
         # Arrange
         test_project = Project()
         test_project.tasks_validated = 0
@@ -30,16 +31,42 @@ class TestStatsService(unittest.TestCase):
         test_user = User()
         test_user.tasks_validated = 0
 
+        last_status.return_value = TaskStatus.MAPPED
+
         # Act
-        StatsService._set_counters_after_validated(test_project, test_user)
+        StatsService._set_counters_after_validated(1, test_project, test_user)
 
         # Assert
         self.assertEqual(test_project.tasks_validated, 1)
         self.assertEqual(test_user.tasks_validated, 1)
 
+    @patch.object(TaskHistory, 'get_last_status')
+    def test_update_after_validating_bad_imagery_increments_counter(self, last_status):
+        # Arrange
+        test_project = Project()
+        test_project.tasks_validated = 0
+        test_project.tasks_mapped = 0
+        test_project.tasks_bad_imagery = 1
+
+        test_user = User()
+        test_user.tasks_validated = 0
+
+        last_status.return_value = TaskStatus.BADIMAGERY
+
+        # Act
+        StatsService._set_counters_after_validated(1, test_project, test_user)
+
+        # Assert
+        self.assertEqual(test_project.tasks_validated, 1)
+        self.assertEqual(test_project.tasks_mapped, 1) # ensure mapping credit is awarded
+        self.assertEqual(test_project.tasks_bad_imagery, 0)
+        self.assertEqual(test_user.tasks_validated, 1)
+
     def test_update_after_flagging_bad_imagery(self):
         # Arrange
         test_project = Project()
+        test_project.tasks_mapped = 0
+        test_project.tasks_validated = 0
         test_project.tasks_bad_imagery = 0
 
         # Act
@@ -47,6 +74,8 @@ class TestStatsService(unittest.TestCase):
 
         # Assert
         self.assertEqual(test_project.tasks_bad_imagery, 1)
+        self.assertEqual(test_project.tasks_mapped, 0) # no mapping credit
+        self.assertEqual(test_project.tasks_validated, 0)
 
     @patch.object(TaskHistory, 'get_last_status')
     def test_update_after_invalidating_mapped_task_sets_counters_correctly(self, last_status):


### PR DESCRIPTION
* Closes #1360, Closes #1384 

* Add additional headline stats for the major task statuses in the
Stats section

* Add new Status Overview table showing the latest status of each task
in the project with sorting and filtering capability

* Add new Status Overview table showing the latest status of each task
in the project with sorting and filtering capability

* Enhance Last Activity table to include sorting and filtering
capability

* Support cross-projects view of Activity & Stats for all published
projects by way of a new "All Activity" option in top-nav dropdown menu

* Support CSV export of summary stats and status overview

* Fix various stats-collection issues and inconsistencies

* Change task invalidation to preserve mapper and invalidator rather than clearing them (note that this only applies to invalidations going forward and does not retroactively set values on existing invalidated tasks)