### PR TITLE
Fix #1622: Circle-ci RDS snapshot replacement is buggy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,8 @@ jobs:
     - run:
         name: Set folder permissions
         command: |
-          chown -R circleci:circleci $CIRCLE_WORKING_DIRECTORY
-          chmod -R 755 $CIRCLE_WORKING_DIRECTORY
+          chown -R circleci:circleci ${CIRCLE_WORKING_DIRECTORY}
+          chmod -R 755 ${CIRCLE_WORKING_DIRECTORY}
     - restore_cache:
         keys:
         - cached-dependencies
@@ -30,22 +30,22 @@ jobs:
         name: Install requirements
         command: |
           # Install NPM packages and build client from gulpfile
-          cd $CIRCLE_WORKING_DIRECTORY/client
+          cd ${CIRCLE_WORKING_DIRECTORY}/client
           npm install
           ./node_modules/.bin/gulp build
-          cd $CIRCLE_WORKING_DIRECTORY
+          cd ${CIRCLE_WORKING_DIRECTORY}
           # Install Python dependencies
           pip install virtualenv
           virtualenv env
-          $CIRCLE_WORKING_DIRECTORY/env/bin/pip install --upgrade pip
-          $CIRCLE_WORKING_DIRECTORY/env/bin/pip install -r requirements.txt
+          ${CIRCLE_WORKING_DIRECTORY}/env/bin/pip install --upgrade pip
+          ${CIRCLE_WORKING_DIRECTORY}/env/bin/pip install -r requirements.txt
     - run:
         name: Run JS Unit tests
         command: |
           # JS Unit Tests
-          cd $CIRCLE_WORKING_DIRECTORY/tests/client
-          mkdir $CIRCLE_WORKING_DIRECTORY/tests/client/junit
-          $CIRCLE_WORKING_DIRECTORY/client/node_modules/.bin/karma start ./karma.conf.js \
+          cd ${CIRCLE_WORKING_DIRECTORY}/tests/client
+          mkdir ${CIRCLE_WORKING_DIRECTORY}/tests/client/junit
+          ${CIRCLE_WORKING_DIRECTORY}/client/node_modules/.bin/karma start ./karma.conf.js \
             --single-run --browsers PhantomJS --reporters junit
         environment:
             JUNIT_REPORT_PATH: $CIRCLE_WORKING_DIRECTORY/tests/client/junit/
@@ -58,13 +58,13 @@ jobs:
         name: Run Python Tests
         command: |
           # Run Python tests
-          cd $CIRCLE_WORKING_DIRECTORY
-          mkdir $CIRCLE_WORKING_DIRECTORY/tests/server/results
+          cd ${CIRCLE_WORKING_DIRECTORY}
+          mkdir ${CIRCLE_WORKING_DIRECTORY}/tests/server/results
           find ./tests/server -name "test*.py" -exec chmod -x {} \;
           env/bin/nosetests ./tests/server --with-xunit \
-            --xunit-file $CIRCLE_WORKING_DIRECTORY/tests/server/results/unitresults.xml \
+            --xunit-file ${CIRCLE_WORKING_DIRECTORY}/tests/server/results/unitresults.xml \
             --with-coverage --cover-erase --cover-package=./server
-          env/bin/coverage xml -o $CIRCLE_WORKING_DIRECTORY/tests/server/results/coverage.xml
+          env/bin/coverage xml -o ${CIRCLE_WORKING_DIRECTORY}/tests/server/results/coverage.xml
     - store_test_results:
         path: tests/server/results
     - store_artifacts:
@@ -175,18 +175,18 @@ jobs:
               echo "Snapshot does not exist, creating one now."
           else
               aws rds copy-db-snapshot \
-                      --source-db-snapshot tm3-<< parameters.stack_name >>-$RDS_ID-latest \
+                      --source-db-snapshot tm3-<< parameters.stack_name >>-${RDS_ID}-latest \
                       --target-db-snapshot tm3-<< parameters.stack_name >>-${RDS_ID}-${NONCE}
               aws rds delete-db-snapshot \
-                      --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest
+                      --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-latest
           fi
           # create new aws rds snapshot
           aws rds create-db-snapshot \
-                      --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest \
-                      --db-instance-identifier $RDS_ID
+                      --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-latest \
+                      --db-instance-identifier ${RDS_ID}
           aws rds wait db-snapshot-completed \
-                      --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest \
-                      --db-instance-identifier $RDS_ID
+                      --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-latest \
+                      --db-instance-identifier ${RDS_ID}
           if [[ $? -eq 255 ]]; then
             echo "Production snapshot creation failed. Exiting with exit-code 125"
             exit 125
@@ -203,7 +203,7 @@ jobs:
         name: Cleanup
         when: always
         command: |
-          DESCRIBE_SNAPSHOT=$(aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-${NONCE} --db-instance-identifier $RDS_ID --output text)
+          DESCRIBE_SNAPSHOT=$(aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-${NONCE} --db-instance-identifier ${RDS_ID} --output text)
           # Copy old snapshot to temporary
           if [ -z "$DESCRIBE_SNAPSHOT" ]
           then
@@ -215,7 +215,7 @@ jobs:
           RDS_ID_NEW=$(./.circleci/rdsid.sh '{"aws:cloudformation:stack-name": "tasking-manager-<< parameters.stack_name >>"}')
           if [ "$RDS_ID" != "$RDS_ID_NEW" ]
           then
-            aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest
+            aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-latest
           fi
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,18 +166,27 @@ jobs:
         name: Remove last snapshot and backup database
         no_output_timeout: 15m
         command: |
-          DESCRIBE_SNAPSHOT=`aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest --db-instance-identifier $RDS_ID --output text`
+          DESCRIBE_SNAPSHOT=$(aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest --db-instance-identifier $RDS_ID --output text)
+          NONCE=$(openssl rand -hex 4)
+          echo "export NONCE=$NONCE" >> $BASH_ENV
           # Copy old snapshot to temporary
           if [ -z "$DESCRIBE_SNAPSHOT" ]
           then
               echo "Snapshot does not exist, creating one now."
           else
-              aws rds copy-db-snapshot --source-db-snapshot tm3-<< parameters.stack_name >>-$RDS_ID-latest --target-db-snapshot tm3-<< parameters.stack_name >>-$RDS_ID-temp
-              aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest
+              aws rds copy-db-snapshot \
+                      --source-db-snapshot tm3-<< parameters.stack_name >>-$RDS_ID-latest \
+                      --target-db-snapshot tm3-<< parameters.stack_name >>-${RDS_ID}-${NONCE}
+              aws rds delete-db-snapshot \
+                      --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest
           fi
           # create new aws rds snapshot
-          aws rds create-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest --db-instance-identifier $RDS_ID
-          aws rds wait db-snapshot-completed --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest --db-instance-identifier $RDS_ID
+          aws rds create-db-snapshot \
+                      --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest \
+                      --db-instance-identifier $RDS_ID
+          aws rds wait db-snapshot-completed \
+                      --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest \
+                      --db-instance-identifier $RDS_ID
           if [[ $? -eq 255 ]]; then
             echo "Production snapshot creation failed. Exiting with exit-code 125"
             exit 125
@@ -194,13 +203,13 @@ jobs:
         name: Cleanup
         when: always
         command: |
-          DESCRIBE_SNAPSHOT=`aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-temp --db-instance-identifier $RDS_ID --output text`
+          DESCRIBE_SNAPSHOT=$(aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-${NONCE} --db-instance-identifier $RDS_ID --output text)
           # Copy old snapshot to temporary
           if [ -z "$DESCRIBE_SNAPSHOT" ]
           then
             echo "temporary snapshot doesn't exist, nothing to cleanup."
           else
-            aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-temp
+            aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-${NONCE}
           fi
           # Delete manual snapshot if database ID changed
           RDS_ID_NEW=$(./.circleci/rdsid.sh '{"aws:cloudformation:stack-name": "tasking-manager-<< parameters.stack_name >>"}')


### PR DESCRIPTION
Introduce a random string nonce for the temporary snapshot name to
avoid collision.