### PR TITLE
Projects mapped filter under project search

### DIFF
--- a/server/api/projects/resources.py
+++ b/server/api/projects/resources.py
@@ -462,23 +462,11 @@ class ProjectSearchBase(Resource):
             if UserService.is_user_a_project_manager(tm.authenticated_user_id):
                 search_dto.is_project_manager = True
 
-            print(search_dto.created_by)
-            print("createdByMeArgs: ", request.args.get("createdByMe"))
             if request.args.get("createdByMe") == "true":
-                print("Created args present")
                 search_dto.created_by = tm.authenticated_user_id
-            else:
-                print("Created Args not Present")
-            print(search_dto.created_by)
 
-            print(search_dto.mapped_by)
-            print("createdByMeArgs: ", request.args.get("mappedByMe"))
             if request.args.get("mappedByMe") == "true":
-                print("Mapped args present")
                 search_dto.mapped_by = tm.authenticated_user_id
-            else:
-                print("Mapped Args not Present")
-            print(search_dto.created_by)
 
         except Exception:
             pass

--- a/server/api/projects/resources.py
+++ b/server/api/projects/resources.py
@@ -462,9 +462,24 @@ class ProjectSearchBase(Resource):
             if UserService.is_user_a_project_manager(tm.authenticated_user_id):
                 search_dto.is_project_manager = True
 
-            search_dto.created_by = (
-                tm.authenticated_user_id if request.args.get("createdByMe") else False
-            )
+            print(search_dto.created_by)
+            print("createdByMeArgs: ", request.args.get("createdByMe"))
+            if request.args.get("createdByMe") == "true":
+                print("Created args present")
+                search_dto.created_by = tm.authenticated_user_id
+            else:
+                print("Created Args not Present")
+            print(search_dto.created_by)
+
+            print(search_dto.mapped_by)
+            print("createdByMeArgs: ", request.args.get("mappedByMe"))
+            if request.args.get("mappedByMe") == "true":
+                print("Mapped args present")
+                search_dto.mapped_by = tm.authenticated_user_id
+            else:
+                print("Mapped Args not Present")
+            print(search_dto.created_by)
+
         except Exception:
             pass
 
@@ -555,6 +570,12 @@ class ProjectsAllAPI(ProjectSearchBase):
             - in: query
               name: createdByMe
               description: Limit to projects created by authenticated user
+              type: boolean
+              required: true
+              default: false
+            - in: query
+              name: mappedByMe
+              description: Limit to projects mapped/validated by authenticated user
               type: boolean
               required: true
               default: false

--- a/server/api/projects/resources.py
+++ b/server/api/projects/resources.py
@@ -559,13 +559,11 @@ class ProjectsAllAPI(ProjectSearchBase):
               name: createdByMe
               description: Limit to projects created by authenticated user
               type: boolean
-              required: true
               default: false
             - in: query
               name: mappedByMe
               description: Limit to projects mapped/validated by authenticated user
               type: boolean
-              required: true
               default: false
             - in: query
               name: teamId

--- a/server/models/dtos/project_dto.py
+++ b/server/models/dtos/project_dto.py
@@ -279,6 +279,7 @@ class ProjectSearchDTO(Model):
     teams = ListType(StringType())
     interests = ListType(IntType())
     created_by = IntType(required=False)
+    mapped_by = IntType(required=False)
 
     def __hash__(self):
         """ Make object hashable so we can cache user searches"""

--- a/server/services/project_search_service.py
+++ b/server/services/project_search_service.py
@@ -209,7 +209,13 @@ class ProjectSearchService:
         query = query.filter(Project.status.in_(project_status_array))
 
         if search_dto.created_by:
+            print("created_by: ", search_dto.created_by)
             query = query.filter(Project.author_id == search_dto.created_by)
+
+        if search_dto.mapped_by:
+            # query = query.filter()
+            print(search_dto.mapped_by)
+            print("created_by: ", search_dto.created_by)
 
         if search_dto.mapper_level and search_dto.mapper_level.upper() != "ALL":
             query = query.filter(

--- a/server/services/project_search_service.py
+++ b/server/services/project_search_service.py
@@ -27,6 +27,7 @@ from server.models.postgis.utils import (
 )
 
 from server.models.postgis.interests import projects_interests
+from server.services.users.user_service import UserService
 
 from server import db
 from flask import current_app
@@ -209,13 +210,11 @@ class ProjectSearchService:
         query = query.filter(Project.status.in_(project_status_array))
 
         if search_dto.created_by:
-            print("created_by: ", search_dto.created_by)
             query = query.filter(Project.author_id == search_dto.created_by)
 
         if search_dto.mapped_by:
-            # query = query.filter()
-            print(search_dto.mapped_by)
-            print("created_by: ", search_dto.created_by)
+            projects_mapped = UserService.get_projects_mapped(search_dto.mapped_by)
+            query = query.filter(Project.id.in_(projects_mapped))
 
         if search_dto.mapper_level and search_dto.mapper_level.upper() != "ALL":
             query = query.filter(

--- a/server/services/users/user_service.py
+++ b/server/services/users/user_service.py
@@ -136,14 +136,12 @@ class UserService:
     @staticmethod
     def get_projects_mapped(user_id: int):
         projects_mapped = (
-            TaskHistory.query.with_entities(TaskHistory.project_id)
-            .filter(
-                TaskHistory.user_id == user_id, TaskHistory.action == "STATE_CHANGE"
-            )
-            .distinct(TaskHistory.project_id)
+            User.query.with_entities(User.projects_mapped)
+            .filter(User.id == user_id)
             .all()
         )
-        projects_mapped = [r[0] for r in projects_mapped]
+        results = [r[0] for r in projects_mapped]
+        projects_mapped = results[0]
         return projects_mapped
 
     @staticmethod


### PR DESCRIPTION
From #2094 - 
* Introduced a filter under `/api/v2/projects/` to filter results from projects mapped/validated by user
* Updated the user model function `get_projects_mapped` to get the pre-computed `projects_mapped` column from users table - it is an array field that captures all projects with at least one task mapped/validated by the user. This function was earlier using TaskHistory model to filter rows every time the function is called. Using pre-computed values will improve search result performance.

