### PR TITLE
Include automatic trigger for indexing text_searchable

### DIFF
--- a/migrations/versions/451f6bd05a19_.py
+++ b/migrations/versions/451f6bd05a19_.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: 451f6bd05a19
+Revises: a43b9748ceee
+Create Date: 2019-07-02 17:03:55.567940
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '451f6bd05a19'
+down_revision = 'a43b9748ceee'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('DROP TRIGGER IF EXISTS tsvectorupdate ON project_info; CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON project_info FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger(text_searchable, "pg_catalog.english", project_id_str, short_description, description)')
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
This PR fixes #1723 . Current database status with latest migration file does not have automatic trigger to index information into the `text_searchable` column from project_info table. This disallows project search since text_searchable column is NULL

The commit enables and automatic trigger which indexes before an insert or update in project info table.

**how to test**:
1. Create a fresh database.
2. Run migrations
```python manage.py db upgrade```
3. Downgrade
```python manage.py db downgrade```
4. Create a project with description and short description.
5. Verify that text_searchable column is null.
```SELECT text_searchable FROM project_info```
6. Update migrations
```python manage.py db upgrade```
7. Edit project_info again
8. Verify that information is indexed
```SELECT text_searchable FROM project_info```

NOTE: This trigger will work also for previous project 


