### PR TITLE
Team membership improvements

### DIFF
--- a/frontend/src/components/notifications/notificationCard.js
+++ b/frontend/src/components/notifications/notificationCard.js
@@ -45,6 +45,7 @@ export const MessageAvatar = ({ messageType, fromUsername, size }: Object) => {
           picture={null}
           colorClasses="white bg-blue-grey"
           size={size}
+          disableLink={true}
         />
       ) : (
         checkIsSystem && (
@@ -53,6 +54,7 @@ export const MessageAvatar = ({ messageType, fromUsername, size }: Object) => {
             picture={systemAvatar}
             size={size}
             colorClasses="white bg-blue-grey"
+            disableLink={true}
           />
         )
       )}

--- a/frontend/src/components/projectDetail/index.js
+++ b/frontend/src/components/projectDetail/index.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { Link } from '@reach/router';
 import { FormattedMessage } from 'react-intl';
 import ReactPlaceholder from 'react-placeholder';
 import { centroid } from '@turf/turf';
@@ -234,14 +233,13 @@ export const ProjectDetail = props => {
       <div className="cf db mb3 ph4">
         {props.contributors &&
           props.contributors.map((user, n) => (
-            <Link to={`/users/${user.username}`} key={n}>
-              <UserAvatar
-                username={user.username}
-                picture={user.pictureUrl}
-                size="large"
-                colorClasses="white bg-blue-grey"
-              />
-            </Link>
+            <UserAvatar
+              username={user.username}
+              picture={user.pictureUrl}
+              size="large"
+              colorClasses="white bg-blue-grey"
+              key={n}
+            />
           ))}
       </div>
 

--- a/frontend/src/components/projectDetail/questionsAndComments.js
+++ b/frontend/src/components/projectDetail/questionsAndComments.js
@@ -6,7 +6,7 @@ import { FormattedMessage, FormattedRelative } from 'react-intl';
 import messages from './messages';
 import { PaginatorLine } from '../paginator';
 import { Button } from '../button';
-import { CurrentUserAvatar } from '../user/avatar';
+import { CurrentUserAvatar, UserAvatar } from '../user/avatar';
 import { htmlFromMarkdown } from '../../utils/htmlFromMarkdown';
 import { pushToLocalJSONAPI, fetchLocalJSONAPI } from '../../network/genericJSONRequest';
 
@@ -154,11 +154,13 @@ function CommentList({ comments }: Object) {
         <div className="w-90 center cf mb2 pa3 ba b--grey-light bg-white" key={n}>
           <div className="cf db">
             <div className="fl">
-              <div className="h2 w2 bg-grey-light br-100 ma0">
-                {comment.pictureUrl === null ? null : (
-                  <img className="h2 w2 br-100" src={comment.pictureUrl} alt={comment.username} />
-                )}
-              </div>
+              {comment.pictureUrl === null ? null : (
+                <UserAvatar
+                  username={comment.username}
+                  picture={comment.pictureUrl}
+                  colorClasses="white bg-blue-grey"
+                />
+              )}
             </div>
             <div className="fl ml3">
               <p className="b ma0">

--- a/frontend/src/components/teamsAndOrgs/campaigns.js
+++ b/frontend/src/components/teamsAndOrgs/campaigns.js
@@ -19,6 +19,7 @@ export function CampaignsManagement({ campaigns, userDetails }: Object) {
         />
       }
       showAddButton={userDetails.role === 'ADMIN'}
+      managementView
     >
       {campaigns.length ? (
         campaigns.map((campaign, n) => <CampaignCard campaign={campaign} key={n} />)

--- a/frontend/src/components/teamsAndOrgs/management.js
+++ b/frontend/src/components/teamsAndOrgs/management.js
@@ -44,11 +44,19 @@ export function VisibilityBox({ visibility, extraClasses }: Object) {
   return <div className={`tc br1 f7 ttu ba ${borderColor} ${color} ${extraClasses}`}>{text}</div>;
 }
 
+export function InviteOnlyBox({ className }: Object) {
+  return (
+    <div className={`tc br1 f7 ttu ba red b--red ${className}`}>
+      <FormattedMessage {...messages.inviteOnly} />
+    </div>
+  );
+}
+
 export function Management(props) {
   return (
     <div className="pull-center cf pb4 ph5-l bg-tan">
       {props.managementView && <ManagementMenu />}
-      <div className="cf">
+      <div className="cf mt4">
         <h3 className="barlow-condensed f2 ma0 pv3 dib v-mid ttu pl2 pl0-l">{props.title}</h3>
         {props.showAddButton && (
           <Link to={'new/'} className="dib ml3">

--- a/frontend/src/components/teamsAndOrgs/messages.js
+++ b/frontend/src/components/teamsAndOrgs/messages.js
@@ -24,6 +24,14 @@ export default defineMessages({
     id: 'management.teams.members',
     defaultMessage: 'Team members',
   },
+  joinRequests: {
+    id: 'management.teams.join_requests',
+    defaultMessage: 'Join requests',
+  },
+  noRequests: {
+    id: 'management.teams.join_requests.empty',
+    defaultMessage: "There isn't requests to join the team.",
+  },
   teams: {
     id: 'management.teams',
     defaultMessage: 'Teams',
@@ -63,6 +71,14 @@ export default defineMessages({
   delete: {
     id: 'management.buttons.delete',
     defaultMessage: 'Delete',
+  },
+  accept: {
+    id: 'management.buttons.accept',
+    defaultMessage: 'Accept',
+  },
+  reject: {
+    id: 'management.buttons.reject',
+    defaultMessage: 'Reject',
   },
   viewAll: {
     id: 'management.links.viewAll',
@@ -156,13 +172,13 @@ export default defineMessages({
     id: 'management.teams.visibility.private',
     defaultMessage: 'Private',
   },
-  secret: {
-    id: 'management.teams.visibility.secret',
-    defaultMessage: 'Secret',
-  },
   inviteOnlyDescription: {
     id: 'management.teams.invite_only.description',
     defaultMessage: "Managers need to approve a member's request to join.",
+  },
+  waitingApproval: {
+    id: 'teamsAndOrgs.management.teams.messages.waiting_approval',
+    defaultMessage: 'Your request to join this team is waiting for approval.',
   },
   noProjectsFound: {
     id: 'management.projects.no_found',

--- a/frontend/src/components/teamsAndOrgs/organisations.js
+++ b/frontend/src/components/teamsAndOrgs/organisations.js
@@ -12,7 +12,11 @@ import { UserAvatar } from '../user/avatar';
 export function OrgsManagement({ organisations, userDetails }: Object) {
   const isAdmin = userDetails.role === 'ADMIN';
   return (
-    <Management title={<FormattedMessage {...messages.myOrganisations} />} showAddButton={isAdmin}>
+    <Management
+      title={<FormattedMessage {...messages.myOrganisations} />}
+      showAddButton={isAdmin}
+      managementView={true}
+    >
       {isAdmin ? (
         organisations.map((org, n) => <OrganisationCard details={org} key={n} />)
       ) : (

--- a/frontend/src/components/teamsAndOrgs/projects.js
+++ b/frontend/src/components/teamsAndOrgs/projects.js
@@ -7,16 +7,18 @@ import messages from './messages';
 import { ProjectCard } from '../projectcard/projectCard';
 import { AddButton, ViewAllLink } from './management';
 
-export function Projects({ projects, viewAllQuery, ownerEntity }: Object) {
+export function Projects({ projects, viewAllQuery, ownerEntity, showAddButton = false }: Object) {
   return (
     <div className="bg-white b--grey-light ba pa4 mb3">
       <div className="cf db">
         <h3 className="f3 blue-dark mv0 fw6 dib v-mid">
           <FormattedMessage {...messages.projects} />
         </h3>
-        <Link to={'/manage/projects/new/'} className="dib ml4">
-          <AddButton />
-        </Link>
+        {showAddButton && (
+          <Link to={'/manage/projects/new/'} className="dib ml4">
+            <AddButton />
+          </Link>
+        )}
         <ViewAllLink link={`/explore/${viewAllQuery ? viewAllQuery : ''}`} />
         <div className="cf pt4">
           <ReactPlaceholder

--- a/frontend/src/components/teamsAndOrgs/tests/members.test.js
+++ b/frontend/src/components/teamsAndOrgs/tests/members.test.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { store } from '../../../store';
+import { createComponentWithIntl } from '../../../utils/testWithIntl';
+import { JoinRequests } from '../members';
+import { UserAvatar } from '../../user/avatar';
+import { Button } from '../../button';
+
+describe('test JoinRequest list', () => {
+  const requests = [
+    {
+      username: 'test_1',
+      function: 'MANAGER',
+      active: false,
+      pictureUrl: 'https://www.gravatar.com/avatar.png',
+    },
+    { username: 'test_2', function: 'MEMBER', active: false, pictureUrl: null },
+  ];
+  const element = createComponentWithIntl(
+    <Provider store={store}>
+      <JoinRequests requests={requests} />
+    </Provider>,
+  );
+  const testInstance = element.root;
+  it('initial div has the correct classes', () => {
+    expect(testInstance.findAllByType('div')[0].props.className).toBe(
+      'bg-white b--grey-light pa4 ba blue-dark',
+    );
+  });
+  it('h3 element has the correct title', () => {
+    expect(testInstance.findByType('h3').children[0].props.id).toBe(
+      'management.teams.join_requests',
+    );
+  });
+  it('number of UserAvatar components is correct', () => {
+    expect(testInstance.findAllByType(UserAvatar).length).toBe(2);
+  });
+  it('Accept and Deny buttons are present', () => {
+    expect(testInstance.findAllByType(Button).length).toBe(4);
+    expect(testInstance.findAllByProps({ className: 'pr2 blue-dark bg-white' }).length).toBe(2);
+    expect(testInstance.findAllByProps({ className: 'pr2 bg-red white' }).length).toBe(2);
+  });
+  it('no requests message is NOT present', () => {
+    expect(() =>
+      testInstance
+        .findByProps({ className: 'tc' })
+        .toThrow(new Error('No instances found with props: {className: "tc"}')),
+    );
+  });
+});
+
+describe('test JoinRequest list without requests', () => {
+  const element = createComponentWithIntl(
+    <Provider store={store}>
+      <JoinRequests requests={[]} />
+    </Provider>,
+  );
+  const testInstance = element.root;
+  it('initial div has the correct classes', () => {
+    expect(testInstance.findAllByType('div')[0].props.className).toBe(
+      'bg-white b--grey-light pa4 ba blue-dark',
+    );
+  });
+  it('h3 element has the correct title', () => {
+    expect(testInstance.findByType('h3').children[0].props.id).toBe(
+      'management.teams.join_requests',
+    );
+  });
+  it('number of UserAvatar components is correct', () => {
+    expect(() =>
+      testInstance
+        .findAllByType(UserAvatar)
+        .toThrow(new Error('No instances found with node type: "UserAvatar"')),
+    );
+  });
+  it('Accept and Deny buttons are present', () => {
+    expect(() =>
+      testInstance
+        .findAllByType(Button)
+        .toThrow(new Error('No instances found with node type: "Button"')),
+    );
+    expect(() =>
+      testInstance
+        .findAllByProps({ className: 'pr2 blue-dark bg-white' })
+        .toThrow(new Error('No instances found with props: {className: "pr2 blue-dark bg-white"}')),
+    );
+    expect(() =>
+      testInstance
+        .findAllByProps({ className: 'pr2 bg-red white' })
+        .toThrow(new Error('No instances found with props: {className: "pr2 bg-red white"}')),
+    );
+  });
+  it('no requests message is present', () => {
+    expect(testInstance.findByProps({ className: 'tc' }).children[0].props.id).toBe(
+      'management.teams.join_requests.empty',
+    );
+  });
+});

--- a/frontend/src/components/teamsAndOrgs/tests/organisations.test.js
+++ b/frontend/src/components/teamsAndOrgs/tests/organisations.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
+import { Provider } from 'react-redux';
 
 import { createComponentWithIntl } from '../../../utils/testWithIntl';
-import { Provider } from 'react-redux';
 import { store } from '../../../store';
 import { OrgsManagement, OrganisationCard } from '../organisations';
 

--- a/frontend/src/components/user/avatar.js
+++ b/frontend/src/components/user/avatar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from '@reach/router';
 import { useSelector } from 'react-redux';
 
 import { ProfilePictureIcon, CloseIcon } from '../svgIcons';
@@ -19,6 +20,7 @@ export const UserAvatar = ({
   colorClasses,
   removeFn,
   editMode,
+  disableLink = false,
 }: Object) => {
   let sizeClasses = 'h2 w2 f5';
   let textPadding = editMode ? { top: '-0.75rem' } : { paddingTop: '0.375rem' };
@@ -51,7 +53,7 @@ export const UserAvatar = ({
       .join('');
   }
 
-  return (
+  const avatar = (
     <div
       title={username}
       style={sizeStyles}
@@ -79,4 +81,10 @@ export const UserAvatar = ({
       )}
     </div>
   );
+
+  if ((removeFn && editMode) || disableLink) {
+    return avatar;
+  } else {
+    return <Link to={`/users/${username}`}>{avatar}</Link>;
+  }
 };

--- a/frontend/src/components/user/tests/userAvatar.test.js
+++ b/frontend/src/components/user/tests/userAvatar.test.js
@@ -1,16 +1,12 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
-import { Provider } from 'react-redux';
 
 import { UserAvatar } from '../avatar';
-import { store } from '../../../store';
 import { CloseIcon } from '../../svgIcons';
 
 it('UserAvatar with picture url and default size', () => {
   const element = TestRenderer.create(
-    <Provider store={store}>
-      <UserAvatar username={'Mary'} picture={'http://image.xyz/photo.jpg'} />
-    </Provider>,
+    <UserAvatar username={'Mary'} picture={'http://image.xyz/photo.jpg'} />,
   );
   const elementInstance = element.root;
   expect(elementInstance.findByType('img').props.src).toBe('http://image.xyz/photo.jpg');
@@ -20,9 +16,7 @@ it('UserAvatar with picture url and default size', () => {
 
 it('UserAvatar with picture url and large size', () => {
   const element = TestRenderer.create(
-    <Provider store={store}>
-      <UserAvatar username={'Mary'} size="large" picture={'http://image.xyz/photo.jpg'} />
-    </Provider>,
+    <UserAvatar username={'Mary'} size="large" picture={'http://image.xyz/photo.jpg'} />,
   );
   const elementInstance = element.root;
   expect(elementInstance.findByType('img').props.src).toBe('http://image.xyz/photo.jpg');
@@ -32,9 +26,7 @@ it('UserAvatar with picture url and large size', () => {
 
 it('UserAvatar without picture url and with large size', () => {
   const element = TestRenderer.create(
-    <Provider store={store}>
-      <UserAvatar username={'Mary'} size="large" colorClasses="white bg-red" />
-    </Provider>,
+    <UserAvatar username={'Mary'} size="large" colorClasses="white bg-red" />,
   );
   const elementInstance = element.root;
   expect(elementInstance.findByType('div').props.className).toBe(
@@ -46,9 +38,7 @@ it('UserAvatar without picture url and with large size', () => {
 
 it('UserAvatar with name with default size', () => {
   const element = TestRenderer.create(
-    <Provider store={store}>
-      <UserAvatar username={'Mary'} name={'Mary Poppins'} colorClasses="white bg-red" />
-    </Provider>,
+    <UserAvatar username={'Mary'} name={'Mary Poppins'} colorClasses="white bg-red" />,
   );
   const elementInstance = element.root;
   expect(elementInstance.findByType('div').props.className).toBe(
@@ -60,9 +50,7 @@ it('UserAvatar with name with default size', () => {
 
 it('UserAvatar with more than 3 words name', () => {
   const element = TestRenderer.create(
-    <Provider store={store}>
-      <UserAvatar username={'Mary'} name={'Mary Poppins Long Name'} colorClasses="white bg-red" />
-    </Provider>,
+    <UserAvatar username={'Mary'} name={'Mary Poppins Long Name'} colorClasses="white bg-red" />,
   );
   const elementInstance = element.root;
   expect(elementInstance.findByType('span').props.children).toContain('MPL');
@@ -70,9 +58,7 @@ it('UserAvatar with more than 3 words name', () => {
 
 it('UserAvatar with username containing space', () => {
   const element = TestRenderer.create(
-    <Provider store={store}>
-      <UserAvatar username={'Mary Poppins Long Name'} colorClasses="white bg-red" />
-    </Provider>,
+    <UserAvatar username={'Mary Poppins Long Name'} colorClasses="white bg-red" />,
   );
   const elementInstance = element.root;
   expect(elementInstance.findByType('span').props.children).toContain('MPL');
@@ -83,9 +69,7 @@ it('UserAvatar with username containing space', () => {
 
 it('UserAvatar with editMode TRUE but without removeFn has NOT a CloseIcon', () => {
   const element = TestRenderer.create(
-    <Provider store={store}>
-      <UserAvatar username={'Mary Poppins Long Name'} colorClasses="white bg-red" editMode={true} />
-    </Provider>,
+    <UserAvatar username={'Mary Poppins Long Name'} colorClasses="white bg-red" editMode={true} />,
   );
   const elementInstance = element.root;
   expect(elementInstance.findByType('span').props.children).toContain('MPL');
@@ -96,13 +80,11 @@ it('UserAvatar with editMode TRUE but without removeFn has NOT a CloseIcon', () 
 
 it('UserAvatar with removeFn, but with editMode FALSE  has NOT a CloseIcon', () => {
   const element = TestRenderer.create(
-    <Provider store={store}>
-      <UserAvatar
-        username={'Mary Poppins Long Name'}
-        colorClasses="white bg-red"
-        removeFn={() => console.log('no')}
-      />
-    </Provider>,
+    <UserAvatar
+      username={'Mary Poppins Long Name'}
+      colorClasses="white bg-red"
+      removeFn={() => console.log('no')}
+    />,
   );
   const elementInstance = element.root;
   expect(elementInstance.findByType('span').props.children).toContain('MPL');
@@ -114,16 +96,15 @@ it('UserAvatar with removeFn, but with editMode FALSE  has NOT a CloseIcon', () 
 it('UserAvatar with removeFn and editMode TRUE has a CloseIcon', () => {
   let value = 0;
   const element = TestRenderer.create(
-    <Provider store={store}>
-      <UserAvatar
-        username={'Mary'}
-        colorClasses="white bg-red"
-        removeFn={() => (value = 1)}
-        editMode={true}
-      />
-    </Provider>,
+    <UserAvatar
+      username={'Mary'}
+      colorClasses="white bg-red"
+      removeFn={() => (value = 1)}
+      editMode={true}
+    />,
   );
   const elementInstance = element.root;
+  expect(element.toJSON().type).toBe('div');
   expect(() => elementInstance.findByType(CloseIcon)).not.toThrow(
     new Error('No instances found with node type: "CloseIcon"'),
   );
@@ -132,4 +113,41 @@ it('UserAvatar with removeFn and editMode TRUE has a CloseIcon', () => {
     .findByProps({ className: 'relative top-0 z-1 fr br-100 f7 tc h1 w1 bg-red white pointer' })
     .props.onClick();
   expect(value).toBe(1);
+});
+
+it('UserAvatar without disableLink prop has a link', () => {
+  const element = TestRenderer.create(<UserAvatar username={'jean'} colorClasses="white bg-red" />);
+  const elementInstance = element.root;
+
+  expect(element.toJSON().type).toBe('a');
+  expect(elementInstance.findByType('a').props.href).toBe('/users/jean');
+});
+
+it('UserAvatar without disableLink, but with editMode prop, has a link', () => {
+  const element = TestRenderer.create(
+    <UserAvatar username={'jean'} colorClasses="white bg-red" editMode={true} />,
+  );
+  const elementInstance = element.root;
+
+  expect(element.toJSON().type).toBe('a');
+  expect(elementInstance.findByType('a').props.href).toBe('/users/jean');
+});
+
+it('UserAvatar without disableLink, but with removeFn prop, has a link', () => {
+  const element = TestRenderer.create(
+    <UserAvatar username={'jean'} colorClasses="white bg-red" removeFn={() => 123} />,
+  );
+  const elementInstance = element.root;
+
+  expect(element.toJSON().type).toBe('a');
+  expect(elementInstance.findByType('a').props.href).toBe('/users/jean');
+});
+
+it('UserAvatar with disableLink prop has not a link', () => {
+  const element = TestRenderer.create(
+    <UserAvatar username={'jean'} colorClasses="white bg-red" disableLink={true} />,
+  );
+  const json_element = element.toJSON();
+  expect(json_element.type).toBe('div');
+  expect(json_element.props.title).toBe('jean');
 });

--- a/frontend/src/utils/teamMembersDiff.js
+++ b/frontend/src/utils/teamMembersDiff.js
@@ -21,6 +21,10 @@ export function filterActiveManagers(members) {
   return members.filter(member => member.function === 'MANAGER').filter(member => member.active);
 }
 
+export function filterInactiveMembersAndManagers(members) {
+  return members.filter(member => !member.active);
+}
+
 export function formatMemberObject(user, manager = false) {
   return {
     username: user.username,

--- a/frontend/src/utils/tests/teamMembersDiff.test.js
+++ b/frontend/src/utils/tests/teamMembersDiff.test.js
@@ -2,6 +2,7 @@ import {
   getMembersDiff,
   filterActiveManagers,
   filterActiveMembers,
+  filterInactiveMembersAndManagers,
   formatMemberObject,
 } from '../teamMembersDiff';
 
@@ -56,6 +57,35 @@ it('should return only the active MEMBERS', () => {
   expect(filterActiveMembers(members_1)).toStrictEqual([
     { username: 'test_3', function: 'MEMBER', active: true, pictureUrl: null },
     { username: 'test_4', function: 'MEMBER', active: true, pictureUrl: null },
+  ]);
+});
+
+it('should return only the inactive MEMBERS and MANAGERS', () => {
+  const members_1 = [
+    {
+      username: 'test_0',
+      function: 'MANAGER',
+      active: true,
+      pictureUrl: 'https://www.gravatar.com/avatar.png',
+    },
+    {
+      username: 'test_1',
+      function: 'MANAGER',
+      active: false,
+      pictureUrl: 'https://www.gravatar.com/avatar.png',
+    },
+    { username: 'test_2', function: 'MEMBER', active: false, pictureUrl: null },
+    { username: 'test_3', function: 'MEMBER', active: true, pictureUrl: null },
+    { username: 'test_4', function: 'MEMBER', active: true, pictureUrl: null },
+  ];
+  expect(filterInactiveMembersAndManagers(members_1)).toStrictEqual([
+    {
+      username: 'test_1',
+      function: 'MANAGER',
+      active: false,
+      pictureUrl: 'https://www.gravatar.com/avatar.png',
+    },
+    { username: 'test_2', function: 'MEMBER', active: false, pictureUrl: null },
   ]);
 });
 

--- a/frontend/src/views/campaigns.js
+++ b/frontend/src/views/campaigns.js
@@ -14,6 +14,7 @@ import {
   CampaignInformation,
   CampaignForm,
 } from '../components/teamsAndOrgs/campaigns';
+import { ManagementMenu } from '../components/teamsAndOrgs/menu';
 import { Projects } from '../components/teamsAndOrgs/projects';
 import { FormSubmitButton, CustomButton } from '../components/button';
 import { DeleteModal } from '../components/deleteModal';
@@ -67,7 +68,8 @@ export function CreateCampaign() {
       render={({ handleSubmit, pristine, form, submitting, values }) => {
         return (
           <form onSubmit={handleSubmit} className="blue-grey">
-            <div className="cf pa4 bg-tan vh-100">
+            <div className="cf ph5-l ph2-m bg-tan vh-100">
+              <ManagementMenu />
               <h3 className="f2 mb3 ttu blue-dark fw7 barlow-condensed">
                 <FormattedMessage {...messages.newCampaign} />
               </h3>

--- a/frontend/src/views/management.js
+++ b/frontend/src/views/management.js
@@ -15,15 +15,17 @@ export function Management() {
   const [teamsError, teamsLoading, teams] = useFetch(`teams/`);
 
   return (
-    <div className="w-100 ph6-l cf pb4">
+    <div className="w-100 ph5-l ph2-m cf pb4">
       <ManagementMenu />
       <Projects
         projects={!projectsLoading && !projectsError && projects}
         viewAllQuery="?createdByMe=1"
+        showAddButton={true}
       />
       <Teams
         teams={!teamsLoading && !teamsError && teams.teams}
         viewAllQuery={`?manager=${userDetails.id}`}
+        showAddButton={true}
       />
     </div>
   );

--- a/frontend/src/views/messages.js
+++ b/frontend/src/views/messages.js
@@ -52,6 +52,10 @@ export default defineMessages({
     id: 'teamsAndOrgs.management.button.join_team',
     defaultMessage: 'Join team',
   },
+  cancelRequest: {
+    id: 'teamsAndOrgs.management.button.cancel_request',
+    defaultMessage: 'Cancel request',
+  },
   leaveTeam: {
     id: 'teamsAndOrgs.management.button.leave_team',
     defaultMessage: 'Leave team',

--- a/frontend/src/views/organisations.js
+++ b/frontend/src/views/organisations.js
@@ -10,6 +10,7 @@ import messages from './messages';
 import { useFetch } from '../hooks/UseFetch';
 import { pushToLocalJSONAPI, fetchLocalJSONAPI } from '../network/genericJSONRequest';
 import { Members } from '../components/teamsAndOrgs/members';
+import { ManagementMenu } from '../components/teamsAndOrgs/menu';
 import { Teams } from '../components/teamsAndOrgs/teams';
 import { Projects } from '../components/teamsAndOrgs/projects';
 import {
@@ -94,7 +95,8 @@ export function CreateOrganisation() {
       render={({ handleSubmit, pristine, form, submitting, values }) => {
         return (
           <form onSubmit={handleSubmit} className="blue-grey">
-            <div className="cf pa4 pb5 bg-tan">
+            <div className="cf ph5-l ph2-m pb5 bg-tan">
+              <ManagementMenu />
               <h3 className="f2 mb3 ttu blue-dark fw7 barlow-condensed">
                 <FormattedMessage {...messages.newOrganisation} />
               </h3>

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -629,7 +629,7 @@ def add_api_endpoints(app):
     api.add_resource(
         TeamsActionsJoinAPI,
         format_url("teams/<int:team_id>/actions/join/"),
-        methods=["POST", "PUT"],
+        methods=["POST", "PATCH"],
     )
     api.add_resource(
         TeamsActionsLeaveAPI,

--- a/server/api/teams/actions.py
+++ b/server/api/teams/actions.py
@@ -113,7 +113,7 @@ class TeamsActionsJoinAPI(Resource):
                         type: string
                         default: member
                         required: false
-                    response:
+                    action:
                         type: string
                         default: accept
                         required: true
@@ -129,9 +129,9 @@ class TeamsActionsJoinAPI(Resource):
         """
         try:
             json_data = request.get_json(force=True)
-            username = int(json_data["username"])
+            username = json_data["username"]
             request_type = json_data.get("type", "join-response")
-            response = json_data["response"]
+            action = json_data["action"]
             role = json_data.get("role", "member")
         except DataError as e:
             current_app.logger.error(f"error validating request: {str(e)}")
@@ -141,7 +141,7 @@ class TeamsActionsJoinAPI(Resource):
             if request_type == "join-response":
                 if TeamService.user_is_manager(team_id, tm.authenticated_user_id):
                     TeamService.accept_reject_join_request(
-                        team_id, tm.authenticated_user_id, username, role, response
+                        team_id, tm.authenticated_user_id, username, role, action
                     )
                     return {"Success": "True"}, 200
                 else:
@@ -153,7 +153,7 @@ class TeamsActionsJoinAPI(Resource):
                     )
             elif request_type == "invite-response":
                 TeamService.accept_reject_invitation_request(
-                    team_id, tm.authenticated_user_id, username, role, response
+                    team_id, tm.authenticated_user_id, username, role, action
                 )
                 return {"Success": "True"}, 200
         except Exception as e:

--- a/server/models/postgis/statuses.py
+++ b/server/models/postgis/statuses.py
@@ -110,7 +110,6 @@ class TeamVisibility(Enum):
 
     PUBLIC = 0
     PRIVATE = 1
-    SECRET = 2
 
 
 class TeamRoles(Enum):

--- a/server/services/team_service.py
+++ b/server/services/team_service.py
@@ -95,16 +95,16 @@ class TeamService:
         )
 
     @staticmethod
-    def accept_reject_join_request(team_id, from_user_id, username, function, response):
+    def accept_reject_join_request(team_id, from_user_id, username, function, action):
         from_user = UserService.get_user_by_id(from_user_id)
         to_user_id = UserService.get_user_by_username(username).id
         team = TeamService.get_team_by_id(team_id)
         MessageService.accept_reject_request_to_join_team(
-            from_user_id, from_user.username, to_user_id, team.name, response
+            from_user_id, from_user.username, to_user_id, team.name, action
         )
 
         is_member = TeamService.is_user_member_of_team(team_id, to_user_id)
-        if response == "accept":
+        if action == "accept":
             if is_member:
                 TeamService.activate_team_member(team_id, to_user_id)
             else:
@@ -114,15 +114,15 @@ class TeamService:
                     TeamMemberFunctions[function.upper()].value,
                     True,
                 )
-        elif response == "reject":
+        elif action == "reject":
             if is_member:
                 TeamService.delete_invite(team_id, to_user_id)
         else:
-            raise TeamServiceError("Invalid response type")
+            raise TeamServiceError("Invalid action type")
 
     @staticmethod
     def accept_reject_invitation_request(
-        team_id, from_user_id, username, function, response
+        team_id, from_user_id, username, function, action
     ):
         from_user = UserService.get_user_by_id(from_user_id)
         to_user = UserService.get_user_by_username(username)
@@ -136,9 +136,9 @@ class TeamService:
                 member.user_id,
                 to_user.username,
                 team.name,
-                response,
+                action,
             )
-        if response == "accept":
+        if action == "accept":
             TeamService.add_team_member(
                 team_id, from_user_id, TeamMemberFunctions[function.upper()].value
             )


### PR DESCRIPTION
- add section to manage team join requests
- fixes on join team api
  - set the correct methods on the `__init__.py`
  - rename response field to accept on the payload
- Remove `secret` option from team visibility field (both frontend and backend)
- changes in the team membership page
  - add box if the team is `inviteOnly`
  - update button to show `Cancel request` instead of `Leave team` if the team is invite only
  - show message if the user has already asked to join the team
  - set a max width to the organisation logo
  - show organisation name
- add `visibility` and `inviteOnly` information to team cards
- add management submenu on all management pages
- Link UserAvatars
- remove `Add+` button from edit team/organisation pages