### PR TITLE
Check field availability before processing

### DIFF
--- a/frontend/src/components/taskSelection/mappingTypes.js
+++ b/frontend/src/components/taskSelection/mappingTypes.js
@@ -14,7 +14,7 @@ export function MappingTypes({ types=[], colorClass }: Object) {
     {titledIcons.map((Element, k) =>
       <span title={Element.title} key={k}>
         <Element.icon
-          className={`ml1 mr3 ${types.includes(Element.value) ? colorClass : 'grey-light'}`}
+          className={`ml1 mr3 ${types && types.includes(Element.value) ? colorClass : 'grey-light'}`}
           height="23"
         />
       </span>

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -650,9 +650,10 @@ class Project(db.Model):
 
         # Cast MappingType values to related string array
         mapping_types_array = []
-        for mapping_type in self.mapping_types:
-            mapping_types_array.append(MappingTypes(mapping_type).name)
-        summary.mapping_types = mapping_types_array
+        if self.mapping_types:
+            for mapping_type in self.mapping_types:
+                mapping_types_array.append(MappingTypes(mapping_type).name)
+            summary.mapping_types = mapping_types_array
 
         centroid_geojson = db.session.scalar(self.centroid.ST_AsGeoJSON())
         summary.aoi_centroid = geojson.loads(centroid_geojson)


### PR DESCRIPTION
Updated `summary` endpoint to check if `mapping_types` field has some value before iteration begins. Thanks for the flag @thadk 