### PR TITLE
Switch CDN from jsdelivr to Cloudfront

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -33,11 +33,11 @@
     <link href="node_modules/openlayers/dist/ol-debug.css" rel="stylesheet">
     <!-- /build -->
 
-    <!-- build:css https://cdn.jsdelivr.net/openlayers.geocoder/latest/ol3-geocoder.min.css -->
+    <!-- build:css https://cdn.hotosm.org/js/ol3-geocoder.js -->
     <link href="node_modules/ol3-geocoder/build/ol3-geocoder.css" rel="stylesheet">
     <!-- /build -->
 
-    <!-- build:css https://cdn.jsdelivr.net/openlayers.layerswitcher/1.1.0/ol3-layerswitcher.css -->
+    <!-- build:css https://cdn.hotosm.org/js/ol3-layerswitcher.js -->
     <link href="node_modules/ol3-layerswitcher/src/ol3-layerswitcher.css" rel="stylesheet">
     <!-- /build -->
 
@@ -139,11 +139,11 @@
 <script src="node_modules/openlayers/dist/ol-debug.js"></script>
 <!-- /build -->
 
-<!-- build:js https://cdn.jsdelivr.net/openlayers.geocoder/latest/ol3-geocoder.js -->
+<!-- build:js https://cdn.hotosm.org/js/ol3-geocoder.js -->
 <script src="node_modules/ol3-geocoder/build/ol3-geocoder-debug.js"></script>
 <!-- /build -->
 
-<!-- build:js https://cdn.jsdelivr.net/openlayers.layerswitcher/1.1.0/ol3-layerswitcher.js -->
+<!-- build:js https://cdn.hotosm.org/js/ol3-layerswitcher.js -->
 <script src="node_modules/ol3-layerswitcher/src/ol3-layerswitcher.js"></script>
 <!-- /build -->
 
@@ -175,7 +175,7 @@
 <script src="node_modules/ng-showdown/dist/ng-showdown.js"></script>
 <!-- /build -->
 
-<!-- build:js https://cdn.jsdelivr.net/npm/@mapbox/geo-viewport@0.4.0/geo-viewport.js -->
+<!-- build:js https://cdn.hotosm.org/js/geo-viewport.js -->
 <script src="node_modules/@mapbox/geo-viewport/geo-viewport.js"></script>
 <!-- /build -->
 
@@ -199,8 +199,8 @@
 <script src="node_modules/ng-tags-input/build/ng-tags-input.js"></script>
 <!-- /build -->
 
-<!-- build:js https://cdn.jsdelivr.net/angular.ment-io/0.9.24/mentio.min.js-->
-<script src="https://cdn.jsdelivr.net/angular.ment-io/0.9.24/mentio.min.js"></script>
+<!-- build:js https://cdn.hotosm.org/js/mentio.min.js -->
+<script src="https://cdn.hotosm.org/js/mentio.min.js"></script>
 <!-- /build -->
 
 <!-- build:js https://cdnjs.cloudflare.com/ajax/libs/angular-translate/2.15.1/angular-translate.min.js -->
@@ -219,7 +219,7 @@
 <script src="node_modules/ng-table/bundles/ng-table.js"></script>
 <!-- /build -->
 
-<!-- build:js https://cdn.jsdelivr.net/npm/osmtogeojson@2.2.12/osmtogeojson.js -->
+<!-- build:js https://cdn.hotosm.org/js/osmtogeojson.js -->
 <script src="node_modules/osmtogeojson/osmtogeojson.js"></script>
 <!-- /build -->
 


### PR DESCRIPTION
Experimentally switch to Cloudfront the resources hosted in jsdelivr. Fixes #912  and addresses #886