### PR TITLE
Include allowedUsers list for private projects

### DIFF
--- a/server/models/dtos/project_dto.py
+++ b/server/models/dtos/project_dto.py
@@ -388,6 +388,7 @@ class ProjectSummary(Model):
     )
     allow_non_beginners = BooleanType(serialized_name="allowNonBeginners")
     private = BooleanType(serialized_name="private")
+    allowed_users = ListType(StringType, serialized_name="allowedUsernames", default=[])
     project_info = ModelType(
         ProjectInfoDTO, serialized_name="projectInfo", serialize_when_none=False
     )

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -655,6 +655,13 @@ class Project(db.Model):
                 mapping_types_array.append(MappingTypes(mapping_type).name)
             summary.mapping_types = mapping_types_array
 
+        # If project is private, fetch list of allowed users
+        if self.private:
+            allowed_users = []
+            for user in self.allowed_users:
+                allowed_users.append(user.username)
+            summary.allowed_users = allowed_users
+
         centroid_geojson = db.session.scalar(self.centroid.ST_AsGeoJSON())
         summary.aoi_centroid = geojson.loads(centroid_geojson)
 


### PR DESCRIPTION
Per chat w/ @willemarcel - added a new field to summary endpoint that lists allowed users for private project.

```
"allowedUsers": [
    "Abdul-Basit_eHA",
    "kazeem",
    "ugwuzor chinwe",
    "seyeabrahams",
    "Junaid Ibrahim",
    "tobiwonderful",
    "Hadeezah Musa",
    "kerry_o"
  ]
```
@willemarcel - what do you think will be useful here - user id or username? At present this returns username, I feel it should return IDs though