### PR TITLE
Add more autoscaling options (#1701)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,6 +242,7 @@ workflows:
         elb_subnets: ELB_SUBNETS_STAGING
         ssl_cert: SSL_CERTIFICATE_ID_STAGING
         tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_STAGING
+        autoscaling_type: AUTOSCALING_TYPE_STAGING
     - deploy:
         name: production
         filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,8 @@ jobs:
         type: env_var_name
       ssl_cert:
         type: env_var_name
+      autoscaling_type:
+        type: env_var_name
     working_directory: /home/circleci/tasking-manager
     docker:
     - image: circleci/python:3-stretch
@@ -129,7 +131,7 @@ jobs:
     - run:
         name: Set Environment Variables
         command: |
-          echo "export JSON_CONFIG='{\"GitSha\":\"$CIRCLE_SHA1\", \"Environment\":\"<< parameters.environment_name >>\", \"DBSnapshot\":\"\", \"DatabaseDump\":\"\", \"NewRelicLicense\":\"${<< parameters.new_relic_license >>}\", \"PostgresDB\":\"${<< parameters.postgres_db >>}\", \"PostgresEndpoint\":\"\", \"PostgresPassword\":\"${<< parameters.postgres_password >>}\", \"PostgresUser\":\"${<< parameters.postgres_user >>}\", \"TaskingManagerAppBaseUrl\":\"${<< parameters.base_url >>}\", \"TaskingManagerConsumerKey\":\"${<< parameters.consumer_key >>}\", \"TaskingManagerConsumerSecret\":\"${<< parameters.consumer_secret >>}\", \"TaskingManagerDefaultChangesetComment\":\"${<< parameters.tm_default_changeset_comment >>}\", \"TaskingManagerSecret\":\"${<< parameters.tm_secret >>}\", \"TaskingManagerEmailFromAddress\":\"${<< parameters.email_from_address >>}\", \"TaskingManagerSMTPHost\":\"${<< parameters.smtp_host >>}\", \"TaskingManagerSMTPPassword\":\"${<< parameters.smtp_password >>}\", \"TaskingManagerSMTPUser\":\"${<< parameters.smtp_user >>}\", \"TaskingManagerSMTPPort\":\"${<< parameters.smtp_port >>}\", \"TaskingManagerLogDirectory\":\"${<< parameters.log_dir >>}\",  \"DatabaseSize\":\"${<< parameters.db_size >>}\",\"ELBSubnets\":\"${<< parameters.elb_subnets >>}\", \"SSLCertificateIdentifier\":\"${<< parameters.ssl_cert >>}\"}'" >> $BASH_ENV
+          echo "export JSON_CONFIG='{\"GitSha\":\"$CIRCLE_SHA1\", \"Environment\":\"<< parameters.environment_name >>\", \"DBSnapshot\":\"\", \"DatabaseDump\":\"\", \"NewRelicLicense\":\"${<< parameters.new_relic_license >>}\", \"PostgresDB\":\"${<< parameters.postgres_db >>}\", \"PostgresEndpoint\":\"\", \"PostgresPassword\":\"${<< parameters.postgres_password >>}\", \"PostgresUser\":\"${<< parameters.postgres_user >>}\", \"TaskingManagerAppBaseUrl\":\"${<< parameters.base_url >>}\", \"TaskingManagerConsumerKey\":\"${<< parameters.consumer_key >>}\", \"TaskingManagerConsumerSecret\":\"${<< parameters.consumer_secret >>}\", \"TaskingManagerDefaultChangesetComment\":\"${<< parameters.tm_default_changeset_comment >>}\", \"TaskingManagerSecret\":\"${<< parameters.tm_secret >>}\", \"TaskingManagerEmailFromAddress\":\"${<< parameters.email_from_address >>}\", \"TaskingManagerSMTPHost\":\"${<< parameters.smtp_host >>}\", \"TaskingManagerSMTPPassword\":\"${<< parameters.smtp_password >>}\", \"TaskingManagerSMTPUser\":\"${<< parameters.smtp_user >>}\", \"TaskingManagerSMTPPort\":\"${<< parameters.smtp_port >>}\", \"TaskingManagerLogDirectory\":\"${<< parameters.log_dir >>}\",  \"DatabaseSize\":\"${<< parameters.db_size >>}\",\"ELBSubnets\":\"${<< parameters.elb_subnets >>}\", \"SSLCertificateIdentifier\":\"${<< parameters.ssl_cert >>}\",  \"AutoscalingType\":\"${<< parameters.autoscaling_type >>}\"}'" >> $BASH_ENV
     - run:
         name: Install Node and modules
         command: |
@@ -267,6 +269,7 @@ workflows:
         elb_subnets: ELB_SUBNETS_PRODUCTION
         ssl_cert: SSL_CERTIFICATE_ID_PRODUCTION
         tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_PRODUCTION
+        autoscaling_type: AUTOSCALING_TYPE_PRODUCTION
     - deploy:
         name: teachosm
         filters:
@@ -294,6 +297,7 @@ workflows:
         elb_subnets: ELB_SUBNETS_TEACHOSM
         ssl_cert: SSL_CERTIFICATE_ID_TEACHOSM
         tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_TEACHOSM
+        autoscaling_type: AUTOSCALING_TYPE_TEACHOSM
     - deploy:
         name: assisted
         filters:
@@ -302,8 +306,8 @@ workflows:
               - deployment/assisted-tasking-manager
         requires:
           - build
-        stack_name: "assisted"
-        environment_name: "staging"
+        stack_name: "assistedv2"
+        environment_name: "production"
         postgres_db: POSTGRES_DB_ASSISTED
         postgres_password: POSTGRES_PASSWORD_ASSISTED
         postgres_user: POSTGRES_USER_ASSISTED
@@ -321,3 +325,4 @@ workflows:
         elb_subnets: ELB_SUBNETS_ASSISTED
         ssl_cert: SSL_CERTIFICATE_ID_ASSISTED
         tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_ASSISTED
+        autoscaling_type: AUTOSCALING_TYPE_ASSISTED


### PR DESCRIPTION
This fix adds more options for autoscaling based on the production/staging environment and a new cloudformation parameter AutoscalingType. Set to `1-4` for smaller production sites and `3-12` for larger (i.e. the main one) sites. 

CircleCI has been updated with the parameters for TeachOSM, Assisted, and Production. 