### PR TITLE
Change circleci production app stack name to current

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ workflows:
               - deployment/hot-tasking-manager
         requires:
           - build
-        stack_name: "prod-restored"
+        stack_name: "production"
         environment_name: "production"
         postgres_db: POSTGRES_DB_PRODUCTION
         postgres_password: POSTGRES_PASSWORD_PRODUCTION


### PR DESCRIPTION
Without the correct stack name, we cannot update the Cloudformation Stack. This fixes the issue with the deployment last night. 

@eternaltyro and I discussed parameterizing this, which we will look into in TM4