### PR TITLE
Replace python3.6 repository for Cloudformation template

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -320,7 +320,7 @@ const Resources = {
         'dpkg-reconfigure --frontend=noninteractive locales',
         'sudo apt-get -y update',
         'sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade',
-        'sudo add-apt-repository ppa:jonathonf/python-3.6 -y',
+        'sudo add-apt-repository ppa:deadsnakes/ppa -y',
         'sudo apt-get update',
         'sudo apt-get -y install python3.6',
         'sudo apt-get -y install python3.6-dev',


### PR DESCRIPTION
This will fix `staging`, then we can push to `deployment/redesign-tasking-manager` to fix tm4. 