### PR TITLE
First Pass Infrastructure update for redesign

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,10 @@ jobs:
         description: "The environment (staging or production) on AWS"
         type: enum
         enum: ["staging", "production"]
+      autoscaling_policy:
+        description: "Setting autoscaling parameters"
+        type: enum
+        enum: ['development', 'demo', 'production']
       new_relic_license:
         type: env_var_name
         default: NEW_RELIC_LICENSE
@@ -132,7 +136,7 @@ jobs:
     - run:
         name: Set Environment Variables
         command: |
-          echo "export JSON_CONFIG='{\"GitSha\":\"$CIRCLE_SHA1\", \"Environment\":\"<< parameters.environment_name >>\", \"DBSnapshot\":\"\", \"DatabaseDump\":\"\", \"NewRelicLicense\":\"${<< parameters.new_relic_license >>}\", \"PostgresDB\":\"${<< parameters.postgres_db >>}\", \"PostgresEndpoint\":\"\", \"PostgresPassword\":\"${<< parameters.postgres_password >>}\", \"PostgresUser\":\"${<< parameters.postgres_user >>}\", \"TaskingManagerAppBaseUrl\":\"${<< parameters.base_url >>}\", \"TaskingManagerConsumerKey\":\"${<< parameters.consumer_key >>}\", \"TaskingManagerConsumerSecret\":\"${<< parameters.consumer_secret >>}\", \"TaskingManagerDefaultChangesetComment\":\"${<< parameters.tm_default_changeset_comment >>}\", \"TaskingManagerSecret\":\"${<< parameters.tm_secret >>}\", \"TaskingManagerEmailFromAddress\":\"${<< parameters.email_from_address >>}\", \"TaskingManagerSMTPHost\":\"${<< parameters.smtp_host >>}\", \"TaskingManagerSMTPPassword\":\"${<< parameters.smtp_password >>}\", \"TaskingManagerSMTPUser\":\"${<< parameters.smtp_user >>}\", \"TaskingManagerSMTPPort\":\"${<< parameters.smtp_port >>}\", \"TaskingManagerLogDirectory\":\"${<< parameters.log_dir >>}\",  \"DatabaseSize\":\"${<< parameters.db_size >>}\",\"ELBSubnets\":\"${<< parameters.elb_subnets >>}\", \"SSLCertificateIdentifier\":\"${<< parameters.ssl_cert >>}\", \"MatomoSiteID\":\"${<< parameters.matomo_site_id >>}\", \"MatomoEndpoint\":\"${<< parameters.matomo_endpoint >>}\"}'" >> $BASH_ENV
+          echo "export JSON_CONFIG='{\"GitSha\":\"$CIRCLE_SHA1\", \"NetworkEnvironment\":\"<< parameters.environment_name >>\", \"AutoscalingPolicy\":\"<< parameters.autoscaling_policy >>\", \"DBSnapshot\":\"\", \"DatabaseDump\":\"\", \"NewRelicLicense\":\"${<< parameters.new_relic_license >>}\", \"PostgresDB\":\"${<< parameters.postgres_db >>}\", \"PostgresEndpoint\":\"\", \"PostgresPassword\":\"${<< parameters.postgres_password >>}\", \"PostgresUser\":\"${<< parameters.postgres_user >>}\", \"TaskingManagerAppBaseUrl\":\"${<< parameters.base_url >>}\", \"TaskingManagerConsumerKey\":\"${<< parameters.consumer_key >>}\", \"TaskingManagerConsumerSecret\":\"${<< parameters.consumer_secret >>}\", \"TaskingManagerDefaultChangesetComment\":\"${<< parameters.tm_default_changeset_comment >>}\", \"TaskingManagerSecret\":\"${<< parameters.tm_secret >>}\", \"TaskingManagerEmailFromAddress\":\"${<< parameters.email_from_address >>}\", \"TaskingManagerSMTPHost\":\"${<< parameters.smtp_host >>}\", \"TaskingManagerSMTPPassword\":\"${<< parameters.smtp_password >>}\", \"TaskingManagerSMTPUser\":\"${<< parameters.smtp_user >>}\", \"TaskingManagerSMTPPort\":\"${<< parameters.smtp_port >>}\", \"TaskingManagerLogDirectory\":\"${<< parameters.log_dir >>}\",  \"DatabaseSize\":\"${<< parameters.db_size >>}\",\"ELBSubnets\":\"${<< parameters.elb_subnets >>}\", \"SSLCertificateIdentifier\":\"${<< parameters.ssl_cert >>}\", \"MatomoSiteID\":\"${<< parameters.matomo_site_id >>}\", \"MatomoEndpoint\":\"${<< parameters.matomo_endpoint >>}\"}'" >> $BASH_ENV
     - run:
         name: Install Node and modules
         command: |
@@ -203,6 +207,7 @@ jobs:
         name: Deploy to << parameters.stack_name >>
         command: |
           export NODE_PATH=/usr/lib/node_modules
+          validate-template $CIRCLE_WORKING_DIRECTORY/scripts/aws/cloudformation/tasking-manager.template.js
           cfn-config update << parameters.stack_name >> $CIRCLE_WORKING_DIRECTORY/scripts/aws/cloudformation/tasking-manager.template.js -f -c hot-cfn-config -t hot-cfn-config -r $AWS_REGION -p "$JSON_CONFIG"
     - run:
         name: Cleanup
@@ -237,6 +242,7 @@ workflows:
         - build
         stack_name: "staging"
         environment_name: "staging"
+        autoscaling_policy: "development"
         postgres_db: POSTGRES_DB_STAGING
         postgres_password: POSTGRES_PASSWORD_STAGING
         postgres_user: POSTGRES_USER_STAGING
@@ -266,6 +272,7 @@ workflows:
           - build
         stack_name: "prod-restored"
         environment_name: "production"
+        autoscaling_policy: "production"
         postgres_db: POSTGRES_DB_PRODUCTION
         postgres_password: POSTGRES_PASSWORD_PRODUCTION
         postgres_user: POSTGRES_USER_PRODUCTION
@@ -295,6 +302,7 @@ workflows:
           - build
         stack_name: "teachosm"
         environment_name: "production"
+        autoscaling_policy: "demo"
         postgres_db: POSTGRES_DB_TEACHOSM
         postgres_password: POSTGRES_PASSWORD_TEACHOSM
         postgres_user: POSTGRES_USER_TEACHOSM
@@ -324,6 +332,7 @@ workflows:
           - build
         stack_name: "assisted"
         environment_name: "staging"
+        autoscaling_policy: "demo"
         postgres_db: POSTGRES_DB_ASSISTED
         postgres_password: POSTGRES_PASSWORD_ASSISTED
         postgres_user: POSTGRES_USER_ASSISTED

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,3 +352,33 @@ workflows:
         tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_ASSISTED
         matomo_site_id: MATOMO_SITE_ID_ASSISTED
         matomo_endpoint: MATOMO_ENDPOINT_ASSISTED
+    - deploy:
+        name: tm4
+        filters:
+          branches:
+            only:
+              - deployment/redesign-tasking-manager
+        requires:
+          - build
+        stack_name: "tm4"
+        environment_name: "production"
+        autoscaling_policy: "demo"
+        postgres_db: POSTGRES_DB_TM4
+        postgres_password: POSTGRES_PASSWORD_TM4
+        postgres_user: POSTGRES_USER_TM4
+        base_url: TM_APP_BASE_URL_TM4
+        consumer_key: TM_CONSUMER_KEY_TM4
+        consumer_secret: TM_CONSUMER_SECRET_TM4
+        tm_secret: TM_SECRET_TM4
+        email_from_address: TM_EMAIL_FROM_ADDRESS_TM4
+        smtp_host: TM_SMTP_HOST_TM4
+        smtp_password: TM_SMTP_PASSWORD_TM4
+        smtp_user: TM_SMTP_USER_TM4
+        smtp_port: TM_SMTP_PORT_TM4
+        log_dir: TM_LOG_DIR_TM4
+        db_size: DATABASE_SIZE_TM4
+        elb_subnets: ELB_SUBNETS_TM4
+        ssl_cert: SSL_CERTIFICATE_ID_TM4
+        tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_TM4
+        matomo_site_id: MATOMO_SITE_ID_TM4
+        matomo_endpoint: MATOMO_ENDPOINT_TM4

--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -156,7 +156,110 @@ const Resources = {
       }
   },
   TaskingManagerLaunchConfiguration: {
-    Type: 'AWS::AutoScaling::LaunchConfiguration',
+    Type: "AWS::AutoScaling::LaunchConfiguration",
+    Metadata: {
+      "AWS::CloudFormation::Init": {
+        "configSets": {
+          "default": [
+            "01_setupCfnHup", 
+            "02_config-amazon-cloudwatch-agent", 
+            "03_restart_amazon-cloudwatch-agent"
+          ],
+          "UpdateEnvironment": [
+            "02_config-amazon-cloudwatch-agent",
+            "03_restart_amazon-cloudwatch-agent"
+            ]
+        },
+        // Definition of json configuration of AmazonCloudWatchAgent, you can change the configuration below.
+        "02_config-amazon-cloudwatch-agent": {
+          "files": {
+            '/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json': {
+              "content": cf.join("\n", [
+                  "{\"logs\": {",
+                  "\"logs_collected\": {",
+                  "\"files\": {",
+                  "\"collect_list\": [",
+                  "{",
+                  "\"file_path\": \"/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log\",",
+                  cf.sub("\"log_group_name\": \"${AWS::StackName}.log\","),
+                  cf.sub("\"log_stream_name\": \"${AWS::StackName}-cloudwatch-agent.log\","),
+                  "\"timezone\": \"UTC\"",
+                  "},",
+                  "{",
+                  cf.sub("\"file_path\": \"${TaskingManagerLogDirectory}/tasking-manager.log\","),
+                  cf.sub("\"log_group_name\": \"${AWS::StackName}.log\","),
+                  cf.sub("\"log_stream_name\": \"${AWS::StackName}.log\","),
+                  "\"timezone\": \"UTC\"",
+                  "}]}},",
+                  cf.sub("\"log_stream_name\": \"${AWS::StackName}-logs\","),
+                  "\"force_flush_interval\" : 15",
+                  "}}"
+              ])
+            }
+          }
+        },
+        // Invoke amazon-cloudwatch-agent-ctl to restart the AmazonCloudWatchAgent.
+        "03_restart_amazon-cloudwatch-agent": {
+          "commands": {
+            "01_stop_service": {
+              "command": "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a stop"
+            },
+            "02_start_service": {
+              "command": "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
+            }
+          }
+        },
+        // Cfn-hup setting, it is to monitor the change of metadata.
+        // When there is change in the contents of json file in the metadata section, cfn-hup will call cfn-init to restart the AmazonCloudWatchAgent.
+        "01_setupCfnHup": {
+          "files": {
+            "/etc/cfn/cfn-hup.conf": {
+              "content": cf.join('\n', [
+                "[main]",
+                cf.sub("stack=${!AWS::StackName}"),
+                cf.sub("region=${!AWS::Region}"),
+                "interval=1"
+              ]),
+              "mode": "000400",
+              "owner": "root",
+              "group": "root"
+            },
+            "/etc/cfn/hooks.d/amazon-cloudwatch-agent-auto-reloader.conf": {
+              "content": cf.join('\n', [
+                "[cfn-auto-reloader-hook]",
+                "triggers=post.update",
+                "path=Resources.EC2Instance.Metadata.AWS::CloudFormation::Init.02_config-amazon-cloudwatch-agent",
+                cf.sub("action=cfn-init -v --stack ${AWS::StackName} --resource EC2Instance --region ${AWS::Region} --configsets UpdateEnvironment"),
+                "runas=root"
+              ]),
+              "mode": "000400",
+              "owner": "root",
+              "group": "root"
+            },
+            "/lib/systemd/system/cfn-hup.service": {
+              "content": cf.join('\n', [
+                "[Unit]",
+                "Description=cfn-hup daemon",
+                "[Service]",
+                "Type=simple",
+                "ExecStart=/opt/aws/bin/cfn-hup",
+                "Restart=always",
+                "[Install]",
+                "WantedBy=multi-user.target"
+                ])
+            }
+          },
+          "commands": {
+            "01enable_cfn_hup": {
+            "command": "systemctl enable cfn-hup.service"
+            },
+            "02start_cfn_hup": {
+              "command": "systemctl start cfn-hup.service"
+            }
+          }
+        }
+      }
+    },
     Properties: {
       IamInstanceProfile: cf.ref('TaskingManagerEC2InstanceProfile'),
       ImageId: 'ami-0565af6e282977273',
@@ -211,6 +314,8 @@ const Resources = {
         'pip install -r requirements.txt',
         'echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf',
         'export LC_ALL=C',
+        'wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb -O /tmp/amazon-cloudwatch-agent.deb',
+        'dpkg -i /tmp/amazon-cloudwatch-agent.deb',
         'wget https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz',
         'pip2 install aws-cfn-bootstrap-latest.tar.gz',
         'echo "Exporting environment variables:"',
@@ -241,6 +346,7 @@ const Resources = {
         'cd ../',
         'echo "------------------------------------------------------------"',
         'gunicorn -b 0.0.0.0:8000 --worker-class gevent --workers 3 --threads 3 --timeout 179 manage:application &',
+        cf.sub('sudo cfn-init -v --stack ${AWS::StackName} --resource TaskingManagerLaunchConfiguration --region ${AWS::Region} --configsets default'),
         cf.sub('cfn-signal --exit-code $? --region ${AWS::Region} --resource TaskingManagerASG --stack ${AWS::StackName}')
       ]),
       KeyName: 'mbtiles'
@@ -280,6 +386,29 @@ const Resources = {
             ],
             Effect: 'Allow',
             Resource: ['arn:aws:cloudformation:*']
+          }]
+        }
+      }, {
+        PolicyName: "CloudwatchAgentPermissions",
+        PolicyDocument: {
+          Version: "2012-10-17",
+          Statement: [{
+            Effect: "Allow",
+            Action: [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:DescribeLogStreams"
+            ],
+            Resource: ["arn:aws:logs:*:*:*"]
+          }, {
+            Effect: "Allow",
+            Action: [
+              "s3:GetObject"
+            ],
+            Resource: [
+              "arn:aws:s3:::tasking-manager/*"
+            ]
           }]
         }
       }],

--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -10,7 +10,8 @@ const Parameters = {
   },
   AutoscalingPolicy: {
     Type: 'String',
-    AllowedValues: ['Testing (max 1 instance)', 'Demo (max 3)', 'Production (max 12)']
+    AllowedValues: ['development', 'demo', 'production'],
+    Description: "development: min 1, max 1 instance; demo: min 1 max 3 instances; production: min 3 max 12 instances"
   },
   DBSnapshot: {
     Type: 'String',


### PR DESCRIPTION
There are 3 major changes in this PR:

- Add Cloudwatch Logging Agent for saving the `/var/log/tasking-manager-logs/tasking-manager.log` to CloudWatch for accessibility
- Rework autoscaling policy for 3 different application types (staging, demo, production)
- Add TM4 infrastructure for demo app

When it is time to push the TM4 app public, we need to 
1. initialize the app manually via command line (i.e `cfn-config create tm4 ...`)
2. Make sure all the correct env vars are set on CircleCI
3. Push a deployment to a new branch called `deployment/redesign-tasking-manager`