### PR TITLE
Enable RDS Cloudwatch Logging and transactional logs

### DIFF
--- a/devops/cloudformation/tasking-manager.template.js
+++ b/devops/cloudformation/tasking-manager.template.js
@@ -418,6 +418,8 @@ const Resources = {
         AllocatedStorage: cf.ref('DatabaseSize'),
         BackupRetentionPeriod: 10,
         StorageType: 'gp2',
+        DBParameterGroupName: 'tm3-logging-postgres11',
+        EnableCloudwatchLogsExports: ['postgresql'],
         DBInstanceClass: cf.if('IsTaskingManagerProduction', 'db.m3.large', 'db.t2.small'),
         DBSnapshotIdentifier: cf.if('UseASnapshot', cf.ref('DBSnapshot'), cf.noValue),
         VPCSecurityGroups: [cf.importValue(cf.join('-', ['hotosm-network-production', cf.ref('Environment'), 'ec2s-security-group', cf.region]))],


### PR DESCRIPTION
Resolved the RDS part of https://github.com/hotosm/tasking-manager/issues/1693

The database is currently at 100GB so it shouldn't fill up like before. The logs are stored temporarily on the file system before being pushed to s3, so as long as they are not massive, it should be fine. 