### PR TITLE
fix set-interest for user URL

### DIFF
--- a/frontend/src/store/actions/auth.js
+++ b/frontend/src/store/actions/auth.js
@@ -26,7 +26,7 @@ export const updateUserEmail = (userDetails, token, relevant_fields) => dispatch
     }, {});
   const payload = JSON.stringify(filtered);
 
-  pushToLocalJSONAPI(`users/actions/set-user/`, payload, token, 'PATCH').then(() => {
+  pushToLocalJSONAPI(`users/me/actions/set-user/`, payload, token, 'PATCH').then(() => {
       dispatch({
         type: types.SET_USER_DETAILS,
         userDetails: userDetails
@@ -90,7 +90,7 @@ export const getUserDetails = state => dispatch => {
 };
 
 export const pushUserDetails = (userDetails, token) => dispatch => {
-  pushToLocalJSONAPI(`users/actions/set-user/`, userDetails, token, 'PATCH').then(data =>
+  pushToLocalJSONAPI(`users/me/actions/set-user/`, userDetails, token, 'PATCH').then(data =>
     dispatch(setUserDetails(safeStorage.getItem('username'), token)),
   );
 };

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -388,7 +388,7 @@ def add_api_endpoints(app):
 
     api.add_resource(
         UsersActionsSetInterestsAPI,
-        "/api/v2/users/<int:user_id>/actions/set-interests/",
+        "/api/v2/users/me/actions/set-interests/",
         endpoint="create_user_interest",
         methods=["POST"],
     )
@@ -653,7 +653,7 @@ def add_api_endpoints(app):
     api.add_resource(UserFavoritesAPI, "/api/v2/users/queries/favorites/")
 
     # Users Actions endpoint
-    api.add_resource(UsersActionsSetUsersAPI, "/api/v2/users/actions/set-user/")
+    api.add_resource(UsersActionsSetUsersAPI, "/api/v2/users/me/actions/set-user/")
 
     api.add_resource(
         UsersActionsSetLevelAPI,
@@ -668,7 +668,7 @@ def add_api_endpoints(app):
         "/api/v2/users/<string:username>/actions/set-expert-mode/<string:is_expert>/",
     )
     api.add_resource(
-        UsersActionsVerifyEmailAPI, "/api/v2/users/myself/actions/verify-email/"
+        UsersActionsVerifyEmailAPI, "/api/v2/users/me/actions/verify-email/"
     )
     api.add_resource(UsersActionsRegisterEmailAPI, "/api/v2/users/actions/register/")
 

--- a/server/api/users/actions.py
+++ b/server/api/users/actions.py
@@ -263,7 +263,7 @@ class UsersActionsVerifyEmailAPI(Resource):
     @token_auth.login_required
     def patch(self):
         """
-        Resends the validation user to the logged in user
+        Resends the verification email token to the logged in user
         ---
         tags:
           - users
@@ -354,7 +354,7 @@ class UsersActionsRegisterEmailAPI(Resource):
 class UsersActionsSetInterestsAPI(Resource):
     @tm.pm_only(False)
     @token_auth.login_required
-    def post(self, user_id):
+    def post(self):
         """
         Creates a relationship between user and interests
         ---
@@ -369,12 +369,6 @@ class UsersActionsSetInterestsAPI(Resource):
               required: true
               type: string
               default: Token sessionTokenHere==
-            - name: user_id
-              in: path
-              description: The unique OSM user id
-              required: true
-              type: integer
-              default: 1
             - in: body
               name: body
               required: true
@@ -397,8 +391,6 @@ class UsersActionsSetInterestsAPI(Resource):
         """
         try:
             data = request.get_json()
-            if user_id != tm.authenticated_user_id:
-                raise ValueError("User id and user token mismatch")
             user_interests = InterestService.create_or_update_user_interests(
                 tm.authenticated_user_id, data["interests"]
             )
@@ -406,7 +398,7 @@ class UsersActionsSetInterestsAPI(Resource):
         except ValueError as e:
             return {"Error": str(e)}, 400
         except NotFound:
-            return {"Error": "User not Found"}, 404
+            return {"Error": "Interest not Found"}, 404
         except Exception as e:
             error_msg = f"User relationship POST - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)


### PR DESCRIPTION
The interests of a user can only be changed by themselves, so we don't need the `user_id` param on the URL. I updated it from `/api/v2/users/<int:user_id>/actions/set-interests/` to `/api/v2/users/actions/set-interests/`.