### PR TITLE
Validate user mapping level for projects with allownonbeginners

### DIFF
--- a/server/models/postgis/statuses.py
+++ b/server/models/postgis/statuses.py
@@ -67,12 +67,13 @@ class MappingNotAllowed(Enum):
 
 
 class ValidatingNotAllowed(Enum):
-    """ Enum describing reasons a user cannot map """
+    """ Enum describing reasons a user cannot validate """
 
     USER_NOT_VALIDATOR = 100
     USER_NOT_ACCEPTED_LICENSE = 101
     USER_NOT_ON_ALLOWED_LIST = 102
     PROJECT_NOT_PUBLISHED = 103
+    USER_IS_BEGINNER = 104
 
 
 class UserGender(Enum):

--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -237,6 +237,15 @@ class ProjectService:
             except StopIteration:
                 return False, ValidatingNotAllowed.USER_NOT_ON_ALLOWED_LIST
 
+        # Restrict validation by non-beginners users only
+        if project.restrict_validation_level_intermediate is True:
+            user = UserService.get_user_by_id(user_id)
+            if user.mapping_level not in (
+                MappingLevel.INTERMEDIATE.value,
+                MappingLevel.ADVANCED.value,
+            ):
+                return False, ValidatingNotAllowed.USER_IS_BEGINNER
+
         return True, "User allowed to validate"
 
     @staticmethod


### PR DESCRIPTION
This PR closes #1902 

**How to test**:
1. Load the database dump from _tests_ folder.
2. Alter projects and set allow_non_beginners = True
```
UPDATE projects SET allow_non_beginners=true;
```
3. Alter a single user and set mapping level as begginer:
```
UPDATE users set mapping_level=1 where user_id=94253
```
4. using flask shell command, import service method
```
python manage.py shell

In [1]: from server.services.project_service import ProjectService                                                                             

In [2]: ProjectService.is_user_permitted_to_validate(1, 360183)                                                                                
Out[2]: (True, 'User allowed to validate')

In [3]: ProjectService.is_user_permitted_to_validate(1, 94253)                                                                                 
Out[3]: (False, <ValidatingNotAllowed.USER_IS_BEGINNER: 104>)
```