### PR TITLE
Update locked tasks DTO field check

### DIFF
--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -243,7 +243,7 @@ class ProjectService:
 
         tasks = Task.get_locked_tasks_for_user(user_id)
 
-        if len(tasks) > 0:
+        if len(tasks.locked_tasks) > 0:
             return False, ValidatingNotAllowed.USER_ALREADY_HAS_TASK_LOCKED
 
         if project.restrict_validation_role and not UserService.is_user_validator(


### PR DESCRIPTION
From https://github.com/hotosm/tasking-manager/issues/2191 - issue arises because of a missing field check. While [introducing additional fields for user's locked tasks DTO](https://github.com/hotosm/tasking-manager/pull/2107), we have the task list included in a new array field called `locked_tasks`. However [`is_user_permitted_to_validate`](https://github.com/hotosm/tasking-manager/blob/develop/server/services/project_service.py#L230) - still has conditional checks for the old DTO, updated the condition check field.
