### PR TITLE
Update eslint to 4.18.2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
     "chart.js": "^2.8.0",
     "connect-modrewrite": "^0.9.0",
     "del": "^2.2.2",
-    "eslint": "4.16.0",
+    "eslint": "4.18.2",
     "eslint-config-angular": "0.5.0",
     "eslint-plugin-angular": "3.2.0",
     "font-awesome": "^4.7.0",

--- a/example.env
+++ b/example.env
@@ -61,8 +61,8 @@ TM_CONSUMER_SECRET=s0m3l0ngr4nd0mstr1ng-b3cr34tiv3&h4v3fun
 # Languages offered by the Tasking Manager (optional)
 # Please note that there must be exactly the same number of Codes as languages.
 #
-# TM_SUPPORTED_LANGUAGES_CODES='ar, cs, da, de, en, es, fa_IR, fi, fr, hu, gl, id, it, ja, lt, mg, nb, nl_NL, pl, pt, pt_BR, ru, si, sl, ta, uk, vi, zh_TW'
-# TM_SUPPORTED_LANGUAGES='Arabic, Česky, Dansk, Deutsch, English, Español, Persian (Iran), Suomi, Français, Magyar, Galician, Indonesia, Italiano, 日本語, Lietuvos, Malagasy, Bokmål, Nederlands, Polish, Português, Português (Brasil), Русский, සිංහල, Slovenščina, தமிழ், Українська, tiếng Việt, 中文')
+# TM_SUPPORTED_LANGUAGES_CODES='ar, cs, da, de, en, es, fa_IR, fi, fr, hu, gl, id, it, ja, ko, lt, mg, nb, nl_NL, pl, pt, pt_BR, ru, si, sl, ta, uk, vi, zh_TW'
+# TM_SUPPORTED_LANGUAGES='Arabic, Česky, Dansk, Deutsch, English, Español, Persian (Iran), Suomi, Français, Magyar, Galician, Indonesia, Italiano, 日本語, 한국어, Lietuvos, Malagasy, Bokmål, Nederlands, Polish, Português, Português (Brasil), Русский, සිංහල, Slovenščina, தமிழ், Українська, tiếng Việt, 中文'
 
 # Time to wait until task auto-unlock (optional)
 # (e.g. '2h' or '7d' or '30m' or '1h30m')


### PR DESCRIPTION
* Eslint has a security update, which is included here
* Further, I sneak in here some minor changes on the example configuration file to support Korean (related to #1717)