### PR TITLE
Do not apply cascade deletion on message model

### DIFF
--- a/migrations/versions/b25f088d40c2_.py
+++ b/migrations/versions/b25f088d40c2_.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: b25f088d40c2
+Revises: fcd9cebaa79c
+Create Date: 2019-06-11 12:31:41.697842
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b25f088d40c2'
+down_revision = 'fcd9cebaa79c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_foreign_key('messages_tasks', 'messages', 'tasks', ['task_id', 'project_id'], ['id', 'project_id'])
+
+
+def downgrade():
+    op.drop_constraint('messages_tasks', 'messages', type_='foreignkey')

--- a/server/services/messaging/message_service.py
+++ b/server/services/messaging/message_service.py
@@ -260,13 +260,13 @@ class MessageService:
     @staticmethod
     def delete_message(message_id: int, user_id: int):
         """ Deletes the specified message """
-        # message = MessageService.get_message(message_id, user_id)
-        # message.delete()
+        message = MessageService.get_message(message_id, user_id)
+        message.delete()
 
     @staticmethod
     def delete_multiple_messages(message_ids: list, user_id: int):
         """ Deletes the specified messages to the user """
-       #  Message.delete_multiple_messages(message_ids, user_id)
+        Message.delete_multiple_messages(message_ids, user_id)
 
     @staticmethod
     def get_task_link(project_id: int, task_id: int, base_url=None) -> str:


### PR DESCRIPTION
This Pr removes the cascade deletion on message model.

**How to test**
1. Apply required migration.
2. Alter your user as admin in your local instance.
3. Create a toy project. 
4. In _Questions and comments_ tab, reference yourself and send messages.
5. Then go to your inbox. The messages will appear.
6. Delete messages.
7. Go back to the project view. Also, you can verify executing a query to get the project from projects table. 