### PR TITLE
make fallback raster style work with https

### DIFF
--- a/frontend/src/components/projects/projectsMap.js
+++ b/frontend/src/components/projects/projectsMap.js
@@ -8,11 +8,11 @@ mapboxgl.accessToken = MAPBOX_TOKEN;
 export const fallbackRasterStyle = {
   version: 8,
   // "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
-  glyphs: 'http://fonts.openmaptiles.org/{fontstack}/{range}.pbf',
+  glyphs: 'https://fonts.openmaptiles.org/{fontstack}/{range}.pbf',
   sources: {
     'raster-tiles': {
       type: 'raster',
-      tiles: ['http://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png'],
+      tiles: ['https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png'],
       tileSize: 128,
       attribution:
         '© <a href="https://www.openstreetmap.org/copyright/">OpenStreetMap</a> contributors',


### PR DESCRIPTION
If no Mapbox API key is set for a custom instance of TM4, then this raster fallback map will appear with the old HOT Humanitarian raster layer, after this tiny pull request adds HTTPS support.

![image](https://user-images.githubusercontent.com/283343/67416879-a80f0680-f595-11e9-9917-aa80bb291b44.png)
![image](https://user-images.githubusercontent.com/283343/67416890-aba28d80-f595-11e9-9187-8b1f6177a99e.png)
