### PR TITLE
Show expert users ISO8601 timestamps on hover

### DIFF
--- a/client/app/admin/dashboard/dashboard.html
+++ b/client/app/admin/dashboard/dashboard.html
@@ -77,10 +77,10 @@
                                      <td>{{ project.percentMapped }}</td>
                                      <td>{{ project.percentValidated }}</td>
                                      <td>
-                                         <span am-time-ago="project.created | amUtc | amLocal"></span>
+                                         <span tm-timestamp="project.created"></span>
                                      </td>
                                      <td>
-                                         <span am-time-ago="project.lastUpdated | amUtc | amLocal"></span>
+                                         <span tm-timestamp="project.lastUpdated"></span>
                                      </td>
                                      <td>
                                          <a class="button button--small"
@@ -143,10 +143,10 @@
                                      <td>{{ project.percentMapped }}</td>
                                      <td>{{ project.percentValidated }}</td>
                                      <td>
-                                         <span am-time-ago="project.created | amUtc | amLocal"></span>
+                                         <span tm-timestamp="project.created"></span>
                                      </td>
                                      <td>
-                                         <span am-time-ago="project.lastUpdated | amUtc | amLocal"></span>
+                                         <span tm-timestamp="project.lastUpdated"></span>
                                      </td>
                                      <td>
                                          <a class="button button--primary button--small"
@@ -209,10 +209,10 @@
                                      <td>{{ project.percentMapped }}</td>
                                      <td>{{ project.percentValidated }}</td>
                                      <td>
-                                         <span am-time-ago="project.created | amUtc | amLocal"></span>
+                                         <span tm-timestamp="project.created"></span>
                                      </td>
                                      <td>
-                                         <span am-time-ago="project.lastUpdated | amUtc | amLocal"></span>
+                                         <span tm-timestamp="project.lastUpdated"></span>
                                      </td>
                                      <td>
                                          <a class="button button--primary button--small"

--- a/client/app/components/ng-click-copy/ng-click-copy.js
+++ b/client/app/components/ng-click-copy/ng-click-copy.js
@@ -1,0 +1,37 @@
+// From https://gist.github.com/JustMaier/6ef7788709d675bd8230
+'use strict';
+
+angular.module('ngClickCopy', [])
+.service('ngCopy', ['$window', function ($window) {
+    var body = angular.element($window.document.body);
+    var textarea = angular.element('<textarea/>');
+    textarea.css({
+        position: 'fixed',
+        opacity: '0'
+    });
+
+    return function (toCopy) {
+        textarea.val(toCopy);
+        body.append(textarea);
+        textarea[0].select();
+
+        try {
+            var successful = document.execCommand('copy');
+            if (!successful) throw successful;
+        } catch (err) {
+            window.prompt("Copy to clipboard: Ctrl+C, Enter", toCopy);
+        }
+
+        textarea.remove();
+    }
+}])
+.directive('ngClickCopy', ['ngCopy', function (ngCopy) {
+    return {
+        restrict: 'A',
+        link: function (scope, element, attrs) {
+            element.bind('click', function (e) {
+                ngCopy(attrs.ngClickCopy);
+            });
+        }
+    }
+}]);

--- a/client/app/components/project-chat/project-chat.html
+++ b/client/app/components/project-chat/project-chat.html
@@ -4,7 +4,7 @@
             <p class="space-bottom--none">
                 <strong>
                     <a href="./user/{{ message.username }}" target="_blank"/>{{ message.username }}</a>
-                </strong> <span class="metadata" am-time-ago="message.timestamp | amUtc | amLocal" title="{{ message.timestamp }}"></span></p>
+                </strong> <span class="metadata" tm-timestamp="message.timestamp"></span></p>
             <p markdown-to-html="message.message"></p>
         </div>
         <div ng-show="projectChatCtrl.messages.length < 1">

--- a/client/app/components/tm-timestamp/tm-timestamp.directive.js
+++ b/client/app/components/tm-timestamp/tm-timestamp.directive.js
@@ -1,0 +1,68 @@
+(function () {
+
+    'use strict';
+
+    /**
+     * @fileoverview This file provides a directive for displaying an ISO8601
+     * format timestamp for expert users when they hover their mouse over a
+     * traditional relative timestamp; clicking on the timestamp will copy the
+     * ISO8601 timestamp to the user's clipboard. Non-expert users simply see
+     * the traditional relative timestamp with no additional behavior.
+     */
+
+    angular
+    .module('taskingManager')
+    .directive('tmTimestamp', ['moment', 'amUtcFilter', 'amLocalFilter', 'amTimeAgoFilter', 'accountService',
+               function(moment, amUtcFilter, amLocalFilter, amTimeAgoFilter, accountService) {
+
+          function link(scope, element, attrs) {
+              scope.$watch(attrs.tmTimestamp, function(value) {
+                  scope.originalTimestamp = value;
+
+                  if (value) {
+                      scope.relativeTimestamp = amTimeAgoFilter(amLocalFilter(amUtcFilter(value)));
+
+                      if (isExpert()) {
+                          var timestamp = moment.utc(value);
+                          // If date representation can't be parsed, use it as-is.
+                          if (!timestamp.isValid()) {
+                              scope.isoTimestamp = value;
+                          }
+                          else {
+                              scope.isoTimestamp = timestamp.format("YYYY-MM-DDTHH:mm:ss[Z]");
+                          }
+                      }
+                  }
+              });
+
+              if (isExpert()) {
+                  element.on('mouseenter', function(event) {
+                      event.preventDefault();
+                      scope.$apply(function() { scope.displayISO = true; });
+                  });
+
+                  element.on('mouseleave', function(event) {
+                      event.preventDefault();
+                      scope.$apply(function() { scope.displayISO = false; });
+                  });
+
+                  element.on('click', function(event) {
+                      scope.$apply(function() { scope.displayISO = false; });
+                  });
+              }
+          }
+
+          /**
+           * Returns true if the logged-in user has expert mode enabled
+           */
+          function isExpert() {
+              return accountService.getAccount() && accountService.getAccount().isExpert;
+          }
+
+          return {
+              link: link,
+              scope: true,
+              templateUrl: 'app/components/tm-timestamp/tm-timestamp.html',
+          }
+      }]);
+})();

--- a/client/app/components/tm-timestamp/tm-timestamp.html
+++ b/client/app/components/tm-timestamp/tm-timestamp.html
@@ -1,0 +1,5 @@
+<span ng-click-copy="{{ isoTimestamp }}"
+      title="{{ isoTimestamp ? ('Click to copy timestamp' | translate) : ''}}"
+      class="{{ isoTimestamp ? ('copyable' | translate) : '' }} tm-timestamp">
+  {{ displayISO ? isoTimestamp : relativeTimestamp }}
+</span>

--- a/client/app/message/inbox.html
+++ b/client/app/message/inbox.html
@@ -48,7 +48,7 @@
                                   </a>
                                 </td>
                                 <td title="'Sent' | translate" sortable="'sentDate'">
-                                    <span am-time-ago="message.sentDate | amUtc | amLocal"></span>
+                                    <span tm-timestamp="message.sentDate"></span>
                                 </td>
                                 <td>
                                     <button class="button"

--- a/client/app/message/message.html
+++ b/client/app/message/message.html
@@ -21,7 +21,7 @@
                     <div class="inbox-message">
                         <h3 ng-bind-html="messageCtrl.message.subject"></h3>
                         <p>{{ 'From' | translate }}: <a ng-href="user/{{ messageCtrl.message.fromUsername }}">{{ messageCtrl.message.fromUsername }}</a></p>
-                        <p><em am-time-ago="messageCtrl.message.sentDate | amUtc | amLocal"></em></p>
+                        <p><em tm-timestamp="messageCtrl.message.sentDate"></em></p>
                         <div>
                             <p ng-bind-html="messageCtrl.message.message"></p>
                         </div>

--- a/client/app/profile/profile.html
+++ b/client/app/profile/profile.html
@@ -74,7 +74,7 @@
                             <div>
                                 <h4>OSM details</h4>
                                 <div ng-show="profileCtrl.osmUserDetails">
-                                    <p>{{ 'Joined OSM' | translate }} <span am-time-ago="profileCtrl.osmUserDetails.accountCreated | amUtc | amLocal"></span></p>
+                                    <p>{{ 'Joined OSM' | translate }} <span tm-timestamp="profileCtrl.osmUserDetails.accountCreated"></span></p>
                                     <p>{{ profileCtrl.osmUserDetails.changesetCount}} {{ 'Total OSM changesets' | translate }}</p>
                                 </div>
                                 <p>

--- a/client/app/project/project-dashboard.html
+++ b/client/app/project/project-dashboard.html
@@ -49,7 +49,7 @@
                                                 <a href="/user/{{ item.actionBy }}">{{ item.actionBy }}</a>
                                             </td>
                                             <td>
-                                                <span am-time-ago="item.actionDate | amUtc | amLocal"></span>
+                                                <span tm-timestamp="item.actionDate"></span>
                                             </td>
                                         </tr>
                                   </tbody>
@@ -133,7 +133,7 @@
                             <tbody>
                                 <tr ng-repeat="comment in projectDashboardCtrl.projectComments | orderBy: '-commentDate'">
                                     <td>{{ comment.comment }}</td>
-                                    <td><span am-time-ago="comment.commentDate | amUtc | amLocal"></span></td>
+                                    <td><span tm-timestamp="comment.commentDate"></span></td>
                                     <td><a href="/user/{{ comment.userName }}" target="_blank" rel="noopener">{{ comment.userName }}</a></td>
                                     <td><a href="/project/{{ projectDashboardCtrl.projectId }}?task={{ comment.taskId}}" target="_blank" rel="noopener">Task {{ comment.taskId }}</a></td>
                                 </tr>

--- a/client/app/project/project.html
+++ b/client/app/project/project.html
@@ -88,7 +88,7 @@
                     <dd><a href="/user/{{ projectCtrl.projectData.author }}">{{ projectCtrl.projectData.author }}</a></dd>
 
                     <dt>{{ 'Last updated' | translate }}: </dt>
-                    <dd am-time-ago="projectCtrl.projectData.lastUpdated | amUtc | amLocal"></dd>
+                    <dd tm-timestamp="projectCtrl.projectData.lastUpdated"></dd>
 
                     <dt>{{ 'Difficulty' | translate }}: </dt>
                     <dd>{{ projectCtrl.projectData.mapperLevel }}</dd>
@@ -676,10 +676,10 @@
                                                 <td ng-show="doneTasks.mappingLevel === 'INTERMEDIATE'">{{ 'Intermediate' | translate }}</td>
                                                 <td ng-show="doneTasks.mappingLevel === 'ADVANCED'">{{ 'Advanced' | translate }}</td>
                                                 <td>{{ doneTasks.mappedTaskCount }}</td>
-                                                <td><span am-time-ago="doneTasks.dateRegistered | amUtc | amLocal"></span>
+                                                <td><span tm-timestamp="doneTasks.dateRegistered"></span>
                                                 </td>
                                                 <td><span
-                                                        am-time-ago="doneTasks.lastValidationDate | amUtc | amLocal"></span>
+                                                        tm-timestamp="doneTasks.lastValidationDate"></span>
                                                 </td>
                                                 <td>
                                                     <a class="normallink"
@@ -1007,8 +1007,8 @@
                                                     <span class="status-marker-split" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'SPLIT'">{{ 'Split' | translate }}</span>
                                                     <span class="status-marker-ready" ng-show="item.action === 'STATE_CHANGE' && item.actionText === 'READY'">{{ 'Marked as ready' | translate }}</span>
                                                 </td>
-                                                <td>
-                                                    <span am-time-ago="item.actionDate | amUtc | amLocal"></span>
+                                                <td class="timestamp">
+                                                    <span tm-timestamp="item.actionDate"></span>
                                                     <span ng-if="projectCtrl.user.isExpert">
                                                     <a ng-show="projectCtrl.isAtticDateLive(item)" class="diff-control {{projectCtrl.selectedItem.actionDate === item.actionDate ? 'selected' : ''}}" ng-click="projectCtrl.selectItemForDiff(item)" title="{{ 'Choose two entries for diff or same once twice for attic data' | translate }}"></a>
                                                     </span>

--- a/client/app/taskingmanager.app.js
+++ b/client/app/taskingmanager.app.js
@@ -2,7 +2,7 @@
 
 (function () {
 
-    angular.module('taskingManager', ['ngRoute', 'ngFileUpload', 'ng-showdown', 'ui.bootstrap', 'angularMoment', 'chart.js', 'ngTagsInput', 'mentio', '720kb.socialshare', 'pascalprecht.translate', 'ngTable', 'taskingmanager.config'])
+    angular.module('taskingManager', ['ngRoute', 'ngFileUpload', 'ng-showdown', 'ui.bootstrap', 'angularMoment', 'chart.js', 'ngTagsInput', 'mentio', '720kb.socialshare', 'pascalprecht.translate', 'ngTable', 'ngClickCopy', 'taskingmanager.config'])
 
     /**
      * Factory that returns the configuration settings for the current environment

--- a/client/assets/icons/clippy.svg
+++ b/client/assets/icons/clippy.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="16" viewBox="0 0 14 16">
+<rect x="0" y="0" width="100%" height="100%" fill="white" />
+<path fill-rule="evenodd" d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"/></svg>

--- a/client/assets/styles/sass/_tables.scss
+++ b/client/assets/styles/sass/_tables.scss
@@ -35,6 +35,15 @@
     border: 2px solid $darkest-grey;
   }
 
+  td.timestamp {
+    min-width: 145px;
+    text-align: right;
+
+    a.disabled {
+      padding-right: 25px; // since no diff control
+    }
+  }
+
   td.comment-text {
     word-break: break-word;
   }

--- a/client/assets/styles/sass/_tmtimestamp.scss
+++ b/client/assets/styles/sass/_tmtimestamp.scss
@@ -1,0 +1,8 @@
+.tm-timestamp {
+  display: inline-block;
+  min-width: 10.5em;
+
+  &.copyable:hover {
+    cursor: url("../../icons/clippy.svg"), auto;
+  }
+}

--- a/client/assets/styles/sass/taskingmanager.scss
+++ b/client/assets/styles/sass/taskingmanager.scss
@@ -37,6 +37,7 @@
 @import "learn";
 @import "map";
 @import "progressbar";
+@import "tmtimestamp";
 @import "project";
 @import "profile";
 @import "structure";

--- a/client/index.html
+++ b/client/index.html
@@ -272,6 +272,7 @@
 <script src="app/components/language/language-switch.directive.js"></script>
 <script src="app/components/popup/map-popup.directive.js"></script>
 <script src="app/components/show-project-aois/show-project-aois.directive.js"></script>
+<script src="app/components/ng-click-copy/ng-click-copy.js"></script>
 <script src="app/components/project-chat/project-chat.directive.js"></script>
 <!-- /build -->
 


### PR DESCRIPTION
* Closes #1359 

* Users in expert mode can hover over a timestamp to view it in IS08601
format

* Clicking the ISO8601 timestamp copies it to the user's clipboard

* Users who are not in expert mode continue to experience existing
behavior

* Introduces a new `tm-timestamp` directive that should be used in place of the old `am-time-ago | amUtc | amLocal` filter chain