### PR TITLE
Use smaller RDS instances for non production stacks

### DIFF
--- a/devops/cloudformation/tasking-manager.template.js
+++ b/devops/cloudformation/tasking-manager.template.js
@@ -105,9 +105,9 @@ const Resources = {
     Properties: {
       AutoScalingGroupName: cf.stackName,
       Cooldown: 300,
-      MinSize: 1,
-      DesiredCapacity: 1,
-      MaxSize: 1,
+      MinSize: cf.if('IsTaskingManagerProduction', 3, 1),
+      DesiredCapacity: cf.if('IsTaskingManagerProduction', 3, 1),
+      MaxSize: cf.if('IsTaskingManagerProduction', 12, 1),
       HealthCheckGracePeriod: 300,
       LaunchConfigurationName: cf.ref('TaskingManagerLaunchConfiguration'),
       TargetGroupARNs: [ cf.ref('TaskingManagerTargetGroup') ],

--- a/devops/cloudformation/tasking-manager.template.js
+++ b/devops/cloudformation/tasking-manager.template.js
@@ -94,7 +94,8 @@ const Parameters = {
 
 const Conditions = {
   UseASnapshot: cf.notEquals(cf.ref('DBSnapshot'), ''),
-  DatabaseDumpFileGiven: cf.notEquals(cf.ref('DatabaseDump'), '')
+  DatabaseDumpFileGiven: cf.notEquals(cf.ref('DatabaseDump'), ''),
+  IsTaskingManagerProduction: cf.equals(cf.stackName, 'tasking-manager-production')
 };
 
 const Resources = {
@@ -417,7 +418,7 @@ const Resources = {
         AllocatedStorage: cf.ref('DatabaseSize'),
         BackupRetentionPeriod: 10,
         StorageType: 'gp2',
-        DBInstanceClass: 'db.m3.large', //rethink here
+        DBInstanceClass: cf.if('IsTaskingManagerProduction', 'db.m3.large', 'db.t2.micro'),
         DBSnapshotIdentifier: cf.if('UseASnapshot', cf.ref('DBSnapshot'), cf.noValue),
         VPCSecurityGroups: [cf.importValue(cf.join('-', ['hotosm-network-production', cf.ref('Environment'), 'ec2s-security-group', cf.region]))],
     }


### PR DESCRIPTION
Instead of making the instance type a configurable parameter, we're keeping them constant across non-production stacks.

I also modified the capacity requirements across stacks to be different for production and the others.

cc/ @smit1678 @xamanu @ramyaragupathy 