### PR TITLE
Add about and learn pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,6 +10,7 @@ import { ProjectCreate } from './components/projectCreate/create';
 import { ORG_NAME } from './config';
 import { Home } from './views/home';
 import { AboutPage } from './views/about';
+import { LearnPage } from './views/learn';
 import { ManageProjectsPage, ProjectsPage, ProjectsPageIndex, MoreFilters, ProjectDetailPage } from './views/project';
 import { Authorized } from './views/authorized';
 import { Login } from './views/login';
@@ -44,6 +45,7 @@ function App() {
               <ProjectsPageIndex path="/" />
               <MoreFilters path="/filters/*" />
             </ProjectsPage>
+            <LearnPage path="learn" />
             <AboutPage path="about" />
             <Authorized path="authorized" />
             <Login path="login" />

--- a/frontend/src/components/header/topBar.js
+++ b/frontend/src/components/header/topBar.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export function TopBar({ pageName }: Object) {
+  return (
+    <div className="cf w-100 bg-grey-light">
+      <div className="ph6-l">
+          <h1 className="ttu f1 barlow-condensed white pv3 ph4 mt6 mb0 bg-red dib">
+            {pageName}
+          </h1>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/projectDetail/messages.js
+++ b/frontend/src/components/projectDetail/messages.js
@@ -124,7 +124,7 @@ export default defineMessages({
   mapThroughOSMCardDescription: {
     id: 'project.detail.cards.mapthroughosm.description',
     defaultMessage:
-      'If you are new to mapping, we recommend checking the How It Works page before you start mapping.',
+      'If you are new to mapping, we recommend checking the Learn page before you start mapping.',
   },
   submitYourWorkCardDescription: {
     id: 'project.detail.cards.submityourwork.description',

--- a/frontend/src/components/user/content.js
+++ b/frontend/src/components/user/content.js
@@ -126,13 +126,13 @@ export function HelpCard() {
         <FormattedMessage {...messages.helpTitle} />
       </h3>
       <p>
-        <a href="help" className="link red pr4">
+        <a href="learn" className="link red pr4">
           <FormattedMessage {...messages.howToMap} />
         </a>
-        <a href="help" className="link red pr4">
+        <a href="learn" className="link red pr4">
           <FormattedMessage {...messages.howToMapBuildings} />
         </a>
-        <a href="help" className="link red">
+        <a href="learn" className="link red">
           <FormattedMessage {...messages.whatIsOSM} />
         </a>
       </p>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -155,7 +155,7 @@
   "project.detail.cards.mapthroughosm.title": "2. Map through OpenStreetMap",
   "project.detail.cards.submityourwork.title": "3. Submit your Work",
   "project.detail.cards.selectATask.description": "Projects are subdivided into a set of tasks managable in size and adapted to your skill level.",
-  "project.detail.cards.mapthroughosm.description": "If you are new to mapping, we recommend checking the How It Works page before you start mapping.",
+  "project.detail.cards.mapthroughosm.description": "If you are new to mapping, we recommend checking the Learn page before you start mapping.",
   "project.detail.cards.submityourwork.description": "Submitting your work is cruicial. If you don't do it, it will not be merged into the project.",
   "project.detail.sections.overview": "Overview",
   "project.detail.sections.howToContribute": "How to contribute",

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -1,4 +1,13 @@
 {
+  "header.nav.projectsLink": "Explorar",
+  "header.nav.learnLink": "Aprender",
+  "header.nav.aboutLink": "Sobre",
+  "header.buttons.languageSelector": "Idioma",
+  "header.buttons.logIn": "Entrar",
+  "header.buttons.signUp": "Cadastrar",
+  "header.topBar.slogan": "Mapping our world together",
+  "header.nav.settings": "Configurações",
+  "header.nav.logout": "Sair",
    "header.nav.projectsLink": "Explorar projetos",
    "header.nav.learnLink": "Como colaborar",
    "header.nav.aboutLink": "Sobre",

--- a/frontend/src/views/about.js
+++ b/frontend/src/views/about.js
@@ -1,5 +1,18 @@
 import React from 'react';
 
 export function AboutPage() {
-  return <div className="pt180 pull-center">This is the About page</div>;
+  return <div className="pt180 pull-center">
+    The Tasking Manager is a mapping tool designed and built for the coordination of volunteers and the organization of groups for collaborative mapping in OpenStreetMap.
+
+    <blockquote><a href="https://openstreetmap.org">OpenStreetMap</a> is the community-driven free and editable map of the world, supported by the not-for-profit OpenStreetMap Foundation. Read more on the OSM Wiki or join the discussion with your local OSM community.</blockquote>
+
+    <h3>How does it work?</h3>
+    <p>The Tasking Manager allows to divide up a mapping project into smaller tasks that can be completed rapidly with many people working on the same overall area. It shows which areas need to be mapped and which areas need to be reviewed for quality assurance.</p>
+    <p>This approach allows the distribution of tasks to many individual mappers in the context of emergency or other humanitarian mapping scenario. It also allows monitoring of the overall project progress and helps improve the consistency of the mapping (e.g., elements to cover, specific tags to use, etc.).</p>
+
+    <h3>Free and Open Source Software</h3>
+
+    <p>The Tasking Manager is Free and Open Source software. Please feel free to report issues and contribute. The <a href="https://github.com/hotosm/tasking-manager">application’s code is available</a> for you.</p>
+
+  </div>;
 }

--- a/frontend/src/views/about.js
+++ b/frontend/src/views/about.js
@@ -1,18 +1,49 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import messages from './messages';
+import { TopBar } from '../components/header/topBar';
 
 export function AboutPage() {
-  return <div className="pt180 pull-center">
-    The Tasking Manager is a mapping tool designed and built for the coordination of volunteers and the organization of groups for collaborative mapping in OpenStreetMap.
-
-    <blockquote><a href="https://openstreetmap.org">OpenStreetMap</a> is the community-driven free and editable map of the world, supported by the not-for-profit OpenStreetMap Foundation. Read more on the OSM Wiki or join the discussion with your local OSM community.</blockquote>
-
-    <h3>How does it work?</h3>
-    <p>The Tasking Manager allows to divide up a mapping project into smaller tasks that can be completed rapidly with many people working on the same overall area. It shows which areas need to be mapped and which areas need to be reviewed for quality assurance.</p>
-    <p>This approach allows the distribution of tasks to many individual mappers in the context of emergency or other humanitarian mapping scenario. It also allows monitoring of the overall project progress and helps improve the consistency of the mapping (e.g., elements to cover, specific tags to use, etc.).</p>
-
-    <h3>Free and Open Source Software</h3>
-
-    <p>The Tasking Manager is Free and Open Source software. Please feel free to report issues and contribute. The <a href="https://github.com/hotosm/tasking-manager">application’s code is available</a> for you.</p>
-
+  return <div className="pt180 pull-center bg-white blue-dark cf">
+    <TopBar pageName={<FormattedMessage {...messages.about} />} />
+    <div className="pl6-l ph4 mr4-l pt4 f4 w-60-l">
+      <FormattedMessage {...messages.tmDescription} />
+      <blockquote className="pt3 f5 pb2">
+        <FormattedMessage
+          {...messages.osmDescription}
+          values={{
+            osmLink: <a className="link red fw5" href="https://openstreetmap.org">OpenStreetMap</a>,
+            osmWikiLink: <a className="link red fw5" href="https://wiki.openstreetmap.org/">OSM Wiki</a>
+          }}
+        />
+      </blockquote>
+    </div>
+    <div className="pl6-l ph4 pt2 mr4-l f4 w-60-l">
+      <h3><FormattedMessage {...messages.howItWorks} /></h3>
+      <p><FormattedMessage {...messages.howItWorksPart1} /></p>
+      <p><FormattedMessage {...messages.howItWorksPart2} /></p>
+    </div>
+    <div className="ph6-l ph4 pt2">
+      <div className="w-100 w-50-l fl">
+        <h1 className="v-mid f2 barlow-condensed ttu fw8"><FormattedMessage {...messages.floss} /></h1>
+      </div>
+      <div className="w-100 w-50-l fl">
+        <img className="w-25 fl mw3" src="https://opensource.org/files/OSIApproved_1.png" alt="OSI aproved license" />
+        <div className="w-75 fl v-mid pl3 f5">
+          <p>
+            <FormattedMessage {...messages.flossDescription} />
+          </p>
+          <p>
+            <FormattedMessage
+              {...messages.repositoryLink}
+              values={{
+                code: <a className="link red fw5" href="https://github.com/hotosm/tasking-manager"><FormattedMessage {...messages.appCode} /></a>
+              }}
+            />
+          </p>
+        </div >
+      </div>
+    </div>
   </div>;
 }

--- a/frontend/src/views/learn.js
+++ b/frontend/src/views/learn.js
@@ -1,39 +1,65 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import messages from './messages';
+import { TopBar } from '../components/header/topBar';
 
 export function LearnPage() {
+  const [activeSection, setActiveSection] = useState('mapping');
   return <div className="pt180 pull-center">
-    <h2>... to map</h2>
-    <p><a href="https://openstreetmap.org">OpenStreetMap</a> is a collaborative, crowd sourced, free map of the world. Anyone can contribute to OpenStreetMap to map any part of the world that interests them.</p>
-
-    <p>The <a href="https://tasks.hotosm.org">Tasking Manager</a> is a tool that coordinates many people mapping a specific geographic area in OpenStreetMap.</p>
-
-    <p><i>Do you have an OpenStreetMap account already? You can start over with step 4</i></p>
-
-    <p>1) Click on the sign-up button in the upper right corner of the Tasking Manager homepage</p>
-
-    <p>2) Provide your email address. We will use it to send you further information during the sign-up process.</p>
-
-    <p>3) You will be redirected to OpenStreetMap.org. Select Register Now and fill out the sign-up form.</p>
-
-    <p>4) Go to the Tasking Manager homepage and click on the login button in the upper right corner.</p>
-
-    <p>5) Choose one of the recommended projects on the welcome page or click on “Explore” in the main navigation to find a mapping project to work on, and select one of your interest.</p>
-
-    <p>5) Choose one of the recommended projects on the welcome page or click on “Explore” in the main navigation to find a mapping project to work on, and select one of your interest.</p>
-
-    <p>6) Read the instructions for the project</p>
-
-    <p>7) Map a randomly selected task for mapping by clicking on the button “Map a task”.
-
-    <i>Alternatively you can also select one from the list or map and choose “Map selected task”.</i></p>
-
-    <p>8) You will be switched to an OpenStreetMap editor; map all the features asked for in the instructions.</p>
-
-    <i>In case you need assistance on mapping, check the documentation on learnOSM.org.</i>
-
-    <p>9) When finished mapping, save your edits and select the button “Submit task”.</p>
-
-    <p><i>After this, you can go back to step 7 and select a new task for mapping. Thank you for your contribution to OpenStreetMap.</i></p>
-
+    <TopBar pageName={<FormattedMessage {...messages.learn} />} />
+    <div className="pl6-l ph4 mr4-l pt4 f5 w-60-l">
+      <div className="cf ttu barlow-condensed f3 pv2 blue-dark">
+        <span
+          className={`mr4 pb2 pointer ${activeSection === 'mapping' && 'bb b--blue-dark'}`}
+          onClick={() => setActiveSection('mapping')}
+        >
+          <FormattedMessage {...messages.howToMap} />
+        </span>
+        <span
+          className={`mr4 pb2 pointer ${activeSection === 'validation' &&
+            'bb b--blue-dark'}`}
+          onClick={() => setActiveSection('validation')}
+        >
+          <FormattedMessage {...messages.howToValidate} />
+        </span>
+      </div>
+      <div className="pt3">
+        {activeSection === 'mapping' && <MappingInstructions /> }
+        {activeSection === 'validation' && <ValidationInstructions /> }
+      </div>
+    </div>
   </div>;
+}
+
+
+function MappingInstructions() {
+  return (
+    <>
+      <p><a className="link red fw5" href="https://openstreetmap.org">OpenStreetMap</a> is a collaborative, crowd sourced, free map of the world. Anyone can contribute to OpenStreetMap to map any part of the world that interests them.</p>
+      <p>The Tasking Manager is a tool that coordinates many people mapping a specific geographic area in OpenStreetMap.</p>
+      <p><i>Do you have an OpenStreetMap account already? You can start over with step 4.</i></p>
+      <p>1) Click on the sign-up button in the upper right corner of the Tasking Manager homepage</p>
+      <p>2) Provide your email address. We will use it to send you further information during the sign-up process.</p>
+      <p>3) You will be redirected to OpenStreetMap.org. Select Register Now and fill out the sign-up form.</p>
+      <p>4) Go to the Tasking Manager homepage and click on the login button in the upper right corner.</p>
+      <p>5) Choose one of the recommended projects on the welcome page or click on “Explore” in the main navigation to find a mapping project to work on, and select one of your interest.</p>
+      <p>5) Choose one of the recommended projects on the welcome page or click on “Explore” in the main navigation to find a mapping project to work on, and select one of your interest.</p>
+      <p>6) Read the instructions for the project</p>
+      <p>7) Map a randomly selected task for mapping by clicking on the button “Map a task”.
+      <i>Alternatively you can also select one from the list or map and choose “Map selected task”.</i></p>
+      <p>8) You will be switched to an OpenStreetMap editor; map all the features asked for in the instructions.</p>
+      <i>In case you need assistance on mapping, check the documentation on learnOSM.org.</i>
+      <p>9) When finished mapping, save your edits and select the button “Submit task”.</p>
+      <p><i>After this, you can go back to step 7 and select a new task for mapping. Thank you for your contribution to OpenStreetMap.</i></p>
+    </>
+  );
+}
+
+function ValidationInstructions() {
+  return (
+    <>
+      <p>Instructions on how to validate</p>
+    </>
+  );
 }

--- a/frontend/src/views/learn.js
+++ b/frontend/src/views/learn.js
@@ -1,0 +1,39 @@
+import React from 'react';
+
+export function LearnPage() {
+  return <div className="pt180 pull-center">
+    <h2>... to map</h2>
+    <p><a href="https://openstreetmap.org">OpenStreetMap</a> is a collaborative, crowd sourced, free map of the world. Anyone can contribute to OpenStreetMap to map any part of the world that interests them.</p>
+
+    <p>The <a href="https://tasks.hotosm.org">Tasking Manager</a> is a tool that coordinates many people mapping a specific geographic area in OpenStreetMap.</p>
+
+    <p><i>Do you have an OpenStreetMap account already? You can start over with step 4</i></p>
+
+    <p>1) Click on the sign-up button in the upper right corner of the Tasking Manager homepage</p>
+
+    <p>2) Provide your email address. We will use it to send you further information during the sign-up process.</p>
+
+    <p>3) You will be redirected to OpenStreetMap.org. Select Register Now and fill out the sign-up form.</p>
+
+    <p>4) Go to the Tasking Manager homepage and click on the login button in the upper right corner.</p>
+
+    <p>5) Choose one of the recommended projects on the welcome page or click on “Explore” in the main navigation to find a mapping project to work on, and select one of your interest.</p>
+
+    <p>5) Choose one of the recommended projects on the welcome page or click on “Explore” in the main navigation to find a mapping project to work on, and select one of your interest.</p>
+
+    <p>6) Read the instructions for the project</p>
+
+    <p>7) Map a randomly selected task for mapping by clicking on the button “Map a task”.
+
+    <i>Alternatively you can also select one from the list or map and choose “Map selected task”.</i></p>
+
+    <p>8) You will be switched to an OpenStreetMap editor; map all the features asked for in the instructions.</p>
+
+    <i>In case you need assistance on mapping, check the documentation on learnOSM.org.</i>
+
+    <p>9) When finished mapping, save your edits and select the button “Submit task”.</p>
+
+    <p><i>After this, you can go back to step 7 and select a new task for mapping. Thank you for your contribution to OpenStreetMap.</i></p>
+
+  </div>;
+}

--- a/frontend/src/views/messages.js
+++ b/frontend/src/views/messages.js
@@ -106,4 +106,69 @@ export default defineMessages({
     defaultMessage:
       'From now on, we will keep you updated on how you can make the difference by mapping on Tasking Manager. You can customize your notification preferences on {link}.',
   },
+  about: {
+    id: 'pages.about.title',
+    defaultMessage:
+      'About Tasking Manager',
+  },
+  learn: {
+    id: 'pages.learn.title',
+    defaultMessage:
+      'Learn',
+  },
+  howToValidate: {
+    id: 'pages.learn.sections.howToValidate',
+    defaultMessage:
+      'How to validate',
+  },
+  howToMap: {
+    id: 'pages.learn.sections.howToMap',
+    defaultMessage:
+      'How to map',
+  },
+  tmDescription: {
+    id: 'pages.about.description',
+    defaultMessage:
+      'Tasking Manager is a mapping tool designed and built for the coordination of volunteers and the organization of groups for collaborative mapping in OpenStreetMap.',
+  },
+  osmDescription: {
+    id: 'pages.about.OpenStreetMap.description',
+    defaultMessage:
+      '{osmLink} is the community-driven free and editable map of the world, supported by the not-for-profit OpenStreetMap Foundation. Read more on the {osmWikiLink} or join the discussion with your local OSM community.',
+  },
+  howItWorks: {
+    id: 'pages.about.howItWorks.title',
+    defaultMessage:
+      'How does it work?',
+  },
+  howItWorksPart1: {
+    id: 'pages.about.howItWorks.description.part_1',
+    defaultMessage:
+      'The Tasking Manager allows to divide up a mapping project into smaller tasks that can be completed rapidly with many people working on the same overall area. It shows which areas need to be mapped and which areas need to be reviewed for quality assurance.',
+  },
+  howItWorksPart2: {
+    id: 'pages.about.howItWorks.description.part_2',
+    defaultMessage:
+      'This approach allows the distribution of tasks to many individual mappers in the context of emergency or other humanitarian mapping scenario. It also allows monitoring the overall project progress and helps improve the consistency of the mapping (e.g., elements to cover, specific tags to use, etc.).',
+  },
+  floss: {
+    id: 'pages.about.floss.title',
+    defaultMessage:
+      'Free and Open Source Software',
+  },
+  flossDescription: {
+    id: 'pages.about.floss.description',
+    defaultMessage:
+      'The Tasking Manager is Free and Open Source software. Please feel free to report issues and contribute.',
+  },
+  repositoryLink: {
+    id: 'pages.about.floss.repository_link',
+    defaultMessage:
+      'The {code} is available for you.',
+  },
+  appCode: {
+    id: 'pages.about.floss.application_code',
+    defaultMessage:
+      'application code',
+  },
 });


### PR DESCRIPTION
This PR adds initial content to the about and learn page. It also removes the help page.

Missing:

* [ ] Styling of the pages
* [ ] Tabs for learn page (Learn: ... to map, ... to validate, ... to create a project)
* [ ] Add screenshots to the learn pages and complete user documentation

Text is being worked on [here](https://docs.google.com/document/d/1TiijUgKZLUB6ui39tfjg_AZYXX4iE0DN1k4kbTbpDFI/edit?usp=sharing)

FYI @willemarcel 