### PR TITLE
Fix user login on TM4

### DIFF
--- a/server/api/users/openstreetmap.py
+++ b/server/api/users/openstreetmap.py
@@ -1,7 +1,6 @@
 from flask_restful import Resource, current_app
 
 from server.services.users.user_service import UserService, UserServiceError, NotFound
-from server.services.users.authentication_service import token_auth
 
 
 class UsersOpenStreetMapAPI(Resource):

--- a/server/api/users/openstreetmap.py
+++ b/server/api/users/openstreetmap.py
@@ -5,7 +5,6 @@ from server.services.users.authentication_service import token_auth
 
 
 class UsersOpenStreetMapAPI(Resource):
-    @token_auth.login_required
     def get(self, username):
         """
         Get details from OpenStreetMap for a specified username


### PR DESCRIPTION
Removed the login requirement on an endpoint that fetches OpenStreetMap details during user login. Testing it with a new non-PM OpenStreetMap login and it was successful.

cc @xamanu @willemarcel @dakotabenjamin 
