### PR TITLE
improve responsiveness of explore projects page

### DIFF
--- a/frontend/src/components/projectcard/projectCard.js
+++ b/frontend/src/components/projectcard/projectCard.js
@@ -105,10 +105,10 @@ export function ProjectCard({
       <Link className={`no-underline color-inherit `} to={`/projects/${projectId}`}>
         <article className={``}>
           <div className={`${bottomButtonSpacer} ph3 ba br1 b--grey-light bg-white shadow-hover`}>
-            <div className="mt3 w-33 fr">
-              <PriorityBox priority={priority} extraClasses={'pv1 ph2'} />
+            <div className="mt3 fr">
+              <PriorityBox priority={priority} extraClasses={'pv1 ph2 dib'} />
             </div>
-            <div className="w-50 red dib">
+            <div className="w-50 cf red dib">
               <img
                 className="h2 mw4 pa1"
                 src={organisationLogo}
@@ -116,8 +116,8 @@ export function ProjectCard({
               />
             </div>
             <div className="ma1 w-100">
-              <div className="f7 blue-grey">#{projectId}</div>
-              <h3 title={name} className="pb2 f5 fw6 h3 lh-title overflow-y-hidden">
+              <div className="f7 blue-grey mt2">#{projectId}</div>
+              <h3 title={name} className="pb2 mt2 f5 fw6 h3 lh-title overflow-y-hidden">
                 {name}
               </h3>
               <div className="tc f6">

--- a/frontend/src/components/projects/projectNav.js
+++ b/frontend/src/components/projects/projectNav.js
@@ -81,7 +81,7 @@ export const ProjectNav = props => {
     /* mb1 mb2-ns (removed for map, but now small gap for more-filters) */
     <header className="bt bb b--tan w-100 ">
       <div className="mt2 mb1 ph2 dib lh-copy w-100 cf">
-        <div className="w-90-ns w-100 fl dib">
+        <div className="w-80-l w-90-m w-100 fl dib">
           <div className="dib">
             <div className="mv2 dib">
               <DifficultyDropdown setQuery={setQuery} fullProjectsQuery={fullProjectsQuery} />
@@ -112,7 +112,7 @@ export const ProjectNav = props => {
             />
           </div>
         </div>
-        <div className="w-10-ns w-100 fr">
+        <div className="w-20-l w-10-m w-100 fr">
           <ShowMapToggle />
         </div>
       </div>


### PR DESCRIPTION
- on project cards 
  - avoid priority text going out of the box 
 - give more space between org logo and project id
- on nav bar, avoid `show map` from going to the top of the toggle switch + set more breakpoints