### PR TITLE
Deprecate former environment schema

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -14,17 +14,11 @@ import warnings
 # Load configuration from file
 load_dotenv(os.path.join(os.path.dirname(__file__), 'tasking-manager.env'))
 
-# Temporarily here - to support backwards compatibility with TM_DB key.
-if os.getenv('TM_DB', False):
-    for key in ['TM_APP_BASE_URL', 'TM_SECRET', 'TM_CONSUMER_KEY', 'TM_CONSUMER_SECRET']:
-        if not os.getenv(key):
-            warnings.warn("%s environmental variable not set." % (key,))
-else:
-    # Check that required environmental variables are set
-    for key in ['TM_APP_BASE_URL', 'POSTGRES_DB', 'POSTGRES_USER', 'POSTGRES_PASSWORD', 'TM_SECRET',
-                'TM_CONSUMER_KEY', 'TM_CONSUMER_SECRET', 'TM_DEFAULT_CHANGESET_COMMENT']:
-        if not os.getenv(key):
-            warnings.warn("%s environmental variable not set." % (key,))
+# Check that required environmental variables are set
+for key in ['TM_APP_BASE_URL', 'POSTGRES_DB', 'POSTGRES_USER', 'POSTGRES_PASSWORD', 'TM_SECRET',
+            'TM_CONSUMER_KEY', 'TM_CONSUMER_SECRET', 'TM_DEFAULT_CHANGESET_COMMENT']:
+    if not os.getenv(key):
+        warnings.warn("%s environmental variable not set." % (key,))
 
 # Initialise the flask app object
 application = create_app()


### PR DESCRIPTION
Aiming for version 4 of the TM, we can deprecate the former environment variables for the configuration and rely only on the one introduced in version 3.2.0