### PR TITLE
review permissions of interests api endpoints

### DIFF
--- a/server/api/interests/resources.py
+++ b/server/api/interests/resources.py
@@ -4,12 +4,13 @@ from schematics.exceptions import DataError
 from server.models.dtos.interests_dto import InterestDTO
 from server.models.postgis.utils import NotFound
 from server.services.interests_service import InterestService
-from server.services.users.authentication_service import token_auth
+from server.services.users.authentication_service import token_auth, tm
 
 from sqlalchemy.exc import IntegrityError
 
 
 class InterestsAllAPI(Resource):
+    @tm.pm_only()
     @token_auth.login_required
     def post(self):
         """
@@ -96,6 +97,7 @@ class InterestsAllAPI(Resource):
 
 
 class InterestsRestAPI(Resource):
+    @tm.pm_only()
     @token_auth.login_required
     def patch(self, interest_id):
         """
@@ -152,6 +154,7 @@ class InterestsRestAPI(Resource):
             current_app.logger.critical(error_msg)
             return {"error": error_msg}, 500
 
+    @tm.pm_only()
     @token_auth.login_required
     def delete(self, interest_id):
         """

--- a/server/api/projects/actions.py
+++ b/server/api/projects/actions.py
@@ -231,6 +231,8 @@ class ProjectsActionsUnFeatureAPI(Resource):
 
 
 class ProjectsActionsSetInterestsAPI(Resource):
+    @tm.pm_only()
+    @token_auth.login_required
     def post(self, project_id):
         """
         Creates a relationship between project and interests

--- a/server/api/users/actions.py
+++ b/server/api/users/actions.py
@@ -352,6 +352,7 @@ class UsersActionsRegisterEmailAPI(Resource):
 
 
 class UsersActionsSetInterestsAPI(Resource):
+    @tm.pm_only(False)
     @token_auth.login_required
     def post(self, user_id):
         """


### PR DESCRIPTION
Related to https://github.com/hotosm/tasking-manager/issues/1926#issuecomment-551311538

- Only PM's can create, update and delete interests
- Only PM's can associate projects with interests
- Only the user can associate themselves with interests