### PR TITLE
Login user from popup

### DIFF
--- a/frontend/src/components/header/createPopup.js
+++ b/frontend/src/components/header/createPopup.js
@@ -1,0 +1,21 @@
+// Code taken from https://github.com/mapbox/osmcha-frontend/blob/master/src/utils/create_popup.js
+export function createPopup(
+  title: string = 'Authentication',
+  location: string
+) {
+  const width = 500;
+  const height = 600;
+  const settings = [
+    ['width', width],
+    ['height', height],
+    ['left', window.innerWidth / 2 - width / 2],
+    ['top', window.innerHeight / 2 - height / 2]
+  ]
+    .map(x => x.join('='))
+    .join(',');
+
+  const popup = window.open(location, '_blank', settings);
+  if (!popup) return;
+
+  return popup
+}

--- a/frontend/src/store/actions/auth.js
+++ b/frontend/src/store/actions/auth.js
@@ -18,7 +18,6 @@ export function clearUserDetails() {
 export const logout = () => dispatch => {
   safeStorage.removeItem('username');
   safeStorage.removeItem('token');
-  safeStorage.removeItem('userPicture');
   dispatch(clearUserDetails());
 };
 
@@ -36,14 +35,11 @@ export function updateToken(token) {
   };
 }
 
-export const setAuthDetails = (username, token, userPicture) => dispatch => {
+export const setAuthDetails = (username, token) => dispatch => {
   const encoded_token = btoa(token);
-  safeStorage.setItem('username', username);
   safeStorage.setItem('token', encoded_token);
+  safeStorage.setItem('username', username);
   dispatch(updateToken(encoded_token));
-  if (userPicture) {
-    safeStorage.setItem('userPicture', userPicture);
-  }
   dispatch(setUserDetails(username, encoded_token));
 };
 

--- a/frontend/src/views/authorized.js
+++ b/frontend/src/views/authorized.js
@@ -18,8 +18,7 @@ class Authorized extends React.Component {
     }
     const username = this.params.get('username');
     const sessionToken = this.params.get('session_token');
-    const userPicture = this.params.get('picture');
-    this.props.authenticateUser(username, sessionToken, userPicture);
+    this.props.authenticateUser(username, sessionToken);
     this.setState({
       isReadyToRedirect: true,
     });
@@ -43,8 +42,8 @@ let mapStateToProps = (state, props) => ({
 
 const mapDispatchToProps = dispatch => {
   return {
-    authenticateUser: (username, token, userPicture) =>
-      dispatch(setAuthDetails(username, token, userPicture)),
+    authenticateUser: (username, token) =>
+      dispatch(setAuthDetails(username, token)),
   };
 };
 

--- a/frontend/src/views/authorized.js
+++ b/frontend/src/views/authorized.js
@@ -10,6 +10,12 @@ class Authorized extends React.Component {
   params = new URLSearchParams(this.props.location.search);
 
   componentDidMount() {
+    let verifier = this.params.get('oauth_verifier');
+    if (verifier !== null) {
+      window.opener.authComplete(verifier)
+      window.close()
+      return;
+    }
     const username = this.params.get('username');
     const sessionToken = this.params.get('session_token');
     const userPicture = this.params.get('picture');

--- a/tests/server/unit/services/users/test_authentication_service.py
+++ b/tests/server/unit/services/users/test_authentication_service.py
@@ -29,9 +29,7 @@ class TestAuthenticationService(unittest.TestCase):
 
         # Act / Assert
         with self.assertRaises(AuthServiceError):
-            AuthenticationService().login_user(
-                osm_response, "/test/redirect", "wont-find"
-            )
+            AuthenticationService().login_user(osm_response, "wont-find")
 
     @patch.object(UserService, "get_user_by_id")
     def test_if_user_get_called_with_osm_id(self, mock_user_get):
@@ -39,7 +37,7 @@ class TestAuthenticationService(unittest.TestCase):
         osm_response = get_canned_osm_user_details()
 
         # Act
-        AuthenticationService.login_user(osm_response, "/test/redirect")
+        AuthenticationService.login_user(osm_response)
 
         # Assert
         mock_user_get.assert_called_with(7777777)
@@ -55,7 +53,7 @@ class TestAuthenticationService(unittest.TestCase):
         mock_user_get.side_effect = NotFound()
 
         # Act
-        AuthenticationService.login_user(osm_response, "/test/redirect")
+        AuthenticationService.login_user(osm_response)
 
         # Assert
         mock_user_register.assert_called_with(7777777, "Thinkwhere Test", 16, None)
@@ -66,15 +64,10 @@ class TestAuthenticationService(unittest.TestCase):
         osm_response = get_canned_osm_user_details()
 
         # Act
-        redirect_url = AuthenticationService.login_user(osm_response, "/test/redirect")
+        params = AuthenticationService.login_user(osm_response)
 
-        # Assert
-        parsed_url = urlparse(redirect_url)
-        query = parse_qs(parsed_url.query)
-
-        self.assertEqual(query["username"][0], "Thinkwhere Test")
-        self.assertTrue(query["session_token"][0])
-        self.assertEqual(query["redirect_to"][0], "/test/redirect")
+        self.assertEqual(params["username"], "Thinkwhere Test")
+        self.assertTrue(params["session_token"])
 
     def test_get_authentication_failed_url_returns_expected_url(self):
         # Act


### PR DESCRIPTION
This PR closes #1892  and #1914. 

**Server side**:
- The api endpoints to login and callback were modified to return oauth params instead of making redirections.
- The api returns openstreetmap login url, OSM oauth_token and oauth_token_secret.
- The login url must have the request parameter _callback_url_. clients should be able to handle this endpoint.

**Client side**:
- The login url is now created within a popup window, which is closed automatically after successfull login

![image](https://user-images.githubusercontent.com/3285923/67812333-f37d5500-fa6c-11e9-8686-1f1e8f84343c.png)


