### PR TITLE
Rename explore projects path

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -29,7 +29,7 @@ function App() {
         <QueryParamProvider reachHistory={globalHistory}>
           <Router>
             <Home path="/" />
-            <ProjectsPage path="contribute">
+            <ProjectsPage path="explore">
               <ProjectsPageIndex path="/" />
               <MoreFilters path="/filters/*" />
             </ProjectsPage>

--- a/frontend/src/components/header/index.js
+++ b/frontend/src/components/header/index.js
@@ -20,7 +20,7 @@ import { createLoginWindow } from '../../utils/login';
 import { supportedLocales } from '../../utils/internationalization';
 
 const menuItems = [
-  { label: messages.exploreProjects, link: 'contribute', showAlways: true },
+  { label: messages.exploreProjects, link: 'explore', showAlways: true },
   { label: messages.howItWorks, link: 'learn', authenticated: false },
   { label: messages.about, link: 'about', authenticated: false },
   { label: messages.help, link: 'help', authenticated: false },

--- a/frontend/src/components/homepage/jumbotron.js
+++ b/frontend/src/components/homepage/jumbotron.js
@@ -8,7 +8,7 @@ import messages from './messages';
 function JumbotronButtons() {
   return (
     <p>
-      <Link to={'contribute'}>
+      <Link to={'explore'}>
         <Button className="bg-red white mr3">
           <FormattedMessage {...messages.startButton} />
         </Button>

--- a/frontend/src/components/projects/moreFiltersForm.js
+++ b/frontend/src/components/projects/moreFiltersForm.js
@@ -91,7 +91,7 @@ export const MoreFiltersForm = props => {
         allQueryParamsForChild={formQuery}
       />
       <div className="tr w-100 mt3">
-        <Link to="/contribute">
+        <Link to="/explore">
           <Button className="bg-white blue-dark mr1 f6 pv2">
             <FormattedMessage {...messages.clear} />
           </Button>

--- a/frontend/src/components/projects/projectNav.js
+++ b/frontend/src/components/projects/projectNav.js
@@ -72,7 +72,7 @@ export const ProjectNav = props => {
     : 'bg-white blue-dark';
   const filterRouteToggled =
     props.location.pathname.indexOf('filters') > -1
-      ? '/contribute' + encodedParams
+      ? '/explore' + encodedParams
       : './filters/' + encodedParams;
 
   // onSelectedItemChange={(changes) => console.log(changes)}

--- a/frontend/src/hooks/UseProjectsQueryAPI.js
+++ b/frontend/src/hooks/UseProjectsQueryAPI.js
@@ -8,7 +8,7 @@ import { CommaArrayParam } from '../utils/CommaArrayParam';
 import { useThrottle } from '../hooks/UseThrottle';
 
 /* See also moreFiltersForm, the useQueryParams are duplicated there for specific modular usage */
-/* This one is e.g. used for updating the URL when returning to /contribute
+/* This one is e.g. used for updating the URL when returning to /explore
  *  and directly submitting the query to the API */
 
 import { useEffect, useReducer } from 'react';

--- a/frontend/src/views/project.js
+++ b/frontend/src/views/project.js
@@ -74,7 +74,7 @@ export const ProjectsPageIndex = props => {
 export const MoreFilters = props => {
   const [fullProjectsQuery] = useExploreProjectsQueryParams();
 
-  const currentUrl = `/contribute${
+  const currentUrl = `/explore${
     stringify(fullProjectsQuery) ? ['?', stringify(fullProjectsQuery)].join('') : ''
   }`;
   return (


### PR DESCRIPTION
@willemarcel We haven't talked about it. But I thought I would propose this via code. Is much faster :smile:

With the new structure we will have a "My contributions" in parallel to the "Explore" or "Explore Projects" section. So using the old path of `contribute` might become misleading. So proposing here to change the path to `explore`.