### PR TITLE
Force files to be read with utf-8 encoding

### DIFF
--- a/migrations/versions/0eee8c1abd3a_.py
+++ b/migrations/versions/0eee8c1abd3a_.py
@@ -55,7 +55,7 @@ def upgrade():
             if is_match:
                 project_continent = continent["properties"]["CONTINENT"]
                 with open(
-                    "migrations/" + project_continent + ".json"
+                    "migrations/" + project_continent + ".json", "r", encoding="utf-8"
                 ) as countries_data:
                     countries = json.load(countries_data)
                     if not project_centroid.is_valid:


### PR DESCRIPTION
This issue closes #1894. 

**How to test:**
- Run migrations script: `python manage.py db upgrade`