### PR TITLE
Enable verbose logging to cloudwatch in cfn template

### DIFF
--- a/devops/cloudformation/tasking-manager.template.js
+++ b/devops/cloudformation/tasking-manager.template.js
@@ -420,6 +420,8 @@ const Resources = {
         StorageType: 'gp2',
         DBInstanceClass: cf.if('IsTaskingManagerProduction', 'db.m3.large', 'db.t2.small'),
         DBSnapshotIdentifier: cf.if('UseASnapshot', cf.ref('DBSnapshot'), cf.noValue),
+        DBParameterGroupName: 'tm3-logging-postgres11',
+        EnableCloudwatchLogsExports: ['postgresql', 'upgrade'],
         VPCSecurityGroups: [cf.importValue(cf.join('-', ['hotosm-network-production', cf.ref('Environment'), 'ec2s-security-group', cf.region]))],
     }
   }


### PR DESCRIPTION
Adds two parameters to the RDS resource:
 - DBParameterGroupName: Uses a [custom parameter group](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html) that enables more verbose logging
 - EnableCloudwatchLogsExports: Exports logs to Cloudwatch for detailed monitoring (see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch)