### PR TITLE
open id editor when user locks a task for mapping/validation

### DIFF
--- a/frontend/src/components/taskSelection/footer.js
+++ b/frontend/src/components/taskSelection/footer.js
@@ -5,6 +5,7 @@ import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
 import { getEditors } from '../../utils/editorsList';
+import { openEditor } from '../../utils/openEditor';
 import { pushToLocalJSONAPI, fetchLocalJSONAPI } from '../../network/genericJSONRequest';
 import { Dropdown } from '../dropdown';
 import { Button } from '../button';
@@ -57,17 +58,53 @@ export function ContributeButton({ action, projectId, selectedTasks, activities 
 export const TaskSelectionFooter = props => {
   const [editor, setEditor] = useState(props.defaultUserEditor);
   const [editorOptions, setEditorOptions] = useState([]);
-  const titleClasses = 'db ttu f6 blue-light mb2';
+  const token = useSelector(state => state.auth.get('token'));
+  const dispatch = useDispatch();
+
+  const updateReduxState = (tasks, project, status) => {
+    dispatch({type: 'SET_LOCKED_TASKS', tasks: tasks});
+    dispatch({type: 'SET_PROJECT', project: project});
+    dispatch({type: 'SET_TASKS_STATUS', status: status});
+  }
+  const lockTasks = () => {
+    if (props.taskAction.startsWith('validate')) {
+      pushToLocalJSONAPI(
+        `projects/${props.project.projectId}/tasks/actions/lock-for-validation/`,
+        JSON.stringify({taskIds: props.selectedTasks}),
+        token
+      ).then(
+        res => {
+          updateReduxState(props.selectedTasks, props.project.projectId, 'LOCKED_FOR_VALIDATION');
+          openEditor(editor, props.project, props.tasks, props.selectedTasks);
+          navigate(`/projects/${props.project.projectId}/validate/`);
+        }
+      ).catch(e => console.log(e));
+    }
+    if (props.taskAction.startsWith('map')) {
+      fetchLocalJSONAPI(
+        `projects/${props.project.projectId}/tasks/actions/lock-for-mapping/${props.selectedTasks[0]}/`,
+        token,
+        'POST'
+      ).then(
+        res => {
+          openEditor(editor, props.project, props.tasks, props.selectedTasks);
+          updateReduxState(props.selectedTasks, props.project.projectId, 'LOCKED_FOR_MAPPING');
+          navigate(`/projects/${props.project.projectId}/map/`);
+        }
+      ).catch(e => console.log(e));
+    }
+  };
 
   useEffect(() => {
-    if (props.taskAction && props.mappingEditors && props.taskAction.startsWith('validate')) {
-      setEditorOptions(getEditors().filter(i => props.validationEditors.includes(i.backendValue)));
+    if (props.taskAction && props.project.mappingEditors && props.taskAction.startsWith('validate')) {
+      setEditorOptions(getEditors().filter(i => props.project.validationEditors.includes(i.backendValue)));
     } else {
-      setEditorOptions(getEditors().filter(i => props.mappingEditors.includes(i.backendValue)));
+      setEditorOptions(getEditors().filter(i => props.project.mappingEditors.includes(i.backendValue)));
     }
-  }, [props.taskAction, props.mappingEditors, props.validationEditors]);
+  }, [props.taskAction, props.project.mappingEditors, props.project.validationEditors]);
 
   const updateEditor = arr => setEditor(arr[0].value);
+  const titleClasses = 'db ttu f6 blue-light mb2';
 
   return (
     <div className="cf bg-white pb2 ph4-l ph2">
@@ -76,14 +113,14 @@ export const TaskSelectionFooter = props => {
           <FormattedMessage {...messages.typesOfMapping} />
         </h3>
         <div className="db fl pt1">
-          <MappingTypes types={props.mappingTypes} />
+          <MappingTypes types={props.project.mappingTypes} />
         </div>
       </div>
       <div className="w-25-ns w-60 fl">
         <h3 className={titleClasses}>
           <FormattedMessage {...messages.imagery} />
         </h3>
-        <Imagery value={props.imagery} />
+        <Imagery value={props.project.imagery} />
       </div>
       <div className="w-20-ns w-40 fl">
         <h3 className={titleClasses}>
@@ -102,8 +139,9 @@ export const TaskSelectionFooter = props => {
       </div>
       <div className="w-30-ns w-60 fl tr">
         <div className="mt3">
-          {/* type value will be changed soon */}
-          <ContributeButton action={props.taskAction} selectedTasks={props.selectedTasks} projectId={props.projectId} />
+          <Button className="white bg-red" onClick={() => lockTasks()}>
+            <FormattedMessage {...messages[props.taskAction]} />
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -217,12 +217,9 @@ export function TaskSelection({ project, type, loading }: Object) {
           ready={typeof project.projectId === 'number' && project.projectId > 0}
         >
           <TaskSelectionFooter
-            mappingTypes={project.mappingTypes}
-            imagery={project.imagery}
-            mappingEditors={project.mappingEditors}
-            validationEditors={project.validationEditors}
             defaultUserEditor={user ? user.defaultEditor : 'iD'}
-            projectId={project.projectId}
+            project={project}
+            tasks={tasks}
             taskAction={taskAction}
             selectedTasks={selected.length && !taskAction.endsWith('AnotherTask') ? selected : randomTask}
           />

--- a/frontend/src/utils/openEditor.js
+++ b/frontend/src/utils/openEditor.js
@@ -1,0 +1,36 @@
+import { API_URL } from '../config';
+import { getCentroidAndZoomFromSelectedTasks } from './tasksGeometry';
+
+export function openEditor(editor, project, tasks, selectedTasks) {
+  const [centroid, zoomLevel] = getCentroidAndZoomFromSelectedTasks(tasks, selectedTasks);
+  if (editor === 'iD Editor') {
+    const idUrl = getIdUrl(project, centroid, zoomLevel, selectedTasks);
+    window.open(idUrl);
+  }
+}
+
+export function getGPXUrl(projectId, selectedTasks) {
+  return new URL(
+    `projects/${projectId}/tasks/queries/gpx/?tasks=${selectedTasks.join(',')}`,
+    API_URL
+  );
+}
+
+export function getIdUrl(project, centroid, zoomLevel, selectedTasks) {
+  const base = 'https://www.openstreetmap.org/edit?editor=id&';
+  let url = base + '#map=' + [zoomLevel, centroid[1], centroid[0]].join('/');
+  if (project.changesetComment){
+    url += '&comment=' + encodeURIComponent(project.changesetComment);
+  }
+  if (project.imagery) {
+    // url is supposed to look like tms[22]:http://hiu...
+    let urlForImagery = project.imagery.substring(project.imagery.indexOf('http'));
+    urlForImagery = urlForImagery.replace('zoom', 'z');
+    url += "&background=custom:" + encodeURIComponent(urlForImagery);
+  }
+  // Add GPX
+  if (project.projectId && selectedTasks) {
+    url += "&gpx=" + encodeURIComponent(getGPXUrl(project.projectId, selectedTasks).href);
+  }
+  return url;
+}

--- a/frontend/src/utils/tasksGeometry.js
+++ b/frontend/src/utils/tasksGeometry.js
@@ -1,0 +1,13 @@
+import * as turf from '@turf/turf';
+
+export function getCentroidAndZoomFromSelectedTasks(tasks, selectedTaskIds) {
+  const selectedTasksGeom = turf.featureCollection(
+    tasks.features.filter(task => selectedTaskIds.includes(task.properties.taskId))
+  );
+  const selectedTasksCentroid = turf.centroid(selectedTasksGeom).geometry.coordinates;
+  let zoomLevel = 15;
+  if (selectedTaskIds.length === 1) {
+    zoomLevel = selectedTasksGeom.features[0].properties.taskZoom;
+  }
+  return [selectedTasksCentroid, zoomLevel];
+}

--- a/frontend/src/utils/tests/openEditor.test.js
+++ b/frontend/src/utils/tests/openEditor.test.js
@@ -1,0 +1,32 @@
+import { API_URL } from '../../config';
+import { getIdUrl, getGPXUrl } from '../openEditor';
+
+it('test if getIdUrl returns the correct url', () => {
+  const testProject = {
+    changesetComment: '#hotosm-project-5522 #osm_in #2018IndiaFloods #mmteamarm',
+    projectId: 1234,
+    imagery: "tms[1,22]:https://api.mapbox.com/styles/v1/tm4/code123/tiles/256/{zoom}/{x}/{y}?access_token=pk.123"
+  };
+  expect(
+    getIdUrl(testProject, [120.25684, -9.663953], 18, [1])
+  ).toBe(
+    'https://www.openstreetmap.org/edit?editor=id&' +
+    '#map=18/-9.663953/120.25684' +
+    '&comment=%23hotosm-project-5522%20%23osm_in%20%232018IndiaFloods%20%23mmteamarm' +
+    '&background=custom:https%3A%2F%2Fapi.mapbox.com%2Fstyles%2Fv1%2Ftm4%2Fcode123%2Ftiles%2F256%2F%7Bz%7D%2F%7Bx%7D%2F%7By%7D%3Faccess_token%3Dpk.123' +
+    '&gpx=http%3A%2F%2F127.0.0.1%3A5000%2Fapi%2Fv2%2Fprojects%2F1234%2Ftasks%2Fqueries%2Fgpx%2F%3Ftasks%3D1'
+  );
+});
+
+it('test if getGPXUrl returns the correct url', () => {
+  expect(
+    getGPXUrl(1, [1])
+  ).toStrictEqual(
+    new URL('/projects/1/tasks/queries/gpx/?tasks=1', API_URL)
+  );
+  expect(
+    getGPXUrl(2312, [1, 344, 54])
+  ).toStrictEqual(
+    new URL('/projects/2312/tasks/queries/gpx/?tasks=1,344,54', API_URL)
+  );
+});

--- a/frontend/src/utils/tests/snippets/tasksGeometry.js
+++ b/frontend/src/utils/tests/snippets/tasksGeometry.js
@@ -1,0 +1,405 @@
+export const tasksGeojson = {
+  features: [
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.253013091, -9.671502972],
+              [120.260671043, -9.671502972],
+              [120.260671043, -9.663953776],
+              [120.253013091, -9.663953776],
+              [120.253013091, -9.671502972],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 1,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39208,
+        taskY: 22236,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.253013091, -9.663953776],
+              [120.260671043, -9.663953776],
+              [120.260671043, -9.65640441],
+              [120.253013091, -9.65640441],
+              [120.253013091, -9.663953776],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 2,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39208,
+        taskY: 22237,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.253013091, -9.65640441],
+              [120.260671043, -9.65640441],
+              [120.260671043, -9.648854875],
+              [120.253013091, -9.648854875],
+              [120.253013091, -9.65640441],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 3,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39208,
+        taskY: 22238,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.253013091, -9.648854875],
+              [120.260671043, -9.648854875],
+              [120.260671043, -9.641305172],
+              [120.253013091, -9.641305172],
+              [120.253013091, -9.648854875],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 4,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39208,
+        taskY: 22239,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.260671043, -9.671502972],
+              [120.268328996, -9.671502972],
+              [120.268328996, -9.663953776],
+              [120.260671043, -9.663953776],
+              [120.260671043, -9.671502972],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 5,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39209,
+        taskY: 22236,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.260671043, -9.663953776],
+              [120.268328996, -9.663953776],
+              [120.268328996, -9.65640441],
+              [120.260671043, -9.65640441],
+              [120.260671043, -9.663953776],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 6,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39209,
+        taskY: 22237,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.260671043, -9.65640441],
+              [120.268328996, -9.65640441],
+              [120.268328996, -9.648854875],
+              [120.260671043, -9.648854875],
+              [120.260671043, -9.65640441],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 7,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39209,
+        taskY: 22238,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.260671043, -9.648854875],
+              [120.268328996, -9.648854875],
+              [120.268328996, -9.641305172],
+              [120.260671043, -9.641305172],
+              [120.260671043, -9.648854875],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 8,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39209,
+        taskY: 22239,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.268328996, -9.671502972],
+              [120.275986949, -9.671502972],
+              [120.275986949, -9.663953776],
+              [120.268328996, -9.663953776],
+              [120.268328996, -9.671502972],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 9,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39210,
+        taskY: 22236,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.268328996, -9.663953776],
+              [120.275986949, -9.663953776],
+              [120.275986949, -9.65640441],
+              [120.268328996, -9.65640441],
+              [120.268328996, -9.663953776],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 10,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39210,
+        taskY: 22237,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.268328996, -9.65640441],
+              [120.275986949, -9.65640441],
+              [120.275986949, -9.648854875],
+              [120.268328996, -9.648854875],
+              [120.268328996, -9.65640441],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 11,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39210,
+        taskY: 22238,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.268328996, -9.648854875],
+              [120.275986949, -9.648854875],
+              [120.275986949, -9.641305172],
+              [120.268328996, -9.641305172],
+              [120.268328996, -9.648854875],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 12,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39210,
+        taskY: 22239,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.275986949, -9.671502972],
+              [120.283644902, -9.671502972],
+              [120.283644902, -9.663953776],
+              [120.275986949, -9.663953776],
+              [120.275986949, -9.671502972],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 13,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39211,
+        taskY: 22236,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.275986949, -9.663953776],
+              [120.283644902, -9.663953776],
+              [120.283644902, -9.65640441],
+              [120.275986949, -9.65640441],
+              [120.275986949, -9.663953776],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 14,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39211,
+        taskY: 22237,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.275986949, -9.65640441],
+              [120.283644902, -9.65640441],
+              [120.283644902, -9.648854875],
+              [120.275986949, -9.648854875],
+              [120.275986949, -9.65640441],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 15,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39211,
+        taskY: 22238,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+    {
+      geometry: {
+        coordinates: [
+          [
+            [
+              [120.275986949, -9.648854875],
+              [120.283644902, -9.648854875],
+              [120.283644902, -9.641305172],
+              [120.275986949, -9.641305172],
+              [120.275986949, -9.648854875],
+            ],
+          ],
+        ],
+        type: 'MultiPolygon',
+      },
+      properties: {
+        taskId: 16,
+        taskIsSquare: true,
+        taskStatus: 'READY',
+        taskX: 39211,
+        taskY: 22239,
+        taskZoom: 16,
+      },
+      type: 'Feature',
+    },
+  ],
+  type: 'FeatureCollection',
+};

--- a/frontend/src/utils/tests/tasksGeometry.test.js
+++ b/frontend/src/utils/tests/tasksGeometry.test.js
@@ -1,0 +1,18 @@
+import { getCentroidAndZoomFromSelectedTasks } from '../tasksGeometry';
+import { tasksGeojson } from './snippets/tasksGeometry';
+
+it('test if centroid and zoom level of multiple selected tasks are correct', () => {
+  expect(
+    getCentroidAndZoomFromSelectedTasks(tasksGeojson, [1, 2])
+  ).toStrictEqual(
+    [[ 120.256842067, -9.663953733499998 ], 15]
+  );
+});
+
+it('test if centroid and zoom level of selected tasks are correct', () => {
+  expect(
+    getCentroidAndZoomFromSelectedTasks(tasksGeojson, [1])
+  ).toStrictEqual(
+    [[ 120.25684206700001, -9.667728374 ], 16]
+  );
+});


### PR DESCRIPTION
It's missing to add other editors, but iD is ready. @xamanu feel free to merge it now or wait for the other editors. I think I can implement the other editors this Thursday.