### PR TITLE
Projects contributed by interest backend

### DIFF
--- a/server/models/dtos/interests_dto.py
+++ b/server/models/dtos/interests_dto.py
@@ -6,7 +6,9 @@ from schematics.types.compound import ListType, ModelType
 class InterestDTO(Model):
     id = IntType()
     name = StringType()
-    user_selected = BooleanType(serialized_name="userSelected", default=False)
+    user_selected = BooleanType(
+        serialized_name="userSelected", serialize_when_none=False
+    )
     count_projects = IntType(serialize_when_none=False, serialized_name="countProjects")
     count_users = IntType(serialize_when_none=False, serialized_name="countUsers")
 

--- a/server/models/dtos/user_dto.py
+++ b/server/models/dtos/user_dto.py
@@ -6,6 +6,7 @@ from schematics.types.compound import ListType, ModelType, BaseType
 from server.models.dtos.stats_dto import Pagination
 from server.models.dtos.mapping_dto import TaskDTO
 from server.models.postgis.statuses import MappingLevel, UserRole
+from server.models.dtos.interests_dto import InterestDTO
 
 
 def is_known_mapping_level(value):
@@ -125,6 +126,9 @@ class UserStatsDTO(Model):
     )
     tasks_mapped = IntType(serialized_name="tasksMapped")
     tasks_validated = IntType(serialized_name="tasksValidated")
+    contributions_interest = ListType(
+        ModelType(InterestDTO), serialized_name="ContributionsByInterest"
+    )
 
 
 class UserOSMDTO(Model):

--- a/server/services/users/user_service.py
+++ b/server/services/users/user_service.py
@@ -1,7 +1,7 @@
 from cachetools import TTLCache, cached
 from flask import current_app
 import datetime
-from sqlalchemy import text, func, or_, desc, and_
+from sqlalchemy import text, func, or_, desc, and_, distinct
 from server import db
 from server.models.dtos.project_dto import ProjectFavoritesDTO
 from server.models.dtos.user_dto import (
@@ -19,8 +19,8 @@ from server.models.dtos.user_dto import (
     UserCountryContributed,
     UserCountriesContributed,
 )
-from server.models.dtos.interests_dto import InterestsDTO
-from server.models.postgis.interests import Interest
+from server.models.dtos.interests_dto import InterestsDTO, InterestDTO
+from server.models.postgis.interests import Interest, projects_interests
 from server.models.postgis.message import Message
 from server.models.postgis.project import Project, ProjectInfo
 from server.models.postgis.user import User, UserRole, MappingLevel, UserEmail
@@ -197,6 +197,42 @@ class UserService:
         return requested_user.as_dto(requested_user.username)
 
     @staticmethod
+    def get_interests_stats(user_id):
+        # Get all projects that the user has contributed.
+        stmt = (
+            TaskHistory.query.with_entities(TaskHistory.project_id)
+            .distinct()
+            .filter(TaskHistory.user_id == user_id)
+        )
+
+        interests = (
+            Interest.query.with_entities(
+                Interest.id,
+                Interest.name,
+                func.count(distinct(projects_interests.c.project_id)).label(
+                    "count_projects"
+                ),
+            )
+            .outerjoin(
+                projects_interests,
+                and_(
+                    Interest.id == projects_interests.c.interest_id,
+                    projects_interests.c.project_id.in_(stmt),
+                ),
+            )
+            .group_by(Interest.id)
+            .order_by(desc("count_projects"))
+            .all()
+        )
+
+        interests_dto = [
+            InterestDTO(dict(id=i.id, name=i.name, count_projects=i.count_projects,))
+            for i in interests
+        ]
+
+        return interests_dto
+
+    @staticmethod
     def get_tasks_dto(
         user_id: int,
         start_date: datetime.datetime = None,
@@ -310,6 +346,8 @@ class UserService:
             if total_mapping_time:
                 stats_dto.time_spent_mapping = total_mapping_time.total_seconds()
                 stats_dto.total_time_spent += stats_dto.time_spent_mapping
+
+        stats_dto.contributions_interest = UserService.get_interests_stats(user.id)
 
         return stats_dto
 


### PR DESCRIPTION
this PR closes #2231 .

You can test using a database dump from _tests_ folde and run `python manage.py shell`

1. Create some interests:
```
from server.models.postgis.interests import Interest
items = ['Water', 'Sanitation', 'Disaster Risk Reduction', 'environment', 'disaster Response', 'public health', 'gender equality'] 
[Interest(name=i).create() for i in items]
```

2. Asociate interests with projects.
```
from server import db
proj = Project.query.get(1)
proj.interests = [Interest.query.get(i) for i in [1, 2, 3]]
db.session.commit()

proj = Project.query.get(2)
proj.interests = [Interest.query.get(i) for i in [1, 2, 4, 5]]
db.session.commit()
```

3. Perform API  request to `/users/wille/statistics/` and `/users/xamanu/statistics/`. The response shows an additional field. Interests without projects will also be shown


