### PR TITLE
Handle no locked tasks scenario as 200 instead of 404

### DIFF
--- a/server/api/tasks/resources.py
+++ b/server/api/tasks/resources.py
@@ -385,8 +385,6 @@ class TasksQueriesOwnLockedAPI(Resource):
                 tm.authenticated_user_id
             )
             return locked_tasks.to_primitive(), 200
-        except NotFound:
-            return {"Error": "User has no locked tasks"}, 404
         except Exception as e:
             error_msg = f"TasksQueriesOwnLockedAPI - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)

--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -149,9 +149,6 @@ class ProjectService:
         """ if the user is working on a task in the project return it """
         tasks = Task.get_locked_tasks_for_user(user_id)
 
-        if len(tasks) == 0:
-            raise NotFound()
-
         tasks_dto = LockedTasksForUser()
         tasks_dto.locked_tasks = tasks
         return tasks_dto

--- a/tests/server/unit/services/test_project_service.py
+++ b/tests/server/unit/services/test_project_service.py
@@ -113,8 +113,7 @@ class TestProjectService(unittest.TestCase):
         mock_user_tasks.return_value = []
 
         # Act / Assert
-        with self.assertRaises(NotFound):
-            ProjectService.get_task_for_logged_in_user(1)
+        self.assertFalse(ProjectService.get_task_for_logged_in_user(1).locked_tasks)
 
     @patch.object(UserService, "is_user_blocked")
     @patch.object(Project, "get")


### PR DESCRIPTION
Per chat w/ @willemarcel - updating the endpoint `/api/v2/projects/tasks/queries/own/locked/` to return an empty array when a user has no locked tasks. At present this returns 404 - modified this to return `{"lockedTasks": []}`