### PR TITLE
TM4 contribute page shows error, not blank, if backend down

### DIFF
--- a/frontend/src/hooks/UseTagAPI.js
+++ b/frontend/src/hooks/UseTagAPI.js
@@ -48,7 +48,12 @@ export const useTagAPI = (initialData, tagType) => {
         const result = await axios(`${API_URL}${tagType}/`);
 
         if (!didCancel) {
-          dispatch({ type: 'FETCH_SUCCESS', payload: result.data });
+          if (result && result.headers && result.headers['content-type'].indexOf('json') !== -1) { 
+            dispatch({ type: 'FETCH_SUCCESS', payload: result.data });
+          } else {
+            console.error('Invalid return content-type for organisation tags');
+            dispatch({ type: 'FETCH_FAILURE' });
+          }
         }
       } catch (error) {
         /* if cancelled, this setting state of unmounted


### PR DESCRIPTION
Make it so the contribute page gracefully handles the backend being down. 

Specifically the API that gets the organisation list, UseTagAPI, needed to check for the `content-type` of the response. The other frontend APIs already check for this.