### PR TITLE
Return project last_updated field in project search endpoint

### DIFF
--- a/server/models/dtos/project_dto.py
+++ b/server/models/dtos/project_dto.py
@@ -185,6 +185,7 @@ class ListSearchResultDTO(Model):
     percent_validated = IntType(serialized_name='percentValidated')
     status = StringType(serialized_name='status')
     active_mappers = IntType(serialized_name='activeMappers')
+    last_updated = DateTimeType(serialized_name='lastUpdated')
 
 
 class ProjectSearchResultsDTO(Model):

--- a/server/services/project_search_service.py
+++ b/server/services/project_search_service.py
@@ -75,6 +75,7 @@ class ProjectSearchService:
             list_dto.mapper_level = MappingLevel(project.mapper_level).name
             list_dto.short_description = project_info_dto.short_description
             list_dto.organisation_tag = project.organisation_tag
+            list_dto.last_updated = project.last_updated
             list_dto.campaign_tag = project.campaign_tag
             list_dto.percent_mapped = Project.calculate_tasks_percent('mapped', project.total_tasks,
                                                                       project.tasks_mapped, project.tasks_validated,
@@ -104,7 +105,8 @@ class ProjectSearchService:
                                  Project.tasks_mapped,
                                  Project.tasks_validated,
                                  Project.status,
-                                 Project.total_tasks).join(ProjectInfo) \
+                                 Project.total_tasks,
+                                 Project.last_updated).join(ProjectInfo) \
             .filter(ProjectInfo.locale.in_([search_dto.preferred_locale, 'en'])) \
             .filter(Project.private != True)
 


### PR DESCRIPTION
This PR includes a hotfix which includes within project search results, the _last_updated_ field from database. It is related to https://github.com/hotosm/tasking-manager/issues/1628#issuecomment-513908693