### PR TITLE
Fix popular projects endpoint

### DIFF
--- a/server/services/project_search_service.py
+++ b/server/services/project_search_service.py
@@ -82,7 +82,7 @@ class ProjectSearchService:
             )
             .filter(Project.private is not True)
             .outerjoin(Organisation, Organisation.id == Project.organisation_id)
-            .group_by(Organisation.id)
+            .group_by(Organisation.id, Project.id)
         )
 
         return query

--- a/server/services/stats_service.py
+++ b/server/services/stats_service.py
@@ -176,7 +176,6 @@ class StatsService:
             .limit(10)
             .subquery()
         )
-
         projects_query = ProjectSearchService.create_search_query()
         projects = projects_query.filter(Project.id == sq.c.id)
 


### PR DESCRIPTION
From #2095 -  add group by clause to include project id. Endpoint affected: `/api/v2/projects/queries/popular/`