### PR TITLE
Send arbitrary changeset tags to an editor

### DIFF
--- a/frontend/src/components/projectEdit/instructionsForm.js
+++ b/frontend/src/components/projectEdit/instructionsForm.js
@@ -41,8 +41,8 @@ export const InstructionsForm = ({ languages }) => {
         <input
           className={styleClasses.inputClass}
           type="text"
-          value={projectInfo.changesetComment}
-          name="changesetComment"
+          value={projectInfo.changesetTags["comment"]}
+          name="changesetTags"
           onChange={handleChange}
         />
         <p className={styleClasses.pClass}>

--- a/frontend/src/components/projectEdit/instructionsForm.js
+++ b/frontend/src/components/projectEdit/instructionsForm.js
@@ -18,10 +18,78 @@ export const InstructionsForm = ({ languages }) => {
       );
       newLocales.push(localeData);
       setProjectInfo({ ...projectInfo, projectInfoLocales: newLocales });
+    } else if ('changesetTags' === event.target.name) {
+      setProjectInfo({ ...projectInfo, [event.target.name]: convertTableToJSON(event.target.name)});
     } else {
       setProjectInfo({ ...projectInfo, [event.target.name]: event.target.value });
     }
   };
+
+    function setAttributes(inputCell, value) {
+        var input = document.createElement("input");
+        inputCell.appendChild(input);
+        input.setAttribute("class", styleClasses.inputClass);
+        input.setAttribute("type", "text");
+        input.onchange = handleChange;
+        input.setAttribute("name", "changesetTags");
+        input.setAttribute("value", value);
+    }
+    function addRow() {
+        var table = document.getElementById("changesetTags");
+        if (table) {
+            var row = document.createElement("tr");
+            for (var i = 0; i < 2; i++) {
+                var cell = document.createElement("td");
+                setAttributes(cell, "");
+                row.appendChild(cell);
+            }
+            table.appendChild(row);
+        }
+    }
+
+    function cleanupTable(tableId) {
+        var table = document.getElementById(tableId);
+        if (table) {
+            for (let i = 0; i < table.children.length; i++) {
+                var row = table.children[i];
+                var tag = row.children[0].firstChild.value;
+                var value = row.children[1].firstChild.value;
+                if (!tag && !value) {
+                    table.removeChild(row);
+                }
+            }
+        }
+    }
+
+    function buildTable(tableId, jsonValue) {
+        const defaultFields = ['comment'];
+        cleanupTable(tableId);
+        var currentJson = convertTableToJSON(tableId);
+        var returnRows = [];
+        for (var tag in jsonValue) {
+            if (!defaultFields.includes(tag) && (tag in currentJson) === false) {
+                returnRows.push(<tr><td><input className={styleClasses.inputClass} type="text" name="changesetTags" value={tag} /></td><td><input className={styleClasses.inputClass} type="text" name="changesetTags" value={jsonValue[tag]} /></td></tr>);
+            }
+        }
+        return returnRows;
+    }
+
+
+    function convertTableToJSON(tableId) {
+        var table = document.getElementById(tableId);
+        var json = {};
+        if (table) {
+            for (let i = 0; i < table.children.length; i++) {
+                var row = table.children[i];
+                var tag = row.children[0].firstChild.value;
+                var value = row.children[1].firstChild.value;
+                if (tag && value) {
+                    json[tag] = value;
+                }
+            }
+        }
+        return json;
+    }
 
   return (
     <div className="w-100">
@@ -37,17 +105,46 @@ export const InstructionsForm = ({ languages }) => {
         <p>The list of entities to map</p>
       </div>
       <div className={styleClasses.divClass}>
-        <label className={styleClasses.labelClass}>Changeset comment</label>
-        <input
-          className={styleClasses.inputClass}
-          type="text"
-          value={projectInfo.changesetTags["comment"]}
-          name="changesetTags"
-          onChange={handleChange}
-        />
+        <label className={styleClasses.labelClass}>Changeset Tags</label>
+        <table>
+          <thead>
+            <tr>
+              <th>Tag</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody id="changesetTags" name="changesetTags" onChange={handleChange}>
+            <tr>
+              <td>
+                <input
+                  className={styleClasses.inputClass}
+                  type="text"
+                  value="comment"
+                  name="changesetTags"
+                  onChange={handleChange}
+                  readonly="readonly"
+                 />
+               </td>
+              <td>
+                <input
+                  className={styleClasses.inputClass}
+                  type="text"
+                  value={projectInfo.changesetTags["comment"]}
+                  name="changesetTags"
+                  onChange={handleChange}
+                  />
+              </td>
+            </tr>
+            { buildTable("changesetTags", projectInfo.changesetTags) }
+          </tbody>
+        </table>
+        <button type="button" onClick={addRow}>Add row</button>
         <p className={styleClasses.pClass}>
-          Default comments added to uploaded changeset comment field. Users should also be
-          encouraged to add text describing what they mapped. Example: #hotosm-project-470
+          Common tags include "comment" and "source" tags. These can usually be changed when the user uploads data.
+        </p>
+        <p className={styleClasses.pClass}>
+          Users should also be encouraged to add text describing what they mapped, expanding upon the provided comment.
+          Example: #hotosm-project-470
           #missingmaps Buildings mapping. Hashtags are sometimes used for analysis later, but should
           be human informative and not overused, #group #event for example.
         </p>

--- a/frontend/src/components/projectEdit/metadataForm.js
+++ b/frontend/src/components/projectEdit/metadataForm.js
@@ -10,7 +10,7 @@ export const MetadataForm = () => {
     { item: 'ROADS', showItem: 'Roads' },
     { item: 'BUILDINGS', showItem: 'Buildings' },
     { item: 'WATERWAYS', showItem: 'Waterways' },
-    { item: 'LANDUSE', showItem: 'Landuse' },
+    { item: 'LAND_USE', showItem: 'Landuse' },
     { item: 'OTHER', showItem: 'Other' },
   ];
 

--- a/frontend/src/utils/openEditor.js
+++ b/frontend/src/utils/openEditor.js
@@ -51,8 +51,8 @@ export function getPotlatch2Url(centroid, zoomLevel) {
 export function getIdUrl(project, centroid, zoomLevel, selectedTasks) {
   const base = 'https://www.openstreetmap.org/edit?editor=id&';
   let url = base + '#map=' + [zoomLevel, centroid[1], centroid[0]].join('/');
-  if (project.changesetComment) {
-    url += '&comment=' + encodeURIComponent(project.changesetComment);
+  if (project.changesetTags){
+    url += '&comment=' + encodeURIComponent(project.changesetTags["comment"]);
   }
   if (project.imagery) {
     // url is supposed to look like tms[22]:http://hiu...
@@ -118,7 +118,7 @@ function loadOsmDataToTasks(project, bbox, selectedTasks) {
     bottom: bbox[1],
     right: bbox[2],
     top: bbox[3],
-    changeset_comment: project.changesetComment,
+    changeset_comment: project.changesetTags["comment"],
     changeset_source: project.changesetSource,
     new_layer: false,
   };

--- a/frontend/src/utils/openEditor.js
+++ b/frontend/src/utils/openEditor.js
@@ -51,8 +51,9 @@ export function getPotlatch2Url(centroid, zoomLevel) {
 export function getIdUrl(project, centroid, zoomLevel, selectedTasks) {
   const base = 'https://www.openstreetmap.org/edit?editor=id&';
   let url = base + '#map=' + [zoomLevel, centroid[1], centroid[0]].join('/');
-  if (project.changesetTags){
-    url += '&comment=' + encodeURIComponent(project.changesetTags["comment"]);
+  var changesetTags = JSON.parse(project.changesetTags);
+  if (changesetTags && "comment" in changesetTags) {
+    url += '&comment=' + encodeURIComponent(changesetTags["comment"]);
   }
   if (project.imagery) {
     // url is supposed to look like tms[22]:http://hiu...

--- a/frontend/src/utils/tests/openEditor.test.js
+++ b/frontend/src/utils/tests/openEditor.test.js
@@ -10,7 +10,7 @@ import {
 
 it('test if getIdUrl returns the correct url', () => {
   const testProject = {
-    changesetTags: '{"comment": "#hotosm-project-5522 #osm_in #2018IndiaFloods #mmteamarm"}',
+    changesetTags: '{"comment": "#hotosm-project-5522 #osm_in #2018IndiaFloods #mmteamarm", "source": "not important"}',
     projectId: 1234,
     imagery:
       'tms[1,22]:https://api.mapbox.com/styles/v1/tm4/code123/tiles/256/{zoom}/{x}/{y}?access_token=pk.123',
@@ -26,7 +26,7 @@ it('test if getIdUrl returns the correct url', () => {
 
 it('test if getIdUrl without imagery and with multiple tasks returns the correct url', () => {
   const testProject = {
-    changesetComment: '#hotosm-project-5522',
+    changesetTags: '{"comment": "#hotosm-project-5522", "source": "not important"}',
     projectId: 1234,
   };
   expect(getIdUrl(testProject, [120.25684, -9.663953], 18, [1, 2])).toBe(

--- a/frontend/src/utils/tests/openEditor.test.js
+++ b/frontend/src/utils/tests/openEditor.test.js
@@ -10,7 +10,7 @@ import {
 
 it('test if getIdUrl returns the correct url', () => {
   const testProject = {
-    changesetComment: '#hotosm-project-5522 #osm_in #2018IndiaFloods #mmteamarm',
+    changesetTags: '{"comment": "#hotosm-project-5522 #osm_in #2018IndiaFloods #mmteamarm"}',
     projectId: 1234,
     imagery:
       'tms[1,22]:https://api.mapbox.com/styles/v1/tm4/code123/tiles/256/{zoom}/{x}/{y}?access_token=pk.123',

--- a/migrations/versions/c8fa5f168271_.py
+++ b/migrations/versions/c8fa5f168271_.py
@@ -1,0 +1,42 @@
+"""empty message
+
+Revision ID: c8fa5f168271
+Revises: f26a7c36eb65_
+Create Date: 2019-09-06 08:08:15.691079
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "c8fa5f168271"
+down_revision = "f26a7c36eb65"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ### Alembic commands ###
+    op.alter_column(
+            'projects',
+            'changeset_comment',
+            new_column_name='changeset_tags',
+            existing_type=sa.String(),
+            type_=sa.JSON(),
+            postgresql_using="json_build_object('comment', changeset_comment)"
+            )
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    # ### Alembic commands ###
+    op.alter_column(
+            'projects',
+            'changeset_tags',
+            new_column_name='changeset_comment',
+            existing_type=sa.JSON(),
+            type_=sa.String(),
+            postgresql_using="changeset_tags::json->'comment'"
+            )
+    # ### end Alembic commands ###

--- a/migrations/versions/c8fa5f168271_.py
+++ b/migrations/versions/c8fa5f168271_.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "c8fa5f168271"
-down_revision = "f26a7c36eb65"
+down_revision = "84c793a951b2"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/c8fa5f168271_.py
+++ b/migrations/versions/c8fa5f168271_.py
@@ -7,7 +7,6 @@ Create Date: 2019-09-06 08:08:15.691079
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "c8fa5f168271"
@@ -19,24 +18,24 @@ depends_on = None
 def upgrade():
     # ### Alembic commands ###
     op.alter_column(
-            'projects',
-            'changeset_comment',
-            new_column_name='changeset_tags',
-            existing_type=sa.String(),
-            type_=sa.JSON(),
-            postgresql_using="json_build_object('comment', changeset_comment)"
-            )
+        "projects",
+        "changeset_comment",
+        new_column_name="changeset_tags",
+        existing_type=sa.String(),
+        type_=sa.JSON(),
+        postgresql_using="json_build_object('comment', changeset_comment)",
+    )
     # ### end Alembic commands ###
 
 
 def downgrade():
     # ### Alembic commands ###
     op.alter_column(
-            'projects',
-            'changeset_tags',
-            new_column_name='changeset_comment',
-            existing_type=sa.JSON(),
-            type_=sa.String(),
-            postgresql_using="changeset_tags::json->'comment'"
-            )
+        "projects",
+        "changeset_tags",
+        new_column_name="changeset_comment",
+        existing_type=sa.JSON(),
+        type_=sa.String(),
+        postgresql_using="changeset_tags::json->'comment'",
+    )
     # ### end Alembic commands ###

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic==1.3.2
 aniso8601==8.0.0
 appdirs==1.4.3
 attrs==19.3.0
-black==19.3b0
+black==19.10b0
 bleach==3.1.0
 cachetools==4.0.0
 certifi==2019.11.28
@@ -10,7 +10,7 @@ chardet==3.0.4
 Click==7.0
 coverage==5.0.3
 entrypoints==0.3
-flake8==3.7.8
+flake8==3.7.9
 Flask==1.1.1
 Flask-Cors==3.0.8
 Flask-HTTPAuth==3.3.0

--- a/server/api/projects/resources.py
+++ b/server/api/projects/resources.py
@@ -294,9 +294,9 @@ class ProjectsRestAPI(Resource):
                     private:
                         type: boolean
                         default: false
-                    changesetComment:
+                    changesetTags:
                         type: string
-                        default: hotosm-project-1
+                        default: {"comment": "hotosm-project-1"}
                     entitiesToMap:
                         type: string
                         default: Buildings only

--- a/server/api/users/actions.py
+++ b/server/api/users/actions.py
@@ -75,8 +75,8 @@ class UsersActionsSetUsersAPI(Resource):
             user_dto = UserDTO(request.get_json())
             if user_dto.email_address == "":
                 user_dto.email_address = (
-                    None
-                )  # Replace empty string with None so validation doesn't break
+                    None  # Replace empty string with None so validation doesn't break
+                )
 
             user_dto.validate()
         except ValueError as e:

--- a/server/api/utils.py
+++ b/server/api/utils.py
@@ -6,8 +6,8 @@ class TMAPIDecorators:
 
     is_pm_only_resource = None
     authenticated_user_id = (
-        None
-    )  # Set by AuthenticationService when user has successfully authenticated
+        None  # Set by AuthenticationService when user has successfully authenticated
+    )
 
     def pm_only(self, pm_only_resource=True):
         """

--- a/server/config.py
+++ b/server/config.py
@@ -27,11 +27,12 @@ class EnvironmentConfig:
     # TM_DEFAULT_CHANGESET_COMMENT is supported only as a compatibility environment variable.
     # It is overwritten by TM_DEFAULT_CHANGESET_TAGS
     def __get_default_changeset_tags():
-        comment = {"comment": os.getenv('TM_DEFAULT_CHANGESET_COMMENT', None)}
-        tags = os.getenv('TM_DEFAULT_CHANGESET_TAGS', {})
+        comment = {"comment": os.getenv("TM_DEFAULT_CHANGESET_COMMENT", None)}
+        tags = os.getenv("TM_DEFAULT_CHANGESET_TAGS", {})
         if comment["comment"]:
             return {**tags, **comment}
         return tags
+
     DEFAULT_CHANGESET_TAGS = __get_default_changeset_tags()
 
     # The address to use as the sender on auto generated emails

--- a/server/config.py
+++ b/server/config.py
@@ -22,8 +22,17 @@ class EnvironmentConfig:
 
     FRONTEND_BASE_URL = os.getenv("TM_FRONTEND_BASE_URL", APP_BASE_URL)
     API_VERSION = os.getenv("TM_APP_API_VERSION", "v2")
-    # The default tag used in the OSM changeset comment
-    DEFAULT_CHANGESET_COMMENT = os.getenv("TM_DEFAULT_CHANGESET_COMMENT", None)
+
+    # Setup the default changset tags. Only comment and source are supported by most editors.
+    # TM_DEFAULT_CHANGESET_COMMENT is supported only as a compatibility environment variable.
+    # It is overwritten by TM_DEFAULT_CHANGESET_TAGS
+    def __get_default_changeset_tags():
+        comment = {"comment": os.getenv('TM_DEFAULT_CHANGESET_COMMENT', None)}
+        tags = os.getenv('TM_DEFAULT_CHANGESET_TAGS', {})
+        if comment["comment"]:
+            return {**tags, **comment}
+        return tags
+    DEFAULT_CHANGESET_TAGS = __get_default_changeset_tags()
 
     # The address to use as the sender on auto generated emails
     EMAIL_FROM_ADDRESS = os.getenv("TM_EMAIL_FROM_ADDRESS", None)

--- a/server/models/dtos/project_dto.py
+++ b/server/models/dtos/project_dto.py
@@ -183,7 +183,9 @@ class ProjectDTO(Model):
     )
     private = BooleanType(required=True)
     entities_to_map = StringType(serialized_name="entitiesToMap")
-    changeset_tags = DictType(StringType, serialized_name='changesetTags', serialize_when_none=False)
+    changeset_tags = DictType(
+        StringType, serialized_name="changesetTags", serialize_when_none=False
+    )
     osmcha_filter_id = StringType(serialized_name="osmchaFilterId")
     due_date = DateTimeType(serialized_name="dueDate")
     imagery = StringType()
@@ -438,7 +440,7 @@ class ProjectSummary(Model):
         StringType, serialized_name="mappingTypes", validators=[is_known_mapping_type]
     )
 
-    changeset_tags = StringType(serialized_name='changesetTags')
+    changeset_tags = StringType(serialized_name="changesetTags")
     percent_mapped = IntType(serialized_name="percentMapped")
     percent_validated = IntType(serialized_name="percentValidated")
     percent_bad_imagery = IntType(serialized_name="percentBadImagery")

--- a/server/models/dtos/project_dto.py
+++ b/server/models/dtos/project_dto.py
@@ -7,6 +7,7 @@ from schematics.types import (
     BooleanType,
     DateTimeType,
     FloatType,
+    DictType,
 )
 from schematics.types.compound import ListType, ModelType
 from server.models.dtos.task_annotation_dto import TaskAnnotationDTO
@@ -182,7 +183,7 @@ class ProjectDTO(Model):
     )
     private = BooleanType(required=True)
     entities_to_map = StringType(serialized_name="entitiesToMap")
-    changeset_comment = StringType(serialized_name="changesetComment")
+    changeset_tags = DictType(StringType, serialized_name='changesetTags', serialize_when_none=False)
     osmcha_filter_id = StringType(serialized_name="osmchaFilterId")
     due_date = DateTimeType(serialized_name="dueDate")
     imagery = StringType()
@@ -437,7 +438,7 @@ class ProjectSummary(Model):
         StringType, serialized_name="mappingTypes", validators=[is_known_mapping_type]
     )
 
-    changeset_comment = StringType(serialized_name="changesetComment")
+    changeset_tags = StringType(serialized_name='changesetTags')
     percent_mapped = IntType(serialized_name="percentMapped")
     percent_validated = IntType(serialized_name="percentValidated")
     percent_bad_imagery = IntType(serialized_name="percentBadImagery")

--- a/server/models/postgis/message.py
+++ b/server/models/postgis/message.py
@@ -20,8 +20,8 @@ class MessageType(Enum):
     MENTION_NOTIFICATION = 3  # Notification that user was mentioned in a comment/chat
     VALIDATION_NOTIFICATION = 4  # Notification that user's mapped task was validated
     INVALIDATION_NOTIFICATION = (
-        5
-    )  # Notification that user's mapped task was invalidated
+        5  # Notification that user's mapped task was invalidated
+    )
     REQUEST_TEAM_NOTIFICATION = 6
     INVITATION_NOTIFICATION = 7
     TASK_COMMENT_NOTIFICATION = 8

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -251,10 +251,14 @@ class Project(db.Model):
 
     def set_default_changeset_tags(self):
         """ Sets the default changeset tags"""
-        default_tags = current_app.config['DEFAULT_CHANGESET_TAGS']
+        default_tags = current_app.config["DEFAULT_CHANGESET_TAGS"]
         if self.changeset_tags is None:
             self.changeset_tags = {}
-        self.changeset_tags["comment"] = f'{default_tags["comment"]}-{self.id} {self.changeset_tags["comment"]}' if self.changeset_tags is not None and "comment" in self.changeset_tags else f'{default_tags["comment"]}-{self.id}'
+        self.changeset_tags["comment"] = (
+            f'{default_tags["comment"]}-{self.id} {self.changeset_tags["comment"]}'
+            if self.changeset_tags is not None and "comment" in self.changeset_tags
+            else f'{default_tags["comment"]}-{self.id}'
+        )
         self.save()
 
     def set_country_info(self):
@@ -359,7 +363,11 @@ class Project(db.Model):
         #  project and the cloned. This is a best effort basis.
         default_comment = current_app.config["DEFAULT_CHANGESET_TAGS"]["comment"]
         changeset_comments = []
-        if original_project.changeset_tags is not None and "comment" in original_project.changeset_tags and original_project.changeset_tags["comment"] is not None:
+        if (
+            original_project.changeset_tags is not None
+            and "comment" in original_project.changeset_tags
+            and original_project.changeset_tags["comment"] is not None
+        ):
             changeset_comments = original_project.changeset_tags["comment"].split(" ")
         if f"{default_comment}-{original_project.id}" in changeset_comments:
             changeset_comments.remove(f"{default_comment}-{original_project.id}")

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -143,7 +143,7 @@ class Project(db.Model):
         db.Boolean, default=False
     )  # Only PMs can set a project as featured
     entities_to_map = db.Column(db.String)
-    changeset_comment = db.Column(db.String)
+    changeset_tags = db.Column(db.JSON)
     osmcha_filter_id = db.Column(
         db.String
     )  # Optional custom filter id for filtering on OSMCha
@@ -249,14 +249,12 @@ class Project(db.Model):
         self.geometry = ST_SetSRID(ST_GeomFromGeoJSON(valid_geojson), 4326)
         self.centroid = ST_Centroid(self.geometry)
 
-    def set_default_changeset_comment(self):
-        """ Sets the default changeset comment"""
-        default_comment = current_app.config["DEFAULT_CHANGESET_COMMENT"]
-        self.changeset_comment = (
-            f"{default_comment}-{self.id} {self.changeset_comment}"
-            if self.changeset_comment is not None
-            else f"{default_comment}-{self.id}"
-        )
+    def set_default_changeset_tags(self):
+        """ Sets the default changeset tags"""
+        default_tags = current_app.config['DEFAULT_CHANGESET_TAGS']
+        if self.changeset_tags is None:
+            self.changeset_tags = {}
+        self.changeset_tags["comment"] = f'{default_tags["comment"]}-{self.id} {self.changeset_tags["comment"]}' if self.changeset_tags is not None and "comment" in self.changeset_tags else f'{default_tags["comment"]}-{self.id}'
         self.save()
 
     def set_country_info(self):
@@ -359,10 +357,10 @@ class Project(db.Model):
         # We try to remove the changeset comment referencing the old project. This
         #  assumes the default changeset comment has not changed between the old
         #  project and the cloned. This is a best effort basis.
-        default_comment = current_app.config["DEFAULT_CHANGESET_COMMENT"]
+        default_comment = current_app.config["DEFAULT_CHANGESET_TAGS"]["comment"]
         changeset_comments = []
-        if original_project.changeset_comment is not None:
-            changeset_comments = original_project.changeset_comment.split(" ")
+        if original_project.changeset_tags is not None and "comment" in original_project.changeset_tags and original_project.changeset_tags["comment"] is not None:
+            changeset_comments = original_project.changeset_tags["comment"].split(" ")
         if f"{default_comment}-{original_project.id}" in changeset_comments:
             changeset_comments.remove(f"{default_comment}-{original_project.id}")
         cloned_project.changeset_comment = " ".join(changeset_comments)
@@ -397,7 +395,7 @@ class Project(db.Model):
         self.private = project_dto.private
         self.mapper_level = MappingLevel[project_dto.mapper_level.upper()].value
         self.entities_to_map = project_dto.entities_to_map
-        self.changeset_comment = project_dto.changeset_comment
+        self.changeset_tags = project_dto.changeset_tags
         self.due_date = project_dto.due_date
         self.imagery = project_dto.imagery
         self.josm_preset = project_dto.josm_preset
@@ -730,7 +728,7 @@ class Project(db.Model):
         area = polygon_aea.area / 1000000
         summary.area = area
         summary.country_tag = self.country
-        summary.changeset_comment = self.changeset_comment
+        summary.changeset_tags = self.changeset_tags
         summary.created = self.created
         summary.last_updated = self.last_updated
         summary.due_date = self.due_date
@@ -878,7 +876,7 @@ class Project(db.Model):
         base_dto.private = self.private
         base_dto.mapper_level = MappingLevel(self.mapper_level).name
         base_dto.entities_to_map = self.entities_to_map
-        base_dto.changeset_comment = self.changeset_comment
+        base_dto.changeset_tags = self.changeset_tags
         base_dto.osmcha_filter_id = self.osmcha_filter_id
         base_dto.due_date = self.due_date
         base_dto.imagery = self.imagery

--- a/server/models/postgis/project_info.py
+++ b/server/models/postgis/project_info.py
@@ -32,9 +32,7 @@ class ProjectInfo(db.Model):
     def create_from_name(cls, name: str):
         """ Creates a new ProjectInfo class from name, used when creating draft projects """
         new_info = cls()
-        new_info.locale = (
-            "en"
-        )  # Draft project default to english, PMs can change this prior to publication
+        new_info.locale = "en"  # Draft project default to english, PMs can change this prior to publication
         new_info.name = name
         return new_info
 

--- a/server/services/mapping_issues_service.py
+++ b/server/services/mapping_issues_service.py
@@ -33,7 +33,7 @@ class MappingIssueCategoryService:
 
     @staticmethod
     def update_mapping_issue_category(
-        category_dto: MappingIssueCategoryDTO
+        category_dto: MappingIssueCategoryDTO,
     ) -> MappingIssueCategoryDTO:
         """ Create MappingIssueCategory in DB """
         category = MappingIssueCategoryService.get_mapping_issue_category(

--- a/server/services/project_admin_service.py
+++ b/server/services/project_admin_service.py
@@ -85,8 +85,12 @@ class ProjectAdminService:
     @staticmethod
     def _set_default_changeset_tags(draft_project: Project):
         """ Sets the default changesset comment when project created """
-        default_tags = current_app.config['DEFAULT_CHANGESET_TAGS']
-        draft_project.changeset_tags = "{\"comment\": \"" + f'{default_comment}-{draft_project.id}' + "\"}"
+        default_tags = current_app.config["DEFAULT_CHANGESET_TAGS"]
+        draft_project.changeset_tags = (
+            '{"comment": "'
+            + f"{default_tags['comment'] if 'comment' in default_tags else ''}-{draft_project.id}"
+            + '"}'
+        )
         draft_project.save()
 
     @staticmethod
@@ -155,9 +159,8 @@ class ProjectAdminService:
                 user = UserService.get_user_by_username(username)
                 allowed_users.append(user)
 
-            project_dto.allowed_users = (
-                allowed_users
-            )  # Dynamically attach the user object to the DTO for more efficient persistence
+            # Dynamically attach the user object to the DTO for more efficient persistence
+            project_dto.allowed_users = allowed_users
         except NotFound:
             raise ProjectAdminServiceError(
                 f"allowedUsers contains an unknown username {user}"

--- a/server/services/project_admin_service.py
+++ b/server/services/project_admin_service.py
@@ -78,15 +78,15 @@ class ProjectAdminService:
         else:
             draft_project.create()  # Create the new project
 
-        draft_project.set_default_changeset_comment()
+        draft_project.set_default_changeset_tags()
         draft_project.set_country_info()
         return draft_project.id
 
     @staticmethod
-    def _set_default_changeset_comment(draft_project: Project):
+    def _set_default_changeset_tags(draft_project: Project):
         """ Sets the default changesset comment when project created """
-        default_comment = current_app.config["DEFAULT_CHANGESET_COMMENT"]
-        draft_project.changeset_comment = f"{default_comment}-{draft_project.id}"
+        default_tags = current_app.config['DEFAULT_CHANGESET_TAGS']
+        draft_project.changeset_tags = "{\"comment\": \"" + f'{default_comment}-{draft_project.id}' + "\"}"
         draft_project.save()
 
     @staticmethod

--- a/server/services/project_search_service.py
+++ b/server/services/project_search_service.py
@@ -285,7 +285,7 @@ class ProjectSearchService:
 
     @staticmethod
     def get_projects_geojson(
-        search_bbox_dto: ProjectSearchBBoxDTO
+        search_bbox_dto: ProjectSearchBBoxDTO,
     ) -> geojson.FeatureCollection:
         """  search for projects meeting criteria provided return as a geojson feature collection"""
 

--- a/server/services/users/authentication_service.py
+++ b/server/services/users/authentication_service.py
@@ -40,8 +40,8 @@ def verify_token(token):
             return False
 
     tm.authenticated_user_id = (
-        user_id
-    )  # Set the user ID on the decorator as a convenience
+        user_id  # Set the user ID on the decorator as a convenience
+    )
     return True  # All tests passed token is good for the requested resource
 
 

--- a/server/services/validator_service.py
+++ b/server/services/validator_service.py
@@ -108,7 +108,7 @@ class ValidatorService:
 
     @staticmethod
     def unlock_tasks_after_validation(
-        validated_dto: UnlockAfterValidationDTO
+        validated_dto: UnlockAfterValidationDTO,
     ) -> TaskDTOs:
         """
         Unlocks supplied tasks after validation

--- a/tests/database/tasking-manager.sql
+++ b/tests/database/tasking-manager.sql
@@ -255,7 +255,7 @@ CREATE TABLE public.projects (
     enforce_validator_role boolean,
     private boolean,
     entities_to_map character varying,
-    changeset_comment character varying,
+    changeset_tags character varying,
     due_date timestamp without time zone,
     imagery character varying,
     josm_preset character varying,
@@ -592,9 +592,9 @@ COPY public.project_chat (id, project_id, user_id, time_stamp, message) FROM std
 --
 
 COPY public.project_info (project_id, locale, name, short_description, description, instructions, project_id_str, text_searchable, per_task_instructions) FROM stdin;
-1	en	testing ssa	testing ssa ahsjhdjshfjsh jhsjdh fsjhdfjs jsfhd jshjf hsjdhf sjhfjsh jshfjsdh jshjf hsjhf jsdhfjs hfjshf jsdhfj sdhfjh jsdhfjshfj shjf hsdj	testing ssa ahsjhdjshfjsh jhsjdh fsjhdfjs jsfhd jshjf hsjdhf sjhfjsh jshfjsdh jshjf hsjhf jsdhfjs hfjshf jsdhfj sdhfjh jsdhfjshfj shjf hsdj	testing ssa ahsjhdjshfjsh jhsjdh fsjhdfjs jsfhd jshjf hsjdhf sjhfjsh jshfjsdh jshjf hsjhf jsdhfjs hfjshf jsdhfj sdhfjh jsdhfjshfj shjf hsdj	1	\N	
-2	en	arbitrary-project	tests tsete	tests tsete	tests tsete	2	\N	
-3	en	arbitrary-1	arbitrary- test split	arbitrary- test split	arbitrary- test split	3	\N	
+1	en	testing ssa	testing ssa ahsjhdjshfjsh jhsjdh fsjhdfjs jsfhd jshjf hsjdhf sjhfjsh jshfjsdh jshjf hsjhf jsdhfjs hfjshf jsdhfj sdhfjh jsdhfjshfj shjf hsdj	testing ssa ahsjhdjshfjsh jhsjdh fsjhdfjs jsfhd jshjf hsjdhf sjhfjsh jshfjsdh jshjf hsjhf jsdhfjs hfjshf jsdhfj sdhfjh jsdhfjshfj shjf hsdj	testing ssa ahsjhdjshfjsh jhsjdh fsjhdfjs jsfhd jshjf hsjdhf sjhfjsh jshfjsdh jshjf hsjhf jsdhfjs hfjshf jsdhfj sdhfjh jsdhfjshfj shjf hsdj	1	\N
+2	en	arbitrary-project	tests tsete	tests tsete	tests tsete	2	\N
+3	en	arbitrary-1	arbitrary- test split	arbitrary- test split	arbitrary- test split	3	\N
 \.
 
 
@@ -610,10 +610,10 @@ COPY public.project_priority_areas (project_id, priority_area_id) FROM stdin;
 -- Data for Name: projects; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-COPY public.projects (id, status, created, priority, default_locale, author_id, mapper_level, enforce_mapper_level, enforce_validator_role, private, entities_to_map, changeset_comment, due_date, imagery, josm_preset, last_updated, mapping_types, organisation_tag, campaign_tag, total_tasks, tasks_mapped, tasks_validated, tasks_bad_imagery, license_id, centroid, geometry, task_creation_mode) FROM stdin;
-2	1	2019-04-08 12:21:37.425808	1	en	360183	1	f	f	f	\N	#hotosm-project-2	\N	\N	\N	2019-04-09 03:34:52.985812	{}	\N	\N	16	1	0	1	\N	0101000020E61000004B5FA2C5E5DC3240E03320AF4AF740C0	0106000020E610000001000000010300000001000000050000000100405B40D53240CDE033A57FF540C0010040B6F2D6324010F53EC585F940C00000C02390E23240EDEACD35A0F840C0000080ADC9E63240EBCFC9CBFBF540C00100405B40D53240CDE033A57FF540C0	1
-1	1	2019-04-08 10:54:25.449637	1	en	360183	1	f	f	f	\N	#tm-project-1	\N	\N	\N	2019-04-08 11:40:37.248906	{}	\N	\N	171	1	1	2	\N	0101000020E61000005A0601152A3543C05A9C94D060CD29C0	0106000020E6100000010000000103000000010000000E00000015A922BEFA3943C0A897377D739529C015A922BE421F43C053173DCE36BD29C015A922BE522D43C0883A6048D8EC29C016A922BE9B2F43C0F948A4C9BBE829C014A9223E5A3C43C0D647DECB9E092AC014A9223ECA4443C05FC6E2FB38072AC015A922BED24343C0988DCFC461F429C015A922BE024143C0B194E08B47E429C015A922BE4B4343C0387210A150D929C016A922BEC73F43C0D1675BBE01CE29C015A922BE7E3D43C0FAB7CBCCD8AF29C016A9223EEC4043C06AD15D4AFE9C29C014A9223E924043C001D02AE3649329C015A922BEFA3943C0A897377D739529C0	0
-3	1	2019-04-08 12:23:34.568831	2	en	360183	1	f	f	f	\N	#hotosm-project-3	\N	\N	\N	2019-04-08 12:24:51.647033	{}	\N	\N	1	0	0	0	\N	0101000020E61000004B5FA2C5E5DC3240E03320AF4AF740C0	0106000020E610000001000000010300000001000000050000000100405B40D53240CDE033A57FF540C0010040B6F2D6324010F53EC585F940C00000C02390E23240EDEACD35A0F840C0000080ADC9E63240EBCFC9CBFBF540C00100405B40D53240CDE033A57FF540C0	1
+COPY public.projects (id, status, created, priority, default_locale, author_id, mapper_level, enforce_mapper_level, enforce_validator_role, private, entities_to_map, changeset_tags, due_date, imagery, josm_preset, last_updated, mapping_types, organisation_tag, campaign_tag, total_tasks, tasks_mapped, tasks_validated, tasks_bad_imagery, license_id, centroid, geometry, task_creation_mode) FROM stdin;
+2	1	2019-04-08 12:21:37.425808	1	en	360183	1	f	f	f	\N	{"comment": "#hotosm-project-2"}	\N	\N	\N	2019-04-09 03:34:52.985812	{}	\N	\N	16	1	0	1	\N	0101000020E61000004B5FA2C5E5DC3240E03320AF4AF740C0	0106000020E610000001000000010300000001000000050000000100405B40D53240CDE033A57FF540C0010040B6F2D6324010F53EC585F940C00000C02390E23240EDEACD35A0F840C0000080ADC9E63240EBCFC9CBFBF540C00100405B40D53240CDE033A57FF540C0	1
+1	1	2019-04-08 10:54:25.449637	1	en	360183	1	f	f	f	\N	{"comment": "#tm-project-1"}	\N	\N	\N	2019-04-08 11:40:37.248906	{}	\N	\N	171	1	1	2	\N	0101000020E61000005A0601152A3543C05A9C94D060CD29C0	0106000020E6100000010000000103000000010000000E00000015A922BEFA3943C0A897377D739529C015A922BE421F43C053173DCE36BD29C015A922BE522D43C0883A6048D8EC29C016A922BE9B2F43C0F948A4C9BBE829C014A9223E5A3C43C0D647DECB9E092AC014A9223ECA4443C05FC6E2FB38072AC015A922BED24343C0988DCFC461F429C015A922BE024143C0B194E08B47E429C015A922BE4B4343C0387210A150D929C016A922BEC73F43C0D1675BBE01CE29C015A922BE7E3D43C0FAB7CBCCD8AF29C016A9223EEC4043C06AD15D4AFE9C29C014A9223E924043C001D02AE3649329C015A922BEFA3943C0A897377D739529C0	0
+3	1	2019-04-08 12:23:34.568831	2	en	360183	1	f	f	f	\N	{"comment": "#hotosm-project-3"}	\N	\N	\N	2019-04-08 12:24:51.647033	{}	\N	\N	1	0	0	0	\N	0101000020E61000004B5FA2C5E5DC3240E03320AF4AF740C0	0106000020E610000001000000010300000001000000050000000100405B40D53240CDE033A57FF540C0010040B6F2D6324010F53EC585F940C00000C02390E23240EDEACD35A0F840C0000080ADC9E63240EBCFC9CBFBF540C00100405B40D53240CDE033A57FF540C0	1
 \.
 
 

--- a/tests/server/unit/models/postgis/test_task.py
+++ b/tests/server/unit/models/postgis/test_task.py
@@ -128,7 +128,7 @@ class TestTask(unittest.TestCase):
         self.assertEqual(instructions, "Test Url is http://test.com/1_2_3")
 
     def test_per_task_instructions_returns_instructions_when_no_dynamic_url_and_task_not_splittable(
-        self
+        self,
     ):
         # Arrange
         test_task = Task()


### PR DESCRIPTION
Currently only JOSM supports arbitrary changeset tags (since JOSM r15316 -- for reference, 78% or so of current JOSM users are on r15492+, as of 12/23/2019, stats taken from 12/01/2019 to 12/23/2019).

Future potential use cases:
* Add `import=yes`
* Add `tm_url=tasks.hotosm.org`, `tm_project=1`, and `tm_task=5` to the changeset.

This pull request also changes `LANDUSE` to `LAND_USE` (there was only one instance of the former) and updates `black` and `flake8` to the current latest versions.

~I was unable to test remote control, since it appears to not currently be present in TM4.~
EDIT: I implemented JOSM remote control (see #2106 ) so I could test that it worked properly.

For documentation, see https://josm.openstreetmap.de/wiki/Help/RemoteControlCommands#load_and_zoom