### PR TITLE
assure OSM attribution is always visible

### DIFF
--- a/frontend/src/components/projectCreate/projectCreationMap.js
+++ b/frontend/src/components/projectCreate/projectCreationMap.js
@@ -18,7 +18,8 @@ const ProjectCreationMap = ({ mapObj, setMapObj, metadata, updateMetadata }) => 
         // style: 'mapbox://styles/mapbox/bright-v9',
         style: MAPBOX_TOKEN ? 'mapbox://styles/mapbox/streets-v11' : fallbackRasterStyle,
         zoom: 0,
-      }),
+        attributionControl: false,
+      }).addControl(new mapboxgl.AttributionControl({ compact: false })),
     });
 
     return () => {

--- a/frontend/src/components/projects/projectsMap.js
+++ b/frontend/src/components/projects/projectsMap.js
@@ -69,7 +69,8 @@ export const ProjectsMap = ({
         container: mapRef.current,
         style: MAPBOX_TOKEN ? 'mapbox://styles/mapbox/bright-v9' : fallbackRasterStyle,
         zoom: 0,
-      }),
+        attributionControl: false,
+      }).addControl(new mapboxgl.AttributionControl({ compact: false })),
     );
 
     return () => {
@@ -180,5 +181,5 @@ export const ProjectsMap = ({
     }
   }, [map, mapResults, clickOnProjectID]);
 
-  return <div id="map" className={`vh-75-l vh-50 fr ${className||''}`} ref={mapRef}></div>;
+  return <div id="map" className={`vh-75-l vh-50 fr ${className || ''}`} ref={mapRef}></div>;
 };

--- a/frontend/src/components/taskSelection/map.js
+++ b/frontend/src/components/taskSelection/map.js
@@ -37,7 +37,8 @@ export const TasksMap = ({
         style: MAPBOX_TOKEN ? 'mapbox://styles/mapbox/bright-v9' : fallbackRasterStyle,
         zoom: 2,
         minZoom: 2,
-      }),
+        attributionControl: false,
+      }).addControl(new mapboxgl.AttributionControl({ compact: false })),
     );
 
     return () => {
@@ -274,7 +275,6 @@ export const TasksMap = ({
       mapboxLayerDefn();
     } else if (tasksReadyMapLoading && !mapLayersAlreadyDefined) {
       map.on('load', mapboxLayerDefn);
-
     } else if (tasksReadyMapLoading || mapReadyTasksReady) {
       console.error('One of the hook dependencies changed and try to redefine the map');
     }
@@ -324,7 +324,7 @@ export const TasksMap = ({
     taskBordersOnly,
     disableScrollZoom,
     navigate,
-    animateZoom
+    animateZoom,
   ]);
 
   return <div id="map" className={className} ref={mapRef}></div>;


### PR DESCRIPTION
Even in smaller screens, the OSM attribution will be always visible and never replaced by the compact attribution.