### PR TITLE
Improve contribution stats endpoint

### DIFF
--- a/client/app/services/project.service.js
+++ b/client/app/services/project.service.js
@@ -712,7 +712,7 @@
             if (enforceValidateRole) {
                 var validatorRoles = ['ADMIN', 'PROJECT_MANAGER', 'VALIDATOR'];
                 userCanValidate = (validatorRoles.indexOf(userRole) != -1);
-            } 
+            }
             if (allowNonBeginners) {
                 var allowedLevels = ['INTERMEDIATE','ADVANCED']
                 userCanValidate = (allowedLevels.indexOf(mappingLevel) != -1);
@@ -804,5 +804,6 @@
                 return $q.reject("error");
             });
         }
+
     }
 })();

--- a/client/app/services/stats.service.js
+++ b/client/app/services/stats.service.js
@@ -14,7 +14,8 @@
             getProjectContributions: getProjectContributions,
             getProjectActivity: getProjectActivity,
             getProjectStats: getProjectStats,
-            getHomePageStats: getHomePageStats
+            getProjectUserStats: getProjectUserStats,
+            getHomePageStats: getHomePageStats,
         };
 
         return service;
@@ -97,6 +98,28 @@
             return $http({
                 method: 'GET',
                 url: configService.tmAPI + '/stats/summary'
+            }).then(function successCallback(response) {
+                // this callback will be called asynchronously
+                // when the response is available
+                return response.data;
+            }, function errorCallback() {
+                // called asynchronously if an error occurs
+                // or server returns response with an error status.
+                return $q.reject("error");
+            });
+        }
+
+        /**
+         * Get project stats
+         * @param projectId
+         * @param username
+         * @returns {*|!jQuery.deferred|!jQuery.Promise|!jQuery.jqXHR}
+         */
+        function getProjectUserStats(projectId, username){
+            // Returns a promise
+            return $http({
+                method: 'GET',
+                url: configService.tmAPI + '/stats/project/' + projectId + 'user/' + username
             }).then(function successCallback(response) {
                 // this callback will be called asynchronously
                 // when the response is available

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -107,7 +107,7 @@ def init_flask_restful_routes(app):
     from server.api.project_apis import ProjectAPI, ProjectAOIAPI, ProjectSearchAPI, HasUserTaskOnProject,\
         HasUserTaskOnProjectDetails, ProjectSearchBBoxAPI, ProjectSummaryAPI, TaskAnnotationsAPI
     from server.api.swagger_docs_api import SwaggerDocsAPI
-    from server.api.stats_api import StatsContributionsAPI, StatsActivityAPI, StatsProjectAPI, HomePageStatsAPI, StatsUserAPI
+    from server.api.stats_api import StatsContributionsAPI, StatsActivityAPI, StatsProjectAPI, HomePageStatsAPI, StatsUserAPI, StatsProjectUserAPI
     from server.api.tags_apis import CampaignsTagsAPI, OrganisationTagsAPI
     from server.api.mapping_issues_apis import MappingIssueCategoryAPI, MappingIssueCategoriesAPI
     from server.api.users.user_apis import UserAPI, UserIdAPI, UserOSMAPI, UserMappedProjects, UserSetRole, UserSetLevel,\
@@ -170,6 +170,7 @@ def init_flask_restful_routes(app):
     api.add_resource(TaskAnnotationsAPI, '/api/v1/project/<int:project_id>/task-annotations/<string:annotation_type>', '/api/v1/project/<int:project_id>/task-annotations', methods=['GET', 'POST'])
     api.add_resource(StatsActivityAPI,              '/api/v1/stats/project/<int:project_id>/activity')
     api.add_resource(StatsProjectAPI,               '/api/v1/stats/project/<int:project_id>')
+    api.add_resource(StatsProjectUserAPI,           '/api/v1/stats/project/<int:project_id>/user/<string:username>')
     api.add_resource(StatsUserAPI,                  '/api/v1/stats/user/<string:username>')
     api.add_resource(HomePageStatsAPI,              '/api/v1/stats/summary')
     api.add_resource(CampaignsTagsAPI,              '/api/v1/tags/campaigns')

--- a/server/api/project_apis.py
+++ b/server/api/project_apis.py
@@ -574,7 +574,7 @@ class TaskAnnotationsAPI(Resource):
             return {"error": "No token supplied"}, 500
 
         try:
-            annotations = request.get_json() or {} 
+            annotations = request.get_json() or {}
         except DataError as e:
             current_app.logger.error(f'Error validating request: {str(e)}')
 

--- a/server/api/stats_api.py
+++ b/server/api/stats_api.py
@@ -111,7 +111,7 @@ class StatsProjectAPI(Resource):
         """
         try:
             preferred_locale = request.environ.get('HTTP_ACCEPT_LANGUAGE')
-            summary = ProjectService.get_project_summary(project_id, preferred_locale)
+            summary = ProjectService.get_project_stats(project_id)
             return summary.to_primitive(), 200
         except NotFound:
             return {"Error": "Project not found"}, 404
@@ -147,6 +147,7 @@ class HomePageStatsAPI(Resource):
 
 
 class StatsUserAPI(Resource):
+
     def get(self, username):
         """
         Get detailed stats about user
@@ -172,6 +173,47 @@ class StatsUserAPI(Resource):
         """
         try:
             stats_dto = UserService.get_detailed_stats(username)
+            return stats_dto.to_primitive(), 200
+        except NotFound:
+            return {"Error": "User not found"}, 404
+        except Exception as e:
+            error_msg = f'User GET - unhandled error: {str(e)}'
+            current_app.logger.critical(error_msg)
+            return {"error": error_msg}, 500
+
+
+class StatsProjectUserAPI(Resource):
+
+    def get(self, project_id, username):
+        """
+        Get detailed stats about user
+        ---
+        tags:
+          - user
+        produces:
+          - application/json
+        parameters:
+            - name: project_id
+              in: path
+              required: true
+              type: integer
+              default: 1
+            - name: username
+              in: path
+              description: The users username
+              required: true
+              type: string
+              default: Thinkwhere
+        responses:
+            200:
+                description: User found
+            404:
+                description: User not found
+            500:
+                description: Internal Server Error
+        """
+        try:
+            stats_dto = ProjectService.get_project_user_stats(project_id, username)
             return stats_dto.to_primitive(), 200
         except NotFound:
             return {"Error": "User not found"}, 404

--- a/server/models/dtos/project_dto.py
+++ b/server/models/dtos/project_dto.py
@@ -245,14 +245,6 @@ class ProjectSummary(Model):
     mapper_level_enforced = BooleanType(serialized_name='mapperLevelEnforced')
     validator_level_enforced = BooleanType(serialized_name='validatorLevelEnforced')
     short_description = StringType(serialized_name='shortDescription')
-    total_mappers = IntType(serialized_name='totalMappers')
-    total_tasks = IntType(serialized_name='totalTasks')
-    total_comments = IntType(serialized_name='totalComments')
-    total_mapping_time = IntType(serialized_name='totalMappingTime')
-    total_validation_time = IntType(serialized_name='totalValidationTime')
-    total_time_spent = IntType(serialized_name='totalTimeSpent')
-    average_mapping_time = IntType(serialized_name='averageMappingTime')
-    average_validation_time = IntType(serialized_name='averageValidationTime')
     status = StringType()
 
 
@@ -279,3 +271,27 @@ class ProjectTaskAnnotationsDTO(Model):
 
     project_id = IntType(required=True, serialized_name='projectId')
     tasks = ListType(ModelType(TaskAnnotationDTO), required=True, serialized_name='tasks')
+
+class ProjectStatsDTO(Model):
+    """ DTO for detailed stats on a project """
+    project_id = IntType(required=True, serialized_name='projectId')
+    area = FloatType(serialized_name='projectArea(in sq.km)')
+    total_mappers = IntType(serialized_name='totalMappers')
+    total_tasks = IntType(serialized_name='totalTasks')
+    total_comments = IntType(serialized_name='totalComments')
+    total_mapping_time = IntType(serialized_name='totalMappingTime')
+    total_validation_time = IntType(serialized_name='totalValidationTime')
+    total_time_spent = IntType(serialized_name='totalTimeSpent')
+    average_mapping_time = IntType(serialized_name='averageMappingTime')
+    average_validation_time = IntType(serialized_name='averageValidationTime')
+    percent_mapped = IntType(serialized_name='percentMapped')
+    percent_validated = IntType(serialized_name='percentValidated')
+    percent_bad_imagery = IntType(serialized_name='percentBadImagery')
+    aoi_centroid = BaseType(serialized_name='aoiCentroid')
+
+
+class ProjectUserStatsDTO(Model):
+    """ DTO for time spent by users on a project """
+    time_spent_mapping = IntType(serialized_name='timeSpentMapping')
+    time_spent_validating = IntType(serialized_name='timeSpentValidating')
+    total_time_spent = IntType(serialized_name='totalTimeSpent')

--- a/server/models/dtos/stats_dto.py
+++ b/server/models/dtos/stats_dto.py
@@ -9,9 +9,6 @@ class UserContribution(Model):
     username = StringType()
     mapped = IntType()
     validated = IntType()
-    time_spent_mapping = IntType(serialized_name='timeSpentMapping')
-    time_spent_validating = IntType(serialized_name='timeSpentValidating')
-    total_time_spent = IntType(serialized_name='totalTimeSpent')
 
 
 class ProjectContributionsDTO(Model):
@@ -72,7 +69,7 @@ class CampaignStatsDTO(Model):
         super().__init__()
         self.tag = tup[0]
         self.projects_created = tup[1]
-    
+
     tag = StringType()
     projects_created = IntType(serialized_name='projectsCreated')
 
@@ -98,4 +95,3 @@ class HomePageStatsDTO(Model):
     # avg_completion_time = IntType(serialized_name='averageCompletionTime')
     organizations = ListType(ModelType(OrganizationStatsDTO))
     campaigns = ListType(ModelType(CampaignStatsDTO))
-    

--- a/server/models/dtos/user_dto.py
+++ b/server/models/dtos/user_dto.py
@@ -38,7 +38,7 @@ class UserDTO(Model):
     date_registered = StringType(serialized_name='dateRegistered')
     total_time_spent = IntType(serialized_name='totalTimeSpent')
     time_spent_mapping = IntType(serialized_name='timeSpentMapping')
-    time_spent_validating = IntType(serialized_name='timeSpentValidating') 
+    time_spent_validating = IntType(serialized_name='timeSpentValidating')
     projects_mapped = IntType(serialized_name='projectsMapped')
     tasks_mapped = IntType(serialized_name='tasksMapped')
     tasks_validated = IntType(serialized_name='tasksValidated')
@@ -55,7 +55,7 @@ class UserStatsDTO(Model):
     """ DTO containing statistics about the user """
     total_time_spent = IntType(serialized_name='totalTimeSpent')
     time_spent_mapping = IntType(serialized_name='timeSpentMapping')
-    time_spent_validating = IntType(serialized_name='timeSpentValidating') 
+    time_spent_validating = IntType(serialized_name='timeSpentValidating')
     projects_mapped = IntType(serialized_name='projectsMapped')
     tasks_mapped = IntType(serialized_name='tasksMapped')
     tasks_validated = IntType(serialized_name='tasksValidated')

--- a/server/services/project_search_service.py
+++ b/server/services/project_search_service.py
@@ -6,7 +6,6 @@ from server.models.dtos.project_dto import ProjectSearchDTO, ProjectSearchResult
 from server.models.postgis.project import Project, ProjectInfo
 from server.models.postgis.statuses import ProjectStatus, MappingLevel, MappingTypes, ProjectPriority
 from server.models.postgis.utils import NotFound, ST_Intersects, ST_MakeEnvelope, ST_Transform, ST_Area
-from server.services.users.user_service import UserService
 from server import db
 from flask import current_app
 from geoalchemy2 import shape
@@ -77,10 +76,12 @@ class ProjectSearchService:
             list_dto.short_description = project_info_dto.short_description
             list_dto.organisation_tag = project.organisation_tag
             list_dto.campaign_tag = project.campaign_tag
-            list_dto.percent_mapped = round(
-                ((project.tasks_mapped + project.tasks_validated) / (project.total_tasks - project.tasks_bad_imagery)) * 100, 0)
-            list_dto.percent_validated = round(
-                (project.tasks_validated / (project.total_tasks + project.tasks_bad_imagery)) * 100, 0)
+            list_dto.percent_mapped = Project.calculate_tasks_percent('mapped', project.total_tasks,
+                                                                      project.tasks_mapped, project.tasks_validated,
+                                                                      project.tasks_bad_imagery)
+            list_dto.percent_validated = Project.calculate_tasks_percent('validated', project.total_tasks,
+                                                                         project.tasks_mapped, project.tasks_validated,
+                                                                         project.tasks_bad_imagery)
             list_dto.status = ProjectStatus(project.status).name
             list_dto.active_mappers = Project.get_active_mappers(project.id)
 

--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -2,7 +2,7 @@ from cachetools import TTLCache, cached
 from flask import current_app
 
 from server.models.dtos.mapping_dto import TaskDTOs
-from server.models.dtos.project_dto import ProjectDTO, LockedTasksForUser, ProjectSummary
+from server.models.dtos.project_dto import ProjectDTO, LockedTasksForUser, ProjectSummary, ProjectStatsDTO, ProjectUserStatsDTO
 from server.models.postgis.project import Project, ProjectStatus, MappingLevel
 from server.models.postgis.statuses import MappingNotAllowed, ValidatingNotAllowed
 from server.models.postgis.task import Task
@@ -177,3 +177,17 @@ class ProjectService:
         """ Gets the project title DTO """
         project = ProjectService.get_project_by_id(project_id)
         return project.get_project_title(preferred_locale)
+
+    @staticmethod
+    def get_project_stats(project_id: int) -> ProjectStatsDTO:
+        """ Gets the project stats DTO """
+        project = ProjectService.get_project_by_id(project_id)
+        return project.get_project_stats()
+
+    @staticmethod
+    def get_project_user_stats(project_id: int, username: str) -> ProjectUserStatsDTO:
+        """ Gets the user stats for a specific project """
+        print(project_id)
+        project = ProjectService.get_project_by_id(project_id)
+        user = UserService.get_user_by_username(username)
+        return project.get_project_user_stats(user.id)


### PR DESCRIPTION
#1685
 Adds an abbreviated parameter to:
- [x] GET /api/v1/stats/project/{project_id}/contributions
- [x] GET /api/v1/project/{project_id}/summary

Both these endpoint defaults to `abbreviated=true`.

Setting abbreviated to true, would fetch only results that are not computationally intensive and satisfies the bare minimum requirement for the page that invokes the endpoint. To implement this moves the time computations to a separate class and added a condition check to the respective functions.

### For Review:
- [ ] Check project activity and stats page. Contribution tab should list all the mapped and validated counts and the loading time should be quick. In the current deployment, this endpoint timeouts or takes more than 30s
- [ ] Check project admin dashboard, this should have a faster load time for centroid on map
- [ ] Check endpoints on swagger with the different query values on abbreviated parameter:
    - [ ] [Project Contributions](http://127.0.0.1:5000/api-docs/swagger-ui/index.html?url=http://127.0.0.1:5000/api/docs#!/stats/get_api_v1_stats_project_project_id_contributions)
    - [ ] [Project Summary](http://127.0.0.1:5000/api-docs/swagger-ui/index.html?url=http://127.0.0.1:5000/api/docs#!/mapping/get_api_v1_project_project_id_summary)
    - [ ] [Project Stats](http://127.0.0.1:5000/api-docs/swagger-ui/index.html?url=http://127.0.0.1:5000/api/docs#!/stats/get_api_v1_stats_project_project_id)
   - [ ] [Filter user stats for a project](http://127.0.0.1:5000/api-docs/swagger-ui/index.html?url=http://127.0.0.1:5000/api/docs#!/user/get_api_v1_stats_project_project_id_user_username)