### PR TITLE
change user's default_editor values

### DIFF
--- a/frontend/src/components/projectEdit/settingsForm.js
+++ b/frontend/src/components/projectEdit/settingsForm.js
@@ -43,9 +43,9 @@ export const SettingsForm = ({ languages, defaultLocale }) => {
 							className="mr2"
 							name="mapping_editors"
 							onChange={handleMappingEditors}
-							checked={projectInfo.mappingEditors.includes(elm.backendValue)}
+							checked={projectInfo.mappingEditors.includes(elm.value)}
 							type="checkbox"
-							value={elm.backendValue}
+							value={elm.value}
 						/>
 						{elm.label}
 					</label>
@@ -59,9 +59,9 @@ export const SettingsForm = ({ languages, defaultLocale }) => {
 							className="mr2"
 							name="validation_editors"
 							onChange={handleValidationEditors}
-							checked={projectInfo.validationEditors.includes(elm.backendValue)}
+							checked={projectInfo.validationEditors.includes(elm.value)}
 							type="checkbox"
-							value={elm.backendValue}
+							value={elm.value}
 						/>
 						{elm.label}
 					</label>

--- a/frontend/src/components/taskSelection/footer.js
+++ b/frontend/src/components/taskSelection/footer.js
@@ -78,11 +78,11 @@ const TaskSelectionFooter = props => {
       props.taskAction.startsWith('validate')
     ) {
       setEditorOptions(
-        getEditors().filter(i => props.project.validationEditors.includes(i.backendValue)),
+        getEditors().filter(i => props.project.validationEditors.includes(i.value)),
       );
     } else {
       setEditorOptions(
-        getEditors().filter(i => props.project.mappingEditors.includes(i.backendValue)),
+        getEditors().filter(i => props.project.mappingEditors.includes(i.value)),
       );
     }
   }, [props.taskAction, props.project.mappingEditors, props.project.validationEditors]);
@@ -123,7 +123,7 @@ const TaskSelectionFooter = props => {
         </h3>
         <Dropdown
           options={editorOptions}
-          value={editor}
+          value={ editorOptions.map(i => i.value).includes(editor) ? editor : editorOptions.length && editorOptions[0].value}
           display={<FormattedMessage {...messages.selectEditor} />}
           className="bg-white bn"
           toTop={true}

--- a/frontend/src/config/index.js
+++ b/frontend/src/config/index.js
@@ -26,9 +26,6 @@ export const ORG_INSTAGRAM = process.env.REACT_APP_ORG_INSTAGRAM || 'https://www
 export const ORG_YOUTUBE = process.env.REACT_APP_ORG_YOUTUBE || 'https://www.youtube.com';
 export const ORG_GITHUB = process.env.REACT_APP_ORG_GITHUB || 'https://github.com/';
 
-export const CUSTOM_ID_EDITOR_INSTANCE_NAME = process.env.REACT_APP_CUSTOM_ID_EDITOR_INSTANCE_NAME;
-export const CUSTOM_ID_EDITOR_INSTANCE_HOST = process.env.REACT_APP_CUSTOM_ID_EDITOR_INSTANCE_HOST;
-
 export const TASK_COLOURS = {
   READY: '#fff',
   LOCKED_FOR_MAPPING: '#fff',

--- a/frontend/src/utils/editorsList.js
+++ b/frontend/src/utils/editorsList.js
@@ -1,33 +1,26 @@
-import { CUSTOM_ID_EDITOR_INSTANCE_NAME, CUSTOM_ID_EDITOR_INSTANCE_HOST } from '../config';
 
 export function getEditors() {
   let editors = [
     {
       label: 'iD Editor',
-      value: 'iD Editor',
-      backendValue: 'ID',
+      value: 'ID',
       url: 'http://www.openstreetmap.org/edit?editor=id&',
     },
-    { label: 'JOSM', value: 'JOSM', backendValue: 'JOSM', url: 'http://127.0.0.1:8111' },
+    {
+      label: 'JOSM',
+      value: 'JOSM',
+      url: 'http://127.0.0.1:8111'
+    },
     {
       label: 'Potlatch 2',
-      value: 'Potlatch 2',
-      backendValue: 'POTLATCH_2',
+      value: 'POTLATCH_2',
       url: 'http://www.openstreetmap.org/edit?editor=potlatch2',
     },
     {
       label: 'Field Papers',
-      value: 'Field Papers',
-      backendValue: 'FIELD_PAPERS',
+      value: 'FIELD_PAPERS',
       url: 'http://fieldpapers.org/compose',
     },
   ];
-  if (CUSTOM_ID_EDITOR_INSTANCE_NAME && CUSTOM_ID_EDITOR_INSTANCE_HOST) {
-    editors.push({
-      label: CUSTOM_ID_EDITOR_INSTANCE_NAME,
-      value: CUSTOM_ID_EDITOR_INSTANCE_NAME,
-      url: CUSTOM_ID_EDITOR_INSTANCE_HOST,
-    });
-  }
   return editors;
 }

--- a/frontend/src/utils/openEditor.js
+++ b/frontend/src/utils/openEditor.js
@@ -6,14 +6,14 @@ export function openEditor(editor, project, tasks, selectedTasks, windowSize) {
     sendJosmCommands(project, tasks, selectedTasks, windowSize);
   }
   const { center, zoom } = getCentroidAndZoomFromSelectedTasks(tasks, selectedTasks, windowSize);
-  if (editor === 'iD Editor') {
+  if (editor === 'ID') {
     const idUrl = getIdUrl(project, center, zoom, selectedTasks);
     window.open(idUrl);
   }
-  if (editor === 'Potlatch 2') {
+  if (editor === 'POTLATCH_2') {
     window.open(getPotlatch2Url(center, zoom));
   }
-  if (editor === 'Field Papers') {
+  if (editor === 'FIELD_PAPERS') {
     window.open(getFieldPapersUrl(center, zoom));
   }
 }


### PR DESCRIPTION
* use the same values on frontend for the user default_editor option and the project editors for mapping and validation 
* define the selected option automatically according to the user preference and with the options available to the action the user is taking.