### PR TITLE
Reopen editor + customEditor

### DIFF
--- a/frontend/src/components/taskSelection/footer.js
+++ b/frontend/src/components/taskSelection/footer.js
@@ -93,11 +93,16 @@ const TaskSelectionFooter = props => {
       props.project.mappingEditors &&
       props.taskAction.startsWith('validate')
     ) {
-      setEditorOptions(getEditors().filter(i => props.project.validationEditors.includes(i.value)));
+      setEditorOptions(getEditors(props.project.validationEditors, props.project.customEditor));
     } else {
-      setEditorOptions(getEditors().filter(i => props.project.mappingEditors.includes(i.value)));
+      setEditorOptions(getEditors(props.project.mappingEditors, props.project.customEditor));
     }
-  }, [props.taskAction, props.project.mappingEditors, props.project.validationEditors]);
+  }, [
+    props.taskAction,
+    props.project.mappingEditors,
+    props.project.validationEditors,
+    props.project.customEditor,
+  ]);
 
   const updateEditor = arr => setEditor(arr[0].value);
   const titleClasses = 'db ttu f6 blue-light mb2';

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -85,6 +85,10 @@ export default defineMessages({
     id: 'project.editor.select',
     defaultMessage: 'Select editor',
   },
+  startAnotherEditor: {
+    id: 'project.editor.start_another_editor',
+    defaultMessage: 'Start another editor',
+  },
   task: {
     id: 'project.task',
     defaultMessage: 'Task',
@@ -263,11 +267,11 @@ export default defineMessages({
   },
   badImagery: {
     id: 'project.tasks.action.options.bad_imagery',
-    defaultMessage: "It was not possible to map due to poor imagery",
+    defaultMessage: 'It was not possible to map due to poor imagery',
   },
   incomplete: {
     id: 'project.tasks.action.options.mapping_incomplete',
-    defaultMessage: "I could not map everything",
+    defaultMessage: 'I could not map everything',
   },
   completelyMapped: {
     id: 'project.tasks.action.options.mapping_complete',

--- a/frontend/src/utils/editorsList.js
+++ b/frontend/src/utils/editorsList.js
@@ -1,4 +1,4 @@
-export function getEditors() {
+export function getEditors(filterList, customEditor) {
   let editors = [
     {
       label: 'iD Editor',
@@ -21,5 +21,11 @@ export function getEditors() {
       url: 'http://fieldpapers.org/compose',
     },
   ];
+  if (filterList) {
+    editors = editors.filter(i => filterList.includes(i.value));
+  }
+  if (customEditor && filterList.includes('CUSTOM')) {
+    editors.push({ label: customEditor.name, value: 'CUSTOM', url: customEditor.url });
+  }
   return editors;
 }

--- a/frontend/src/utils/openEditor.js
+++ b/frontend/src/utils/openEditor.js
@@ -16,6 +16,11 @@ export function openEditor(editor, project, tasks, selectedTasks, windowSize) {
   if (editor === 'FIELD_PAPERS') {
     window.open(getFieldPapersUrl(center, zoom));
   }
+  if (editor === 'CUSTOM') {
+    const customUrl = project.customEditor.url;
+    const idUrl = getIdUrl(project, center, zoom, selectedTasks, customUrl);
+    window.open(idUrl);
+  }
 }
 
 export function getTaskGpxUrl(projectId, selectedTasks) {
@@ -48,8 +53,10 @@ export function getPotlatch2Url(centroid, zoomLevel) {
   ].join('/')}`;
 }
 
-export function getIdUrl(project, centroid, zoomLevel, selectedTasks) {
-  const base = 'https://www.openstreetmap.org/edit?editor=id&';
+export function getIdUrl(project, centroid, zoomLevel, selectedTasks, customUrl) {
+  const base = customUrl
+    ? formatCustomUrl(customUrl)
+    : 'https://www.openstreetmap.org/edit?editor=id&';
   let url = base + '#map=' + [zoomLevel, centroid[1], centroid[0]].join('/');
   if (project.changesetComment) {
     url += '&comment=' + encodeURIComponent(project.changesetComment);
@@ -136,6 +143,10 @@ function loadOsmDataToTasks(project, bbox, selectedTasks) {
 
 export function formatJosmUrl(endpoint, params) {
   return new URL(formatUrlParams(params), `http://127.0.0.1:8111/${endpoint}`);
+}
+
+export function formatCustomUrl(url) {
+  return url.includes('?') ? url : `${url}?`;
 }
 
 function roundToDecimals(input, decimals) {

--- a/frontend/src/utils/tests/editorsList.test.js
+++ b/frontend/src/utils/tests/editorsList.test.js
@@ -1,0 +1,69 @@
+import { getEditors } from '../editorsList';
+
+describe('test getEditors', () => {
+  it('without filterList and without customEditor', () => {
+    expect(getEditors()).toStrictEqual([
+      {
+        label: 'iD Editor',
+        value: 'ID',
+        url: 'http://www.openstreetmap.org/edit?editor=id&',
+      },
+      {
+        label: 'JOSM',
+        value: 'JOSM',
+        url: 'http://127.0.0.1:8111',
+      },
+      {
+        label: 'Potlatch 2',
+        value: 'POTLATCH_2',
+        url: 'http://www.openstreetmap.org/edit?editor=potlatch2',
+      },
+      {
+        label: 'Field Papers',
+        value: 'FIELD_PAPERS',
+        url: 'http://fieldpapers.org/compose',
+      },
+    ]);
+  });
+
+  it('with ID and JOSM in the filterList', () => {
+    expect(getEditors(['ID', 'JOSM'])).toStrictEqual([
+      {
+        label: 'iD Editor',
+        value: 'ID',
+        url: 'http://www.openstreetmap.org/edit?editor=id&',
+      },
+      {
+        label: 'JOSM',
+        value: 'JOSM',
+        url: 'http://127.0.0.1:8111',
+      },
+    ]);
+  });
+
+  it('with customEditor and filterList including the CUSTOM value', () => {
+    const customEditor = {
+      name: 'RapiD',
+      description: null,
+      url: 'https://mapwith.ai/rapid',
+      enabled: true,
+    };
+    expect(getEditors(['ID', 'JOSM', 'CUSTOM'], customEditor)).toStrictEqual([
+      {
+        label: 'iD Editor',
+        value: 'ID',
+        url: 'http://www.openstreetmap.org/edit?editor=id&',
+      },
+      {
+        label: 'JOSM',
+        value: 'JOSM',
+        url: 'http://127.0.0.1:8111',
+      },
+      {
+        label: 'RapiD',
+        value: 'CUSTOM',
+        url: 'https://mapwith.ai/rapid',
+      },
+    ]);
+  });
+});

--- a/frontend/src/utils/tests/openEditor.test.js
+++ b/frontend/src/utils/tests/openEditor.test.js
@@ -6,35 +6,59 @@ import {
   getFieldPapersUrl,
   getPotlatch2Url,
   formatJosmUrl,
+  formatCustomUrl,
 } from '../openEditor';
 
-it('test if getIdUrl returns the correct url', () => {
-  const testProject = {
-    changesetComment: '#hotosm-project-5522 #osm_in #2018IndiaFloods #mmteamarm',
-    projectId: 1234,
-    imagery:
-      'tms[1,22]:https://api.mapbox.com/styles/v1/tm4/code123/tiles/256/{zoom}/{x}/{y}?access_token=pk.123',
-  };
-  expect(getIdUrl(testProject, [120.25684, -9.663953], 18, [1])).toBe(
-    'https://www.openstreetmap.org/edit?editor=id&' +
-      '#map=18/-9.663953/120.25684' +
-      '&comment=%23hotosm-project-5522%20%23osm_in%20%232018IndiaFloods%20%23mmteamarm' +
-      '&background=custom:https%3A%2F%2Fapi.mapbox.com%2Fstyles%2Fv1%2Ftm4%2Fcode123%2Ftiles%2F256%2F%7Bz%7D%2F%7Bx%7D%2F%7By%7D%3Faccess_token%3Dpk.123' +
-      '&gpx=http%3A%2F%2F127.0.0.1%3A5000%2Fapi%2Fv2%2Fprojects%2F1234%2Ftasks%2Fqueries%2Fgpx%2F%3Ftasks%3D1',
-  );
+describe('test if getIdUrl', () => {
+  it('returns the correct url', () => {
+    const testProject = {
+      changesetComment: '#hotosm-project-5522 #osm_in #2018IndiaFloods #mmteamarm',
+      projectId: 1234,
+      imagery:
+        'tms[1,22]:https://api.mapbox.com/styles/v1/tm4/code123/tiles/256/{zoom}/{x}/{y}?access_token=pk.123',
+    };
+    expect(getIdUrl(testProject, [120.25684, -9.663953], 18, [1])).toBe(
+      'https://www.openstreetmap.org/edit?editor=id&' +
+        '#map=18/-9.663953/120.25684' +
+        '&comment=%23hotosm-project-5522%20%23osm_in%20%232018IndiaFloods%20%23mmteamarm' +
+        '&background=custom:https%3A%2F%2Fapi.mapbox.com%2Fstyles%2Fv1%2Ftm4%2Fcode123%2Ftiles%2F256%2F%7Bz%7D%2F%7Bx%7D%2F%7By%7D%3Faccess_token%3Dpk.123' +
+        '&gpx=http%3A%2F%2F127.0.0.1%3A5000%2Fapi%2Fv2%2Fprojects%2F1234%2Ftasks%2Fqueries%2Fgpx%2F%3Ftasks%3D1',
+    );
+  });
+
+  it('with customUrl returns the correct formatted url', () => {
+    const testProject = {
+      changesetComment: '#hotosm-project-5522 #osm_in #2018IndiaFloods #mmteamarm',
+      projectId: 1234,
+      imagery:
+        'tms[1,22]:https://api.mapbox.com/styles/v1/tm4/code123/tiles/256/{zoom}/{x}/{y}?access_token=pk.123',
+    };
+    expect(getIdUrl(testProject, [120.25684, -9.663953], 18, [1], 'https://mapwith.ai/rapid')).toBe(
+      'https://mapwith.ai/rapid?' +
+        '#map=18/-9.663953/120.25684' +
+        '&comment=%23hotosm-project-5522%20%23osm_in%20%232018IndiaFloods%20%23mmteamarm' +
+        '&background=custom:https%3A%2F%2Fapi.mapbox.com%2Fstyles%2Fv1%2Ftm4%2Fcode123%2Ftiles%2F256%2F%7Bz%7D%2F%7Bx%7D%2F%7By%7D%3Faccess_token%3Dpk.123' +
+        '&gpx=http%3A%2F%2F127.0.0.1%3A5000%2Fapi%2Fv2%2Fprojects%2F1234%2Ftasks%2Fqueries%2Fgpx%2F%3Ftasks%3D1',
+    );
+  });
+
+  it('without imagery and with multiple tasks returns the correct url', () => {
+    const testProject = {
+      changesetComment: '#hotosm-project-5522',
+      projectId: 1234,
+    };
+    expect(getIdUrl(testProject, [120.25684, -9.663953], 18, [1, 2])).toBe(
+      'https://www.openstreetmap.org/edit?editor=id&' +
+        '#map=18/-9.663953/120.25684' +
+        '&comment=%23hotosm-project-5522' +
+        '&gpx=http%3A%2F%2F127.0.0.1%3A5000%2Fapi%2Fv2%2Fprojects%2F1234%2Ftasks%2Fqueries%2Fgpx%2F%3Ftasks%3D1%2C2',
+    );
+  });
 });
 
-it('test if getIdUrl without imagery and with multiple tasks returns the correct url', () => {
-  const testProject = {
-    changesetComment: '#hotosm-project-5522',
-    projectId: 1234,
-  };
-  expect(getIdUrl(testProject, [120.25684, -9.663953], 18, [1, 2])).toBe(
-    'https://www.openstreetmap.org/edit?editor=id&' +
-      '#map=18/-9.663953/120.25684' +
-      '&comment=%23hotosm-project-5522' +
-      '&gpx=http%3A%2F%2F127.0.0.1%3A5000%2Fapi%2Fv2%2Fprojects%2F1234%2Ftasks%2Fqueries%2Fgpx%2F%3Ftasks%3D1%2C2',
-  );
+it('test if formatCustomUrl returns the url with question mark', () => {
+  expect(formatCustomUrl('https://mapwith.ai/rapid')).toBe('https://mapwith.ai/rapid?');
+  expect(formatCustomUrl('https://mapwith.ai/rapid?')).toBe('https://mapwith.ai/rapid?');
 });
 
 it('test if getFieldPapersUrl returns the correct url', () => {
@@ -67,17 +91,19 @@ it('test if getTaskXmlUrl returns the correct url', () => {
   );
 });
 
-it('test if formatJosmUrl returns the correct url', () => {
-  expect(
-    formatJosmUrl('imagery', {
-      title: 'osm',
-      type: 'tms',
-      url: 'http://tile.openstreetmap.org/{zoom}/{x}/{y}.png',
-    }).href,
-  ).toBe(
-    new URL(
-      '?title=osm&type=tms&url=http%3A%2F%2Ftile.openstreetmap.org%2F%7Bzoom%7D%2F%7Bx%7D%2F%7By%7D.png',
-      'http://127.0.0.1:8111/imagery',
-    ).href,
-  );
+describe('test if formatJosmUrl', () => {
+  it('returns the correct url', () => {
+    expect(
+      formatJosmUrl('imagery', {
+        title: 'osm',
+        type: 'tms',
+        url: 'http://tile.openstreetmap.org/{zoom}/{x}/{y}.png',
+      }).href,
+    ).toBe(
+      new URL(
+        '?title=osm&type=tms&url=http%3A%2F%2Ftile.openstreetmap.org%2F%7Bzoom%7D%2F%7Bx%7D%2F%7By%7D.png',
+        'http://127.0.0.1:8111/imagery',
+      ).href,
+    );
+  });
 });

--- a/server/models/dtos/project_dto.py
+++ b/server/models/dtos/project_dto.py
@@ -475,6 +475,9 @@ class ProjectSummary(Model):
         serialized_name="validationEditors",
         validators=[is_known_editor],
     )
+    custom_editor = ModelType(
+        CustomEditorDTO, serialized_name="customEditor", serialize_when_none=False
+    )
 
 
 class PMDashboardDTO(Model):

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -775,6 +775,9 @@ class Project(db.Model):
 
             summary.validation_editors = validation_editors
 
+        if self.custom_editor:
+            summary.custom_editor = self.custom_editor.as_dto()
+
         # If project is private, fetch list of allowed users
         if self.private:
             allowed_users = []


### PR DESCRIPTION
- add dropdown to reopen editor on map/validation pages (solves #2088)
- add customEditor field to project summary endpoint
- add customEditor to editors list on task selection, map and validation page (it's missing to add it on the project edit) (related to #1924)