### PR TITLE
make api-docs url load even with trailing backslash

### DIFF
--- a/server/web/controller.py
+++ b/server/web/controller.py
@@ -32,7 +32,7 @@ def app(path):
     return send_from_directory(main.static_folder, 'app/' + path)
 
 
-@main.route('/api-docs')
+@main.route('/api-docs/')
 def api():
     """
     Route for API Docs welcome page


### PR DESCRIPTION
api-docs was failing to load if we access with a trailing backslash