### PR TITLE
Remove duplicate priority geometries

### DIFF
--- a/scripts/database/duplicate-priority-area-cleanup.sql
+++ b/scripts/database/duplicate-priority-area-cleanup.sql
@@ -1,0 +1,41 @@
+-- Filter out projects with duplicate priorities
+-- Stores results in a temporary table `priority_duplicates`
+-- X (lng), Y (lat)
+DROP TABLE IF EXISTS priority_duplicates;
+SELECT
+	project_id, priority_area_id, geometry, count(*)
+	INTO TEMPORARY TABLE
+    priority_duplicates
+	FROM project_priority_areas, priority_areas
+	WHERE priority_areas.id = project_priority_areas.priority_area_id
+	GROUP BY project_id, priority_area_id, geometry
+	HAVING count(*) > 1
+	ORDER BY project_id DESC;
+
+
+
+
+-- Function to iterate over duplicate priority areas and delete table entries
+-- Affected tables:
+--    priority_areas, project_priority_areas
+CREATE OR REPLACE FUNCTION delete_duplicate_priority_geom()
+   RETURNS SETOF text AS
+$func$
+DECLARE
+  proj int;
+  priority int;
+	bounds geometry;
+BEGIN
+  FOR proj, priority, bounds IN
+	 SELECT project_id, priority_area_id, geometry FROM priority_duplicates
+  LOOP
+   DELETE  FROM public.project_priority_areas WHERE priority_area_id = priority AND project_id = proj;
+   DELETE  FROM public.priority_areas WHERE id = priority ;
+   INSERT INTO public.priority_areas (id, geometry) VALUES (priority, bounds);
+   INSERT INTO public.project_priority_areas (project_id, priority_area_id) VALUES (proj, priority);
+   RETURN NEXT proj;
+  END LOOP;
+END
+ $func$  LANGUAGE plpgsql;
+
+SELECT * FROM delete_duplicate_priority_geom();


### PR DESCRIPTION
From #1789 - using a script to remove duplicate entries of priority areas. Tested the script against a local DB - database operation and subsequent interaction in localhost went well.

Number of projects with duplicate priority areas: 808


Table|Entries in the Current State|Entries After Script Execution
-----|--------------|----------------------
`priority_areas`| 858 | 858
`project_priority_areas`|4888| 848 

* 808 projects- each had 6 entries for one of their priority area, so after removing - 5x808 = 4040 entries in total, `project_priority_areas` will have 848 entries in total

* Other observation - there is a mismatch of about 10 priority areas between tables` priority_areas` and `project_priority_areas`. This is because 10 priority area IDs( 4112, 3876, 3827, 3826, 3825, 3824, 2708, 6, 5, 4) do not have a project matched in `proejct_priority_areas` table. Looks like this has been existent for a while.


