### PR TITLE
Specify Python 3.7 in tasking-manager Dockerfile

### DIFF
--- a/scripts/docker/tasking-manager/Dockerfile
+++ b/scripts/docker/tasking-manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-buster
+FROM python:3.7-buster
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
Change allows Docker image to build - previously Python 3.8 would cause error when installing pyproj.