### PR TITLE
List popular projects

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -146,6 +146,7 @@ def add_api_endpoints(app):
     from server.api.projects.statistics import (
         ProjectsStatisticsAPI,
         ProjectsStatisticsQueriesUsernameAPI,
+        ProjectsStatisticsQueriesPopularAPI,
     )
     from server.api.projects.actions import (
         ProjectsActionsTransferAPI,
@@ -297,9 +298,14 @@ def add_api_endpoints(app):
     api.add_resource(
         ProjectsStatisticsAPI, "/api/v2/projects/<int:project_id>/statistics/"
     )
+
     api.add_resource(
         ProjectsStatisticsQueriesUsernameAPI,
         "/api/v2/projects/<int:project_id>/statistics/queries/<string:username>/",
+    )
+
+    api.add_resource(
+        ProjectsStatisticsQueriesPopularAPI, "/api/v2/projects/queries/popular/"
     )
 
     # Projects actions endoints

--- a/server/api/projects/statistics.py
+++ b/server/api/projects/statistics.py
@@ -1,6 +1,30 @@
 from flask_restful import Resource, current_app
-from server.services.stats_service import NotFound
+from server.services.stats_service import NotFound, StatsService
 from server.services.project_service import ProjectService
+
+
+class ProjectsStatisticsQueriesPopularAPI(Resource):
+    def get(self):
+        """
+        Get Popular project Stats
+        ---
+        tags:
+          - projects
+        produces:
+          - application/json
+        responses:
+            200:
+                description: Popular Projects stats
+            500:
+                description: Internal Server Error
+        """
+        try:
+            stats = StatsService.get_popular_projects()
+            return stats.to_primitive(), 200
+        except Exception as e:
+            error_msg = f"Unhandled error: {str(e)}"
+            current_app.logger.critical(error_msg)
+            return {"error": error_msg}, 500
 
 
 class ProjectsStatisticsAPI(Resource):

--- a/server/services/project_search_service.py
+++ b/server/services/project_search_service.py
@@ -116,16 +116,13 @@ class ProjectSearchService:
     @staticmethod
     def get_total_contributions(paginated_results):
         paginated_projects_ids = [p.id for p in paginated_results]
-        filtered_projects = Project.query.filter(
-            Project.id.in_(paginated_projects_ids)
-        ).subquery()
 
         # We need to make a join to return projects without contributors.
         project_contributors_count = (
             Project.query.with_entities(
                 Project.id, func.count(distinct(TaskHistory.user_id)).label("total")
             )
-            .filter(Project.id == filtered_projects.c.id)
+            .filter(Project.id.in_(paginated_projects_ids))
             .outerjoin(TaskHistory, TaskHistory.project_id == Project.id)
             .group_by(Project.id)
             .all()


### PR DESCRIPTION
This PR fixes #1613 . The established logic corresponds to list 30 most popular projects. The popularity level consists on projects with most tasks changes for the past 30 days.

**How to test**
Using a database dump, hit `/api/v1/stats/popular/projects`

