### PR TITLE
Change ASG Policy to Target Request Count threshold (#1701)

### DIFF
--- a/devops/cloudformation/tasking-manager.template.js
+++ b/devops/cloudformation/tasking-manager.template.js
@@ -127,9 +127,9 @@ const Resources = {
         AutoScalingGroupName: cf.ref('TaskingManagerASG'),
         PolicyType: 'TargetTrackingScaling',
         TargetTrackingConfiguration: {
-          TargetValue: 85,
+          TargetValue: 400,
           PredefinedMetricSpecification: {
-            PredefinedMetricType: 'ASGAverageCPUUtilization'
+            PredefinedMetricType: 'ALBRequestCountPerTarget'
           }
         },
         Cooldown: 300


### PR DESCRIPTION
Resolves #1701 

This PR would change the Autoscaling Policy from monitoring CPU to trigger new instances to using Target Requests (see https://github.com/hotosm/tasking-manager/issues/1701#issuecomment-503731829)

I'm open to turning this into a hotfix @xamanu 