### PR TITLE
Avoid providing standard changeset comment

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -10,21 +10,21 @@ from server.services.users.user_service import UserService
 
 import os
 import warnings
- 
+
 # Load configuration from file
 load_dotenv(os.path.join(os.path.dirname(__file__), 'tasking-manager.env'))
 
 # Temporarily here - to support backwards compatibility with TM_DB key.
 if os.getenv('TM_DB', False):
-    for key in ['TM_APP_BASE_URL','TM_SECRET','TM_CONSUMER_KEY','TM_CONSUMER_SECRET']:
+    for key in ['TM_APP_BASE_URL', 'TM_SECRET', 'TM_CONSUMER_KEY', 'TM_CONSUMER_SECRET']:
         if not os.getenv(key):
             warnings.warn("%s environmental variable not set." % (key,))
 else:
     # Check that required environmental variables are set
-    for key in ['TM_APP_BASE_URL','POSTGRES_DB','POSTGRES_USER','POSTGRES_PASSWORD','TM_SECRET','TM_CONSUMER_KEY','TM_CONSUMER_SECRET']:
+    for key in ['TM_APP_BASE_URL', 'POSTGRES_DB', 'POSTGRES_USER', 'POSTGRES_PASSWORD', 'TM_SECRET',
+                'TM_CONSUMER_KEY', 'TM_CONSUMER_SECRET', 'TM_DEFAULT_CHANGESET_COMMENT']:
         if not os.getenv(key):
             warnings.warn("%s environmental variable not set." % (key,))
-
 
 # Initialise the flask app object
 application = create_app()

--- a/server/config.py
+++ b/server/config.py
@@ -2,6 +2,7 @@ import logging
 import os
 from dotenv import load_dotenv
 
+
 class EnvironmentConfig:
     """ Base class for configuration. """
     """ Most settings can be defined through environment variables. """
@@ -13,7 +14,7 @@ class EnvironmentConfig:
     APP_BASE_URL = os.getenv('TM_APP_BASE_URL', 'http://127.0.0.1:5000')
     
     # The default tag used in the OSM changeset comment
-    DEFAULT_CHANGESET_COMMENT = os.getenv('TM_DEFAULT_CHANGESET_COMMENT', '#tm-project')
+    DEFAULT_CHANGESET_COMMENT = os.getenv('TM_DEFAULT_CHANGESET_COMMENT', None)
     
     # The address to use as the sender on auto generated emails
     EMAIL_FROM_ADDRESS = os.getenv('TM_EMAIL_FROM_ADDRESS', None)


### PR DESCRIPTION
Fixes #1663

This PR requires instances to set their own changeset comment. This is very important because they should never be the same between instances.