### PR TITLE
Replace jonathonf python ppa with deadsnakes

### DIFF
--- a/devops/cloudformation/tasking-manager.template.js
+++ b/devops/cloudformation/tasking-manager.template.js
@@ -163,7 +163,7 @@ const Resources = {
         'dpkg-reconfigure --frontend=noninteractive locales',
         'sudo apt-get -y update',
         'sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade',
-        'sudo add-apt-repository ppa:jonathonf/python-3.6 -y',
+        'sudo add-apt-repository ppa:deadsnakes/ppa -y',
         'sudo apt-get update',
         'sudo apt-get -y install python3.6',
         'sudo apt-get -y install python3.6-dev',


### PR DESCRIPTION
As of December 11, the [PPA we were using to install Python 3.6](https://launchpad.net/~jonathonf) on our AWS Cloudformation stacks took all of their packages private. We have replaced that PPA repo with a [new one](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa). 

This change only affects AWS deployments. I didn't see this repo being used anywhere else. I tested the changes on a fresh cloudformation stack with no errors- the logs showed that Python3.6 was installed and the rest of the installation went well. I was able to connect to the running instance from my browser. 

These changes affect the TM infrastructure- changes to the LaunchConfiguration resource will replace all running instances in the Autoscaling Group. No other resources are affected. 