### PR TITLE
Increase staging DB Instance Class to db.t2.small

### DIFF
--- a/devops/cloudformation/tasking-manager.template.js
+++ b/devops/cloudformation/tasking-manager.template.js
@@ -418,7 +418,7 @@ const Resources = {
         AllocatedStorage: cf.ref('DatabaseSize'),
         BackupRetentionPeriod: 10,
         StorageType: 'gp2',
-        DBInstanceClass: cf.if('IsTaskingManagerProduction', 'db.m3.large', 'db.t2.micro'),
+        DBInstanceClass: cf.if('IsTaskingManagerProduction', 'db.m3.large', 'db.t2.small'),
         DBSnapshotIdentifier: cf.if('UseASnapshot', cf.ref('DBSnapshot'), cf.noValue),
         VPCSecurityGroups: [cf.importValue(cf.join('-', ['hotosm-network-production', cf.ref('Environment'), 'ec2s-security-group', cf.region]))],
     }


### PR DESCRIPTION
Increasing from t2.micro to t2.small will bump the DB instance memory from 1GB to 2GB and improve page load times for the staging stack. 

See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html#Concepts.DBInstanceClass.Types for more details. 

