### PR TITLE
Remove verbose RDS logging

### DIFF
--- a/devops/cloudformation/tasking-manager.template.js
+++ b/devops/cloudformation/tasking-manager.template.js
@@ -420,8 +420,6 @@ const Resources = {
         StorageType: 'gp2',
         DBInstanceClass: cf.if('IsTaskingManagerProduction', 'db.m3.large', 'db.t2.small'),
         DBSnapshotIdentifier: cf.if('UseASnapshot', cf.ref('DBSnapshot'), cf.noValue),
-        DBParameterGroupName: 'tm3-logging-postgres11',
-        EnableCloudwatchLogsExports: ['postgresql', 'upgrade'],
         VPCSecurityGroups: [cf.importValue(cf.join('-', ['hotosm-network-production', cf.ref('Environment'), 'ec2s-security-group', cf.region]))],
     }
   }

--- a/server/services/messaging/message_service.py
+++ b/server/services/messaging/message_service.py
@@ -260,13 +260,13 @@ class MessageService:
     @staticmethod
     def delete_message(message_id: int, user_id: int):
         """ Deletes the specified message """
-        message = MessageService.get_message(message_id, user_id)
-        message.delete()
+        # message = MessageService.get_message(message_id, user_id)
+        # message.delete()
 
     @staticmethod
     def delete_multiple_messages(message_ids: list, user_id: int):
         """ Deletes the specified messages to the user """
-        Message.delete_multiple_messages(message_ids, user_id)
+       #  Message.delete_multiple_messages(message_ids, user_id)
 
     @staticmethod
     def get_task_link(project_id: int, task_id: int, base_url=None) -> str:


### PR DESCRIPTION
Enabling verboser logging inadvertently caused the RDS instance storage to fill up. This PR will revert those changes. 