### PR TITLE
Include missing libraries for gunicorn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,11 @@ Flask-RESTful==0.3.7
 Flask-Script==2.0.6
 Flask-SQLAlchemy==2.4.0
 flask-swagger==0.2.14
+gevent==1.4.0
 GeoAlchemy2==0.6.3
 geojson==1.3.4
 glob2==0.7
+greenlet==0.4.15
 gunicorn==19.9.0
 html5lib==1.0.1
 idna==2.8


### PR DESCRIPTION
This PR solves the following error when executing gunicorn with multiple workers:
```
RuntimeError: You need gevent installed to use this worker.
```