### PR TITLE
Local tests fixes

### DIFF
--- a/server/models/postgis/task.py
+++ b/server/models/postgis/task.py
@@ -803,7 +803,7 @@ class Task(db.Model):
     @staticmethod
     def get_tasks_as_geojson_feature_collection(
         project_id,
-        task_ids_str: str,
+        task_ids_str: str = None,
         order_by: str = None,
         order_by_type: str = "ASC",
         status: int = None,

--- a/server/services/messaging/message_service.py
+++ b/server/services/messaging/message_service.py
@@ -304,15 +304,17 @@ class MessageService:
         current_app.logger.debug("Sending Favorite Project Activities")
         favorited_projects = UserService.get_projects_favorited(user_id)
         contributed_projects = UserService.get_projects_mapped(user_id)
-        projects_list = contributed_projects
+        if contributed_projects is None:
+            contributed_projects = []
+
         for favorited_project in favorited_projects.favorited_projects:
-            projects_list.append(favorited_project.project_id)
+            contributed_projects.append(favorited_project.project_id)
 
         recently_updated_projects = (
             Project.query.with_entities(
                 Project.id, func.DATE(Project.last_updated).label("last_updated")
             )
-            .filter(Project.id.in_(projects_list))
+            .filter(Project.id.in_(contributed_projects))
             .filter(
                 func.DATE(Project.last_updated)
                 > datetime.date.today() - datetime.timedelta(days=300)

--- a/server/services/users/authentication_service.py
+++ b/server/services/users/authentication_service.py
@@ -1,6 +1,5 @@
 import base64
 import urllib.parse
-import os
 
 from flask import current_app, request, session
 from flask_httpauth import HTTPTokenAuth
@@ -81,8 +80,7 @@ class AuthenticationService:
         try:
             UserService.get_user_by_id(osm_id)
             UserService.update_user(osm_id, username, user_picture)
-            if "CI" not in os.environ.keys():
-                MessageService.send_favorite_project_activities(osm_id)
+            MessageService.send_favorite_project_activities(osm_id)
         except NotFound:
             # User not found, so must be new user
             changesets = osm_user.find("changesets")

--- a/tests/server/integration/models/postgis/test_project.py
+++ b/tests/server/integration/models/postgis/test_project.py
@@ -63,10 +63,14 @@ class TestProject(unittest.TestCase):
 
         # Act
         feature_collection = Task.get_tasks_as_geojson_feature_collection(
-            self.test_project.id
+            self.test_project.id, "1"
         )
+        self.assertIsInstance(feature_collection, geojson.FeatureCollection)
+        self.assertEqual(1, len(feature_collection.features))
 
-        # Assert
+        feature_collection = Task.get_tasks_as_geojson_feature_collection(
+            self.test_project.id, None
+        )
         self.assertIsInstance(feature_collection, geojson.FeatureCollection)
         self.assertEqual(2, len(feature_collection.features))
 

--- a/tests/server/unit/services/users/test_authentication_service.py
+++ b/tests/server/unit/services/users/test_authentication_service.py
@@ -32,7 +32,8 @@ class TestAuthenticationService(unittest.TestCase):
             AuthenticationService().login_user(osm_response, "wont-find")
 
     @patch.object(UserService, "get_user_by_id")
-    def test_if_user_get_called_with_osm_id(self, mock_user_get):
+    @patch.object(MessageService, "send_favorite_project_activities")
+    def test_if_user_get_called_with_osm_id(self, mock_user_get, mock_message_act):
         # Arrange
         osm_response = get_canned_osm_user_details()
 
@@ -59,7 +60,8 @@ class TestAuthenticationService(unittest.TestCase):
         mock_user_register.assert_called_with(7777777, "Thinkwhere Test", 16, None)
 
     @patch.object(UserService, "get_user_by_id")
-    def test_valid_auth_request_gets_token(self, mock_user_get):
+    @patch.object(MessageService, "send_favorite_project_activities")
+    def test_valid_auth_request_gets_token(self, mock_user_get, mock_message_act):
         # Arrange
         osm_response = get_canned_osm_user_details()
 


### PR DESCRIPTION
…ts variable as array

These tests need to be run locally using a fresh database.

**Notes:**

1.  I think we would have to review the _UserService.get_projects_mapped_ function, since **projects_mapped** db column is repeated twice within the User model. This might cause the **None** value returned in tests

- https://github.com/hotosm/tasking-manager/blob/develop/server/models/postgis/user.py#L37
- https://github.com/hotosm/tasking-manager/blob/develop/server/models/postgis/user.py#L41 

2. The CI environment check does not need to be done within the **server** folder for two reasons: 
a. Not all TM forks might use CI/CD
b. The check removes the _send_favorite_project_activities_ function to be tested locally.