### PR TITLE
List contributions from a user by day

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -112,7 +112,8 @@ def init_flask_restful_routes(app):
     from server.api.tags_apis import CampaignsTagsAPI, OrganisationTagsAPI
     from server.api.mapping_issues_apis import MappingIssueCategoryAPI, MappingIssueCategoriesAPI
     from server.api.users.user_apis import UserAPI, UserIdAPI, UserOSMAPI, UserMappedProjects, UserSetRole, UserSetLevel,\
-        UserSetExpertMode, UserAcceptLicense, UserSearchFilterAPI, UserSearchAllAPI, UserUpdateAPI
+        UserSetExpertMode, UserAcceptLicense, UserSearchFilterAPI, UserSearchAllAPI, UserUpdateAPI,\
+        UserContributionsAPI
     from server.api.validator_apis import LockTasksForValidationAPI, UnlockTasksAfterValidationAPI, StopValidatingAPI,\
         MappedTasksByUser, UserInvalidatedTasks
     from server.api.grid.grid_apis import IntersectingTilesAPI
@@ -192,6 +193,7 @@ def init_flask_restful_routes(app):
     api.add_resource(UserSetLevel,                  '/api/v1/user/<string:username>/set-level/<string:level>')
     api.add_resource(UserAcceptLicense,             '/api/v1/user/accept-license/<int:license_id>')
     api.add_resource(UserIdAPI,                     '/api/v1/user-id/<int:userid>')
+    api.add_resource(UserContributionsAPI,          '/api/v1/user-id/<int:userid>/contributions')
     api.add_resource(IntersectingTilesAPI,          '/api/v1/grid/intersecting-tiles')
     api.add_resource(SplitTaskAPI,                  '/api/v1/project/<int:project_id>/task/<int:task_id>/split')
     api.add_resource(LanguagesAPI,                  '/api/v1/settings')

--- a/server/api/users/user_apis.py
+++ b/server/api/users/user_apis.py
@@ -92,6 +92,49 @@ class UserIdAPI(Resource):
             return {"error": error_msg}, 500
 
 
+class UserContributionsAPI(Resource):
+    @tm.pm_only(False)
+    @token_auth.login_required
+    def get(self, userid):
+        """
+        Gets daiy user contributions by id
+        ---
+        tags:
+          - user
+        produces:
+          - application/json
+        parameters:
+            - in: header
+              name: Authorization
+              description: Base64 encoded sesesion token
+              required: true
+              type: string
+              default: Token sessionTokenHere==
+            - name: userid
+              in: path
+              description: The users user id
+              required: true
+              type: integer
+              default: 1
+        responses:
+            200:
+                description: User found
+            404:
+                description: User not found
+            500:
+                description: Internal Server Error
+        """
+        try:
+            contributions = UserService.get_contributions_by_day(userid)
+            return contributions.to_primitive(), 200
+        except NotFound:
+            return {"Error": "User not found"}, 404
+        except Exception as e:
+            error_msg = f'Userid GET - unhandled error: {str(e)}'
+            current_app.logger.critical(error_msg)
+            return {"error": error_msg}, 500
+
+
 class UserUpdateAPI(Resource):
     @tm.pm_only(False)
     @token_auth.login_required

--- a/server/api/users/user_apis.py
+++ b/server/api/users/user_apis.py
@@ -97,7 +97,7 @@ class UserContributionsAPI(Resource):
     @token_auth.login_required
     def get(self, userid):
         """
-        Gets daiy user contributions by id
+        Gets daily amount of user contributions by id
         ---
         tags:
           - user

--- a/server/models/dtos/user_dto.py
+++ b/server/models/dtos/user_dto.py
@@ -97,6 +97,20 @@ class UserSearchQuery(Model):
         return hash((self.username, self.role, self.mapping_level, self.page))
 
 
+class UserContributionDTO(Model):
+    date = StringType()
+    count = IntType()
+
+
+class UserContributionsDTO(Model):
+    """ DTO for projects a user has mapped """
+    def __init__(self):
+        super().__init__()
+        self.contributions = []
+
+    contributions = ListType(ModelType(UserContributionDTO), serialized_name='contributions')
+
+
 class ListedUser(Model):
     """ Describes a user within the User List """
     id = LongType()


### PR DESCRIPTION
This PR closes #1604. Within the API, when hitting:
```
'/api/v1/user-id/<int:userid>/contributions
```
The server will return the number of contributions by day for the last 365 days. Dates without contributions will have the value of 0.

