### PR TITLE
Read registered user email from localstorage

### DIFF
--- a/frontend/src/components/header/signUp.js
+++ b/frontend/src/components/header/signUp.js
@@ -8,6 +8,8 @@ import { Button } from '../button';
 import { CloseIcon } from '../svgIcons';
 import { registerUser } from '../../store/actions/user';
 
+import * as safeStorage from '../../utils/safe_storage';
+
 class SignUp extends Component {
   constructor(props) {
     super(props);
@@ -31,6 +33,7 @@ class SignUp extends Component {
 
       if (res.success === true) {
         setTimeout(() => (window.location.href = 'https://www.openstreetmap.org/user/new'), 1500);
+        safeStorage.setItem('email_address', formdata.email)
       }
     });
   };

--- a/frontend/src/utils/login.js
+++ b/frontend/src/utils/login.js
@@ -1,4 +1,5 @@
 import { API_URL } from '../config';
+import * as safeStorage from '../utils/safe_storage';
 
 // Code taken from https://github.com/mapbox/osmcha-frontend/blob/master/src/utils/create_popup.js
 export function createPopup(title: string = 'Authentication', location: string) {
@@ -31,7 +32,15 @@ export const createLoginWindow = redirectTo => {
           oauth_token: resp.oauth_token,
           oauth_token_secret: resp.oauth_token_secret,
         }).toString();
-        fetch(`${API_URL}system/authentication/callback/?${tokens}&oauth_verifier=${verifier}`)
+        let callback_url = `${API_URL}system/authentication/callback/?${tokens}&oauth_verifier=${verifier}`
+
+        const emailAddress = safeStorage.getItem('email_address')
+        if (emailAddress !== null) {
+          callback_url += `&email_address=${emailAddress}`
+          safeStorage.removeItem('email_address')
+        }
+
+        fetch(callback_url)
           .then(res => res.json())
           .then(res => {
             const params = new URLSearchParams({

--- a/frontend/src/utils/login.js
+++ b/frontend/src/utils/login.js
@@ -1,4 +1,4 @@
-import { API_URL } from '../config';
+import { fetchLocalJSONAPI } from '../network/genericJSONRequest';
 import * as safeStorage from '../utils/safe_storage';
 
 // Code taken from https://github.com/mapbox/osmcha-frontend/blob/master/src/utils/create_popup.js
@@ -21,9 +21,8 @@ export function createPopup(title: string = 'Authentication', location: string) 
 }
 
 export const createLoginWindow = redirectTo => {
-  let url = `${API_URL}system/authentication/login/?callback_url=${window.location.origin}/authorized/`;
-  fetch(url)
-    .then(resp => resp.json())
+  let url = `system/authentication/login/?callback_url=${window.location.origin}/authorized/`;
+  fetchLocalJSONAPI(url)
     .then(resp => {
       createPopup('OSM auth', resp.auth_url);
       // Perform token exchange.
@@ -32,7 +31,7 @@ export const createLoginWindow = redirectTo => {
           oauth_token: resp.oauth_token,
           oauth_token_secret: resp.oauth_token_secret,
         }).toString();
-        let callback_url = `${API_URL}system/authentication/callback/?${tokens}&oauth_verifier=${verifier}`
+        let callback_url = `system/authentication/callback/?${tokens}&oauth_verifier=${verifier}`
 
         const emailAddress = safeStorage.getItem('email_address')
         if (emailAddress !== null) {
@@ -40,8 +39,7 @@ export const createLoginWindow = redirectTo => {
           safeStorage.removeItem('email_address')
         }
 
-        fetch(callback_url)
-          .then(res => res.json())
+        fetchLocalJSONAPI(callback_url)
           .then(res => {
             const params = new URLSearchParams({
               username: res.username,

--- a/server/api/system/authentication.py
+++ b/server/api/system/authentication.py
@@ -66,6 +66,7 @@ class SystemAuthenticationCallbackAPI(Resource):
         if token_secret is None:
             return {"Error": "Missing oauth_token_secret parameter"}, 500
 
+        email = request.args.get("email_address", None)
         session["osm_oauthtok"] = (
             request.args.get("oauth_token"),
             request.args.get("oauth_token_secret"),
@@ -87,7 +88,7 @@ class SystemAuthenticationCallbackAPI(Resource):
             return redirect(AuthenticationService.get_authentication_failed_url())
 
         try:
-            user_params = AuthenticationService.login_user(osm_response.data)
+            user_params = AuthenticationService.login_user(osm_response.data, email)
             user_params["session"] = osm_resp
             return user_params, 200
         except AuthServiceError:

--- a/server/services/users/authentication_service.py
+++ b/server/services/users/authentication_service.py
@@ -56,7 +56,7 @@ class AuthServiceError(Exception):
 
 class AuthenticationService:
     @staticmethod
-    def login_user(osm_user_details, user_element="user") -> str:
+    def login_user(osm_user_details, email, user_element="user") -> str:
         """
         Generates authentication details for user, creating in DB if user is unknown to us
         :param osm_user_details: XML response from OSM
@@ -88,7 +88,7 @@ class AuthenticationService:
             changesets = osm_user.find("changesets")
             changeset_count = int(changesets.attrib["count"])
             new_user = UserService.register_user(
-                osm_id, username, changeset_count, user_picture
+                osm_id, username, changeset_count, user_picture, email
             )
             MessageService.send_welcome_message(new_user)
 

--- a/server/services/users/user_service.py
+++ b/server/services/users/user_service.py
@@ -145,7 +145,7 @@ class UserService:
         return projects_mapped
 
     @staticmethod
-    def register_user(osm_id, username, changeset_count, picture_url):
+    def register_user(osm_id, username, changeset_count, picture_url, email):
         """
         Creates user in DB
         :param osm_id: Unique OSM user id
@@ -167,6 +167,9 @@ class UserService:
             new_user.mapping_level = MappingLevel.INTERMEDIATE.value
         else:
             new_user.mapping_level = MappingLevel.BEGINNER.value
+
+        if email is not None:
+            new_user.email_address = email
 
         new_user.create()
         return new_user

--- a/tests/server/integration/services/users/test_authentication_service.py
+++ b/tests/server/integration/services/users/test_authentication_service.py
@@ -42,7 +42,7 @@ class TestAuthenticationService(unittest.TestCase):
         osm_response = get_canned_osm_user_details()
 
         # Act
-        params = AuthenticationService().login_user(osm_response)
+        params = AuthenticationService().login_user(osm_response, None)
 
         self.assertEqual(params["username"], "Thinkwhere Test")
         self.assertTrue(params["session_token"])
@@ -55,7 +55,7 @@ class TestAuthenticationService(unittest.TestCase):
         osm_response = get_canned_osm_user_details_changed_name()
 
         # Act
-        params = AuthenticationService().login_user(osm_response)
+        params = AuthenticationService().login_user(osm_response, None)
 
         self.assertEqual(params["username"], "Thinkwhere Test Changed")
         self.assertTrue(params["session_token"])

--- a/tests/server/integration/services/users/test_user_service.py
+++ b/tests/server/integration/services/users/test_user_service.py
@@ -78,7 +78,7 @@ class TestAuthenticationService(unittest.TestCase):
     def test_user_can_register_with_correct_mapping_level(self, mock_user):
         # Act
         test_user = UserService().register_user(
-            12, "Thinkwhere", 300, "some_picture_url"
+            12, "Thinkwhere", 300, "some_picture_url", None
         )
 
         # Assert

--- a/tests/server/unit/services/users/test_authentication_service.py
+++ b/tests/server/unit/services/users/test_authentication_service.py
@@ -29,7 +29,7 @@ class TestAuthenticationService(unittest.TestCase):
 
         # Act / Assert
         with self.assertRaises(AuthServiceError):
-            AuthenticationService().login_user(osm_response, "wont-find")
+            AuthenticationService().login_user(osm_response, None, "wont-find")
 
     @patch.object(UserService, "get_user_by_id")
     def test_if_user_get_called_with_osm_id(self, mock_user_get):
@@ -37,7 +37,7 @@ class TestAuthenticationService(unittest.TestCase):
         osm_response = get_canned_osm_user_details()
 
         # Act
-        AuthenticationService.login_user(osm_response)
+        AuthenticationService.login_user(osm_response, None)
 
         # Assert
         mock_user_get.assert_called_with(7777777)
@@ -53,10 +53,12 @@ class TestAuthenticationService(unittest.TestCase):
         mock_user_get.side_effect = NotFound()
 
         # Act
-        AuthenticationService.login_user(osm_response)
+        AuthenticationService.login_user(osm_response, None)
 
         # Assert
-        mock_user_register.assert_called_with(7777777, "Thinkwhere Test", 16, None)
+        mock_user_register.assert_called_with(
+            7777777, "Thinkwhere Test", 16, None, None
+        )
 
     @patch.object(UserService, "get_user_by_id")
     def test_valid_auth_request_gets_token(self, mock_user_get):
@@ -64,7 +66,7 @@ class TestAuthenticationService(unittest.TestCase):
         osm_response = get_canned_osm_user_details()
 
         # Act
-        params = AuthenticationService.login_user(osm_response)
+        params = AuthenticationService.login_user(osm_response, None)
 
         self.assertEqual(params["username"], "Thinkwhere Test")
         self.assertTrue(params["session_token"])


### PR DESCRIPTION
This PR closes #2092 .

When a new user signs up into Tasking Manager, the client stores within  **LocalStorage** the registered email. Then, when the user goes back from OSM login, the client validates the email_address within localstorage and sends it to the server, which is then saved into the database. This happens only for new users.

**how to test**: The reviewer needs a clean migrated database. In other case, the reviewer OSM username removed from **users** table.
- Sign up into Tasking Manager. If success, the client redirects to OSM website.
- Login to Tasking Manager. If success, you will see automatically, the email address