### PR TITLE
Include auto unlock operations for time aggregates

### DIFF
--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -590,7 +590,7 @@ class Project(db.Model):
         stats_dto.total_time_spent = 0
 
         query = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                   WHERE action='LOCKED_FOR_MAPPING'
+                   WHERE (action='LOCKED_FOR_MAPPING' or action='AUTO_UNLOCKED_FOR_MAPPING')
                    and user_id = :user_id and project_id = :project_id;"""
         total_mapping_time = db.engine.execute(
             text(query), user_id=user_id, project_id=self.id
@@ -602,7 +602,7 @@ class Project(db.Model):
                 stats_dto.total_time_spent += stats_dto.time_spent_mapping
 
         query = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                   WHERE action='LOCKED_FOR_VALIDATION'
+                   WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION')
                    and user_id = :user_id and project_id = :project_id;"""
         total_validation_time = db.engine.execute(
             text(query), user_id=user_id, project_id=self.id
@@ -678,7 +678,7 @@ class Project(db.Model):
         project_stats.average_validation_time = 0
 
         query = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                   WHERE action='LOCKED_FOR_MAPPING' and project_id = :project_id;"""
+                   WHERE (action='LOCKED_FOR_MAPPING' or action='AUTO_UNLOCKED_FOR_MAPPING') and project_id = :project_id;"""
         total_mapping_time = db.engine.execute(text(query), project_id=self.id)
         for row in total_mapping_time:
             total_mapping_time = row[0]
@@ -691,7 +691,7 @@ class Project(db.Model):
                     project_stats.average_mapping_time = average_mapping_time
 
         query = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                   WHERE action='LOCKED_FOR_VALIDATION' and project_id = :project_id;"""
+                   WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION') and project_id = :project_id;"""
         total_validation_time = db.engine.execute(text(query), project_id=self.id)
         for row in total_validation_time:
             total_validation_time = row[0]

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -678,7 +678,8 @@ class Project(db.Model):
         project_stats.average_validation_time = 0
 
         query = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                   WHERE (action='LOCKED_FOR_MAPPING' or action='AUTO_UNLOCKED_FOR_MAPPING') and project_id = :project_id;"""
+                   WHERE (action='LOCKED_FOR_MAPPING' or action='AUTO_UNLOCKED_FOR_MAPPING')
+                   and project_id = :project_id;"""
         total_mapping_time = db.engine.execute(text(query), project_id=self.id)
         for row in total_mapping_time:
             total_mapping_time = row[0]
@@ -691,7 +692,8 @@ class Project(db.Model):
                     project_stats.average_mapping_time = average_mapping_time
 
         query = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                   WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION') and project_id = :project_id;"""
+                   WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION')
+                   and project_id = :project_id;"""
         total_validation_time = db.engine.execute(text(query), project_id=self.id)
         for row in total_validation_time:
             total_validation_time = row[0]

--- a/server/models/postgis/user.py
+++ b/server/models/postgis/user.py
@@ -355,7 +355,7 @@ class User(db.Model):
         user_dto.self_description_gender = self.self_description_gender
 
         sql = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                WHERE action='LOCKED_FOR_VALIDATION'
+                WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION')
                 and user_id = :user_id;"""
         total_validation_time = db.engine.execute(text(sql), user_id=self.id)
         for row in total_validation_time:
@@ -366,7 +366,7 @@ class User(db.Model):
                 user_dto.total_time_spent += user_dto.time_spent_validating
 
         sql = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                WHERE action='LOCKED_FOR_MAPPING'
+                WHERE (action='LOCKED_FOR_MAPPING' or action='AUTO_UNLOCKED_FOR_MAPPING')
                 and user_id = :user_id;"""
         total_mapping_time = db.engine.execute(text(sql), user_id=self.id)
         for row in total_mapping_time:

--- a/server/services/users/user_service.py
+++ b/server/services/users/user_service.py
@@ -274,7 +274,7 @@ class UserService:
         stats_dto.time_spent_validating = 0
 
         sql = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                WHERE action='LOCKED_FOR_VALIDATION'
+                WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION')
                 and user_id = :user_id;"""
         total_validation_time = db.engine.execute(text(sql), user_id=user.id)
         for time in total_validation_time:
@@ -284,7 +284,7 @@ class UserService:
                 stats_dto.total_time_spent += stats_dto.time_spent_validating
 
         sql = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                WHERE action='LOCKED_FOR_MAPPING'
+                WHERE (action='LOCKED_FOR_MAPPING' or action='AUTO_UNLOCKED_FOR_MAPPING')
                 and user_id = :user_id;"""
         total_mapping_time = db.engine.execute(text(sql), user_id=user.id)
         for time in total_mapping_time:


### PR DESCRIPTION
Endpoints affected
* [x] /api/v2/projects/<int:project_id>/statistics/queries/<string:username>/
* [x] /api/v2/users/<string:username>/statistics/
* [x] /api/v2/users/queries/<string:username>/