### PR TITLE
Add the default changeset comment env variable to CloudFormation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,8 @@ jobs:
         type: env_var_name
       tm_secret:
         type: env_var_name
+      tm_default_changeset_comment:
+        type: env_var_name
       email_from_address:
         type: env_var_name
       smtp_host:
@@ -237,6 +239,7 @@ workflows:
         db_size: DATABASE_SIZE_STAGING
         elb_subnets: ELB_SUBNETS_STAGING
         ssl_cert: SSL_CERTIFICATE_ID_STAGING
+        tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_STAGING
     - deploy:
         name: production
         filters:
@@ -263,6 +266,7 @@ workflows:
         db_size: DATABASE_SIZE_PRODUCTION
         elb_subnets: ELB_SUBNETS_PRODUCTION
         ssl_cert: SSL_CERTIFICATE_ID_PRODUCTION
+        tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_PRODUCTION
     - deploy:
         name: teachosm
         filters:
@@ -289,6 +293,7 @@ workflows:
         db_size: DATABASE_SIZE_TEACHOSM
         elb_subnets: ELB_SUBNETS_TEACHOSM
         ssl_cert: SSL_CERTIFICATE_ID_TEACHOSM
+        tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_TEACHOSM
     - deploy:
         name: assisted
         filters:
@@ -315,3 +320,4 @@ workflows:
         db_size: DATABASE_SIZE_ASSISTED
         elb_subnets: ELB_SUBNETS_ASSISTED
         ssl_cert: SSL_CERTIFICATE_ID_ASSISTED
+        tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_ASSISTED

--- a/devops/cloudformation/tasking-manager.template.js
+++ b/devops/cloudformation/tasking-manager.template.js
@@ -69,6 +69,10 @@ const Parameters = {
     Description: 'TM_SMTP_PORT environment variable',
     Type: 'String'
   },
+  TaskingManagerDefaultChangesetComment: {
+    Description: 'TM_DEFAULT_CHANGESET_COMMENT= environment variable',
+    Type: 'String'
+  },
   TaskingManagerLogDirectory: {
     Description: 'TM_LOG_DIR environment variable',
     Type: 'String'
@@ -206,6 +210,7 @@ const Resources = {
         cf.sub('export TM_SMTP_PASSWORD="${TaskingManagerSMTPPassword}"'),
         cf.sub('export TM_SMTP_PORT="${TaskingManagerSMTPPort}"'),
         cf.sub('export TM_SMTP_USER="${TaskingManagerSMTPUser}"'),
+        cf.sub('export TM_DEFAULT_CHANGESET_COMMENT="${TaskingManagerDefaultChangesetComment}"'),
         cf.if('DatabaseDumpFileGiven', cf.sub('aws s3 cp ${DatabaseDump} dump.sql; sudo -u postgres psql "postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_ENDPOINT/$POSTGRES_DB" < dump.sql'), ''),
         './venv/bin/python3.6 manage.py db upgrade',
         'cd client/',


### PR DESCRIPTION
Fixes https://github.com/hotosm/tasking-manager/issues/1632 when done. 

## TODO:

* [x] Add the `TM_DEFAULT_CHANGESET_COMMENT_ASSISTED`, `TM_DEFAULT_CHANGESET_COMMENT_STAGING`, `TM_DEFAULT_CHANGESET_COMMENT_PRODUCTION` and `TM_DEFAULT_CHANGESET_COMMENT_TEACHOSM` env variables to Circle CI.