### PR TITLE
update permissions to the new schema based on teams and/or level

### DIFF
--- a/frontend/src/components/projectDetail/index.js
+++ b/frontend/src/components/projectDetail/index.js
@@ -250,8 +250,8 @@ export const ProjectDetail = props => {
         <FormattedMessage {...messages.teams} />
       </h3>
       <div className="ph4 mb3 cf db">
-        {props.project.projectTeams && props.project.projectTeams.length ? (
-          <TeamsBoxList teams={props.project.projectTeams} />
+        {props.project.teams && props.project.teams.length ? (
+          <TeamsBoxList teams={props.project.teams} />
         ) : (
           <FormattedMessage {...messages.noProjectTeams} />
         )}

--- a/frontend/src/components/projectEdit/messages.js
+++ b/frontend/src/components/projectEdit/messages.js
@@ -4,8 +4,62 @@ import { defineMessages } from 'react-intl';
  * Internationalized messages for use on project edit.
  */
 export default defineMessages({
+  privacy: {
+    id: 'formInputs.privacy.title',
+    defaultMessage: 'Privacy',
+  },
+  privacyDescription: {
+    id: 'formInputs.privacy.description',
+    defaultMessage:
+      'Private means that only the users that are project team members can access, map or validate this project. This option overrides the mapping and validation permissions.',
+  },
+  teams: {
+    id: 'formInputs.teams.title',
+    defaultMessage: 'Teams',
+  },
+  organisation: {
+    id: 'formInputs.organisation.title',
+    defaultMessage: 'Organisation',
+  },
+  organisationDescription: {
+    id: 'formInputs.organisation.description',
+    defaultMessage:
+      'Organisation that is coordinating the project, if there is any. The managers of that organisation will have administration rights over the project.',
+  },
   selectOrganisation: {
     id: 'formInputs.organisation.select',
     defaultMessage: 'Select organisation',
+  },
+  permissions_ANY: {
+    id: 'formInputs.permissions.any',
+    defaultMessage: 'Any user',
+  },
+  permissions_LEVEL: {
+    id: 'formInputs.permissions.level',
+    defaultMessage: 'Only users with intermediate or advanced level',
+  },
+  permissions_TEAMS: {
+    id: 'formInputs.permissions.teams',
+    defaultMessage: 'Only team members',
+  },
+  permissions_TEAMS_LEVEL: {
+    id: 'formInputs.permissions.teamsAndLevel',
+    defaultMessage: 'Only intermediate and advanced team members',
+  },
+  mappingPermissionDescription: {
+    id: 'formInputs.permissions.mapping.description',
+    defaultMessage: 'Define which users can map this project.',
+  },
+  validationPermissionDescription: {
+    id: 'formInputs.permissions.validation.description',
+    defaultMessage: 'Define which users can validate this project.',
+  },
+  mappingPermission: {
+    id: 'formInputs.permissions.mapping.title',
+    defaultMessage: 'Mapping permissions',
+  },
+  validationPermission: {
+    id: 'formInputs.permissions.validation.title',
+    defaultMessage: 'Validation permissions',
   },
 });

--- a/frontend/src/components/projectEdit/permissionsForm.js
+++ b/frontend/src/components/projectEdit/permissionsForm.js
@@ -1,6 +1,5 @@
 import React, { useContext, useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import Popup from 'reactjs-popup';
 import Select from 'react-select';
 import { FormattedMessage } from 'react-intl';
 
@@ -9,12 +8,9 @@ import { SwitchToggle } from '../formInputs';
 import { StateContext, styleClasses } from '../../views/projectEdit';
 import { TeamSelect } from './teamSelect';
 import { fetchLocalJSONAPI } from '../../network/genericJSONRequest';
-import { API_URL } from '../../config';
 
 export const PermissionsForm = () => {
   const { projectInfo, setProjectInfo } = useContext(StateContext);
-  const [users, setUsers] = useState([]);
-  const [searchUser, setsearchUser] = useState('');
   const userDetails = useSelector(state => state.auth.get('userDetails'));
   const [organisations, setOrganisations] = useState([]);
   useEffect(() => {
@@ -26,104 +22,72 @@ export const PermissionsForm = () => {
     }
   }, [userDetails]);
 
-  const handleUsers = e => {
-    const fetchUsers = async user => {
-      const res = await fetch(`${API_URL}users/queries/filter/${user}`);
-      if (res.status === 200) {
-        const res_json = await res.json();
-        setUsers(res_json.usernames);
-      } else {
-        setUsers([]);
-      }
-    };
-
-    const user = e.target.value;
-    setsearchUser(user);
-    fetchUsers(user);
-  };
-
-  const appendUser = user => {
-    let selectedUsers = projectInfo.allowedUsernames;
-    if (selectedUsers.includes(user) === false) {
-      selectedUsers.push(user);
-      setProjectInfo({ ...projectInfo, allowedUsernames: selectedUsers });
-    }
-    setsearchUser('');
-    setUsers([]);
-  };
-
-  const removeUser = user => {
-    let selectedUsers = projectInfo.allowedUsernames;
-    selectedUsers = selectedUsers.filter(u => u !== user);
-
-    setProjectInfo({ ...projectInfo, allowedUsernames: selectedUsers });
-    setsearchUser('');
-    setUsers([]);
-  };
+  const permissions = [
+    { label: <FormattedMessage {...messages.permissions_ANY} />, value: 'ANY' },
+    { label: <FormattedMessage {...messages.permissions_LEVEL} />, value: 'LEVEL' },
+    { label: <FormattedMessage {...messages.permissions_TEAMS} />, value: 'TEAMS' },
+    { label: <FormattedMessage {...messages.permissions_TEAMS_LEVEL} />, value: 'TEAMS_LEVEL' },
+  ];
 
   return (
     <div className="w-100">
       <div className={styleClasses.divClass}>
-        <label className={styleClasses.labelClass}>Mappers</label>
-        <SwitchToggle
-          label={'Only mappers with experience level BEGINNER or higher can map'}
-          labelPosition="right"
-          isChecked={projectInfo.restrictMappingLevelToProject}
-          onChange={() =>
-            setProjectInfo({
-              ...projectInfo,
-              restrictMappingLevelToProject: !projectInfo.restrictMappingLevelToProject,
-            })
-          }
-        />
-        <p className={styleClasses.pClass}>
-          If checked, only users with the listed mapper experience level will be able to contribute
-          to this project. If unchecked, anyone can contribute. Go to the Metadata panel to change
-          the mapper experience level for this project.
-        </p>
-      </div>
-      <div className={styleClasses.divClass}>
-        <label className={styleClasses.labelClass}>Validators</label>
-        <SwitchToggle
-          label={'Only users with validator role or higher'}
-          labelPosition="right"
-          isChecked={projectInfo.restrictValidationRole}
-          onChange={() =>
-            setProjectInfo({
-              ...projectInfo,
-              restrictValidationRole: !projectInfo.restrictValidationRole,
-            })
-          }
-        />
-        <p className={`styleClasses.pClass pb2`}>
-          If checked, only users with the Validator or a higher role will be able to validate tasks
-          in this project. If unchecked, anyone can validate or invalidate tasks.
-        </p>
-
-        <label className={styleClasses.pClass}>
-          <SwitchToggle
-            label={'Require experience level INTERMEDIATE or ADVANCED'}
-            labelPosition="right"
-            isChecked={projectInfo.restrictValidationLevelIntermediate}
-            onChange={() =>
-              setProjectInfo({
-                ...projectInfo,
-                restrictValidationLevelIntermediate: !projectInfo.restrictValidationLevelIntermediate,
-              })
-            }
-          />
+        <label className={styleClasses.labelClass}>
+          <FormattedMessage {...messages.mappingPermission} />
         </label>
         <p className={styleClasses.pClass}>
-          If checked, only users with the experience level of Intermediate and Advanced will be able
-          to validate tasks in this project.
+          <FormattedMessage {...messages.mappingPermissionDescription} />
         </p>
+        {permissions.map(permission => (
+          <label className="db pv2" key={permission}>
+            <input
+              value={permission.value}
+              checked={projectInfo.mapping_permission === permission.value}
+              onChange={() =>
+                setProjectInfo({
+                  ...projectInfo,
+                  mapping_permission: permission.value,
+                })
+              }
+              type="radio"
+              className={`radio-input input-reset pointer v-mid dib h2 w2 mr2 br-100 ba b--blue-light`}
+            />
+            {permission.label}
+          </label>
+        ))}
+      </div>
+      <div className={styleClasses.divClass}>
+        <label className={styleClasses.labelClass}>
+          <FormattedMessage {...messages.validationPermission} />
+        </label>
+        <p className={styleClasses.pClass}>
+          <FormattedMessage {...messages.validationPermissionDescription} />
+        </p>
+        {permissions.map(permission => (
+          <label className="db pv2" key={permission}>
+            <input
+              value={permission.value}
+              checked={projectInfo.validation_permission === permission.value}
+              onChange={() =>
+                setProjectInfo({
+                  ...projectInfo,
+                  validation_permission: permission.value,
+                })
+              }
+              type="radio"
+              className={`radio-input input-reset pointer v-mid dib h2 w2 mr2 br-100 ba b--blue-light`}
+            />
+            {permission.label}
+          </label>
+        ))}
       </div>
 
       <div className={styleClasses.divClass}>
-        <label className={styleClasses.labelClass}>Organisation</label>
+        <label className={styleClasses.labelClass}>
+          <FormattedMessage {...messages.organisation} />
+        </label>
         <p className={styleClasses.pClass}>
-          Organisation that is coordinating the project, if there is any. The managers of that
-          organisation will have administration rights over the project.
+          <FormattedMessage {...messages.organisationDescription} />
         </p>
         <Select
           isClearable={false}
@@ -145,58 +109,25 @@ export const PermissionsForm = () => {
       </div>
 
       <div className={styleClasses.divClass.replace('w-70', 'w-90')}>
-        <label className={styleClasses.labelClass}>Teams</label>
+        <label className={styleClasses.labelClass}>
+          <FormattedMessage {...messages.teams} />
+        </label>
         <TeamSelect />
       </div>
 
       <div className={styleClasses.divClass}>
-        <label className={styleClasses.labelClass}>Privacy</label>
+        <label className={styleClasses.labelClass}>
+          <FormattedMessage {...messages.privacy} />
+        </label>
+        <p className={styleClasses.pClass}>
+          <FormattedMessage {...messages.privacyDescription} />
+        </p>
         <SwitchToggle
           label={'Private project'}
           labelPosition="right"
           isChecked={projectInfo.private}
           onChange={() => setProjectInfo({ ...projectInfo, private: !projectInfo.private })}
         />
-
-        <p className={styleClasses.pClass}>
-          Private means that only the given list of users below can access this project. Before a
-          user name can be added to the Allowed Users list the user must first login to this
-          installation of OSM Tasking Manager.
-        </p>
-      </div>
-      <div className={styleClasses.divClass}>
-        <label className={styleClasses.labelClass}>Allowed users on private project</label>
-        {projectInfo.allowedUsernames ? (
-          <div>
-            <p className="f7">
-              <b>Note.</b>Click to remove
-            </p>
-            <ul className="list pa0 dib mv1">
-              {projectInfo.allowedUsernames.map(u => (
-                <li onClick={() => removeUser(u)} className="ph3 pv2 mb2 dib white bg-navy fl mr2 ">
-                  {u}
-                </li>
-              ))}
-            </ul>
-          </div>
-        ) : null}
-
-        <Popup
-          contentStyle={{ padding: 0, border: 0 }}
-          arrow={false}
-          trigger={
-            <input value={searchUser} onChange={handleUsers} className="w-50 pa2" type="text" />
-          }
-          on="focus"
-          position="bottom left"
-          open={users.length !== 0 ? true : false}
-        >
-          <div>
-            {users.map(u => (
-              <span onClick={() => appendUser(u)}>{u}</span>
-            ))}
-          </div>
-        </Popup>
       </div>
     </div>
   );

--- a/frontend/src/components/projectEdit/teamSelect.js
+++ b/frontend/src/components/projectEdit/teamSelect.js
@@ -34,7 +34,7 @@ export const TeamSelect = () => {
   };
 
   const editTeam = id => {
-    const team = projectInfo.projectTeams.filter(t => t.teamId === id)[0];
+    const team = projectInfo.teams.filter(t => t.teamId === id)[0];
     const role = teamRoles.filter(r => team.role === r.value)[0];
 
     setTeamSelect(t => {
@@ -43,8 +43,8 @@ export const TeamSelect = () => {
   };
 
   const removeTeam = id => {
-    const teams = projectInfo.projectTeams.filter(t => t.teamId !== id);
-    setProjectInfo({ ...projectInfo, projectTeams: teams });
+    const teams = projectInfo.teams.filter(t => t.teamId !== id);
+    setProjectInfo({ ...projectInfo, teams: teams });
   };
 
   const newTeam = () => {
@@ -56,21 +56,21 @@ export const TeamSelect = () => {
   };
 
   const addTeam = () => {
-    const teams = projectInfo.projectTeams;
+    const teams = projectInfo.teams;
     teams.push(newTeam());
-    setProjectInfo({ ...projectInfo, projectTeams: teams });
+    setProjectInfo({ ...projectInfo, teams: teams });
     setTeamSelect(nullState);
   };
 
   const updateTeam = () => {
-    const teams = projectInfo.projectTeams.map(t => {
+    const teams = projectInfo.teams.map(t => {
       let item = t;
       if (t.teamId === teamSelect.team.teamId) {
         item = newTeam();
       }
       return item;
     });
-    setProjectInfo({ ...projectInfo, projectTeams: teams });
+    setProjectInfo({ ...projectInfo, teams: teams });
     setTeamSelect(nullState);
   };
 
@@ -81,7 +81,7 @@ export const TeamSelect = () => {
   };
 
   // Get only ids.
-  const teamsIds = projectInfo.projectTeams.map(t => {
+  const teamsIds = projectInfo.teams.map(t => {
     return t.teamId;
   });
 
@@ -103,7 +103,7 @@ export const TeamSelect = () => {
   return (
     <div className="w-80">
       <div className="mb4">
-        {projectInfo.projectTeams.map(t => {
+        {projectInfo.teams.map(t => {
           return (
             <div className="w-100 cf pa2 bg-white blue-dark mb2">
               <div className="w-50 fl fw5">{t.name}</div>

--- a/frontend/src/components/projectEdit/teamSelect.js
+++ b/frontend/src/components/projectEdit/teamSelect.js
@@ -2,7 +2,7 @@ import React, { useState, useContext, useEffect } from 'react';
 import { Button } from '../../components/button';
 import Select from 'react-select';
 import { StateContext } from '../../views/projectEdit';
-import { PencilIcon, WasteIcon } from '../svgIcons';
+import { PencilIcon, WasteIcon, LinkIcon } from '../svgIcons';
 import { fetchLocalJSONAPI } from '../../network/genericJSONRequest';
 
 export const TeamSelect = () => {
@@ -106,7 +106,17 @@ export const TeamSelect = () => {
         {projectInfo.teams.map(t => {
           return (
             <div className="w-100 cf pa2 bg-white blue-dark mb2">
-              <div className="w-50 fl fw5">{t.name}</div>
+              <div className="w-50 fl fw5">
+                <span className="pr1">{t.name}</span>
+                <a
+                  className="link blue-light"
+                  href={`/teams/${t.teamId}/membership/`}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  <LinkIcon />
+                </a>
+              </div>
               <div className="w-30 fl">{getLabel(t.role)}</div>
               <div className="w-20 fl pl3 tr">
                 <span

--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -60,6 +60,11 @@ export function TaskSelection({ project, type, loading }: Object) {
     `projects/${project.projectId}/activities/latest/`,
     60000,
   );
+  /* eslint-disable-next-line */
+  const [userTeamsError, userTeamsLoading, userTeams] = useFetch(
+    `teams/?member=${user.id}`,
+    user.id,
+  );
 
   // if the user is a beginner, open the page with the instructions tab activated
   useEffect(() => {
@@ -87,11 +92,20 @@ export function TaskSelection({ project, type, loading }: Object) {
         dispatch({ type: 'SET_TASKS_STATUS', status: lockedByCurrentUser[0].taskStatus });
       } else {
         // otherwise we check if the user can map or validate the project
-        setTaskAction(getTaskAction(user, project, null));
+        setTaskAction(getTaskAction(user, project, null, userTeams.teams));
       }
       setMapInit(true);
     }
-  }, [lockedTasks, dispatch, initialActivities, user.username, mapInit, project, user]);
+  }, [
+    lockedTasks,
+    dispatch,
+    initialActivities,
+    user.username,
+    mapInit,
+    project,
+    user,
+    userTeams.teams,
+  ]);
 
   // refresh the task status on the map each time the activities are updated
   useEffect(() => {
@@ -118,7 +132,7 @@ export function TaskSelection({ project, type, loading }: Object) {
       // unselecting tasks
       if (selected.includes(selection)) {
         setSelectedTasks([]);
-        setTaskAction(getTaskAction(user, project, null));
+        setTaskAction(getTaskAction(user, project, null, userTeams.teams));
       } else {
         setSelectedTasks([selection]);
         if (lockedTasks.get('tasks').includes(selection)) {
@@ -128,7 +142,7 @@ export function TaskSelection({ project, type, loading }: Object) {
               : 'resumeValidation',
           );
         } else {
-          setTaskAction(getTaskAction(user, project, status));
+          setTaskAction(getTaskAction(user, project, status, userTeams.teams));
         }
       }
     }

--- a/frontend/src/utils/projectPermissions.js
+++ b/frontend/src/utils/projectPermissions.js
@@ -17,21 +17,21 @@ export function userCanMap(user, project, userTeams = []) {
     }
   }
 
-  // if mappingPermission is any, all users can map
-  if (project.mappingPermission === 'any') return true;
+  // if mappingPermission is ANY, all users can map
+  if (project.mappingPermission === 'ANY') return true;
 
   // if mappingPermission is level, only INTERMEDIATE and ADVANCED users can map
-  if (project.mappingPermission === 'level') {
+  if (project.mappingPermission === 'LEVEL') {
     return isUserExperienced;
   }
 
   // if mappingPermission is team, only members of a project team can map
-  if (project.mappingPermission === 'teams') {
+  if (project.mappingPermission === 'TEAMS') {
     return isUserMemberOfATeam;
   }
 
   // if mappingPermission is team, only INTERMEDIATE and ADVANCED members of a project team can map
-  if (project.mappingPermission === 'teamsAndLevel') {
+  if (project.mappingPermission === 'TEAMS_LEVEL') {
     return isUserMemberOfATeam && isUserExperienced;
   }
 }
@@ -55,21 +55,21 @@ export function userCanValidate(user, project, userTeams = []) {
     }
   }
 
-  // if validationPermission is any, all users can validate
-  if (project.validationPermission === 'any') return true;
+  // if validationPermission is ANY, all users can validate
+  if (project.validationPermission === 'ANY') return true;
 
   // if validationPermission is level, only INTERMEDIATE and ADVANCED users can validate
-  if (project.validationPermission === 'level') {
+  if (project.validationPermission === 'LEVEL') {
     return isUserExperienced;
   }
 
   // if validationPermission is team, only members of a project team can validate
-  if (project.validationPermission === 'teams') {
+  if (project.validationPermission === 'TEAMS') {
     return isUserMemberOfATeam;
   }
 
   // if validationPermission is team, only INTERMEDIATE and ADVANCED members of a project team can validate
-  if (project.validationPermission === 'teamsAndLevel') {
+  if (project.validationPermission === 'TEAMS_LEVEL') {
     return isUserMemberOfATeam && isUserExperienced;
   }
 }

--- a/frontend/src/utils/projectPermissions.js
+++ b/frontend/src/utils/projectPermissions.js
@@ -1,40 +1,77 @@
-export function userCanMap(user, project) {
+export function userCanMap(user, project, userTeams = []) {
   if (user.role === 'READ_ONLY') return false;
-  if (project.private && !project.allowedUsernames.includes(user.username)) {
-    return false;
-  }
-  if (project.restrictMappingLevelToProject === false) return true;
+  if (user.role === 'ADMIN') return true;
+  const projectTeamsIds = project.teams
+    .filter(team => ['MAPPER', 'VALIDATOR', 'PROJECT_MANAGER'].includes(team.role))
+    .map(team => team.teamId);
+  const isUserMemberOfATeam =
+    userTeams.filter(team => projectTeamsIds.includes(team.teamId)).length > 0;
+  const isUserExperienced = ['INTERMEDIATE', 'ADVANCED'].includes(user.mappingLevel);
 
-  const levels = { BEGINNER: 1, INTERMEDIATE: 2, ADVANCED: 3 };
-  if (levels[user.mappingLevel] < levels[project.mapperLevel]) {
-    return false;
-  } else {
-    return true;
+  // check for private projects
+  if (project.private) {
+    if (project.allowedUsernames.includes(user.username) || isUserMemberOfATeam) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  // if mappingPermission is any, all users can map
+  if (project.mappingPermission === 'any') return true;
+
+  // if mappingPermission is level, only INTERMEDIATE and ADVANCED users can map
+  if (project.mappingPermission === 'level') {
+    return isUserExperienced;
+  }
+
+  // if mappingPermission is team, only members of a project team can map
+  if (project.mappingPermission === 'teams') {
+    return isUserMemberOfATeam;
+  }
+
+  // if mappingPermission is team, only INTERMEDIATE and ADVANCED members of a project team can map
+  if (project.mappingPermission === 'teamsAndLevel') {
+    return isUserMemberOfATeam && isUserExperienced;
   }
 }
 
-export function userCanValidate(user, project) {
+export function userCanValidate(user, project, userTeams = []) {
   if (user.role === 'READ_ONLY') return false;
-  if (project.private && !project.allowedUsernames.includes(user.username)) {
-    return false;
-  }
-  let userRolePermission = true;
-  let userLevelPermission = true;
-  if (project.restrictValidationRole) {
-    if (['ADMIN', 'PROJECT_MANAGER', 'VALIDATOR'].includes(user.role)) {
-      userRolePermission = true;
+  if (user.role === 'ADMIN') return true;
+  const projectTeamsIds = project.teams
+    .filter(team => ['VALIDATOR', 'PROJECT_MANAGER'].includes(team.role))
+    .map(team => team.teamId);
+  const isUserMemberOfATeam =
+    userTeams.filter(team => projectTeamsIds.includes(team.teamId)).length > 0;
+  const isUserExperienced = ['INTERMEDIATE', 'ADVANCED'].includes(user.mappingLevel);
+
+  // check for private projects
+  if (project.private) {
+    if (project.allowedUsernames.includes(user.username) || isUserMemberOfATeam) {
+      return true;
     } else {
-      userRolePermission = false;
+      return false;
     }
   }
-  if (project.restrictValidationLevelIntermediate) {
-    if (['INTERMEDIATE', 'ADVANCED'].includes(user.mappingLevel)) {
-      userLevelPermission = true;
-    } else {
-      userLevelPermission = false;
-    }
+
+  // if validationPermission is any, all users can validate
+  if (project.validationPermission === 'any') return true;
+
+  // if validationPermission is level, only INTERMEDIATE and ADVANCED users can validate
+  if (project.validationPermission === 'level') {
+    return isUserExperienced;
   }
-  return userRolePermission && userLevelPermission;
+
+  // if validationPermission is team, only members of a project team can validate
+  if (project.validationPermission === 'teams') {
+    return isUserMemberOfATeam;
+  }
+
+  // if validationPermission is team, only INTERMEDIATE and ADVANCED members of a project team can validate
+  if (project.validationPermission === 'teamsAndLevel') {
+    return isUserMemberOfATeam && isUserExperienced;
+  }
 }
 
 export function getMessageOnMappingContext(taskStatus) {
@@ -61,14 +98,14 @@ export function getMessageOnValidationContext(mappingIsPossible, taskStatus) {
   return 'validateATask';
 }
 
-export function getTaskAction(user, project, taskStatus) {
+export function getTaskAction(user, project, taskStatus, userTeams = []) {
   // nothing more to do if all tasks are validated or set as BADIMAGERY
   if (project.percentValidated + project.percentBadImagery === 100) {
     return 'projectIsComplete';
   }
-  const validationIsPossible = userCanValidate(user, project);
+  const validationIsPossible = userCanValidate(user, project, userTeams);
   const mappingIsPossible =
-    userCanMap(user, project) && project.percentMapped + project.percentBadImagery < 100;
+    userCanMap(user, project, userTeams) && project.percentMapped + project.percentBadImagery < 100;
 
   if (validationIsPossible) {
     return getMessageOnValidationContext(mappingIsPossible, taskStatus);

--- a/frontend/src/utils/tests/permissionsToMap.test.js
+++ b/frontend/src/utils/tests/permissionsToMap.test.js
@@ -9,10 +9,10 @@ it('READ_ONLY role USER can NOT map any project', () => {
     },
   ];
   const user = { mappingLevel: 'ADVANCED', role: 'READ_ONLY' };
-  const project1 = { mappingPermission: 'any', teams: [{ teamId: 7, role: 'MAPPER' }] };
-  const project2 = { mappingPermission: 'teams', teams: [{ teamId: 7, role: 'MAPPER' }] };
-  const project3 = { mappingPermission: 'level', teams: [{ teamId: 7, role: 'MAPPER' }] };
-  const project4 = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 7, role: 'MAPPER' }] };
+  const project1 = { mappingPermission: 'ANY', teams: [{ teamId: 7, role: 'MAPPER' }] };
+  const project2 = { mappingPermission: 'TEAMS', teams: [{ teamId: 7, role: 'MAPPER' }] };
+  const project3 = { mappingPermission: 'LEVEL', teams: [{ teamId: 7, role: 'MAPPER' }] };
+  const project4 = { mappingPermission: 'TEAMS_LEVEL', teams: [{ teamId: 7, role: 'MAPPER' }] };
   expect(userCanMap(user, project1, userTeams)).toBe(false);
   expect(userCanMap(user, project2, userTeams)).toBe(false);
   expect(userCanMap(user, project3, userTeams)).toBe(false);
@@ -22,8 +22,8 @@ it('READ_ONLY role USER can NOT map any project', () => {
 describe('PROJECTS with mappingPermission set to any', () => {
   it('CAN be mapped by a BEGINNER user that is not on a team', () => {
     const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'any', teams: [] };
-    const project2 = { mappingPermission: 'any', teams: [{ teamId: 7, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'ANY', teams: [] };
+    const project2 = { mappingPermission: 'ANY', teams: [{ teamId: 7, role: 'MAPPER' }] };
     expect(userCanMap(user, project1)).toBe(true);
     expect(userCanMap(user, project2)).toBe(true);
   });
@@ -39,7 +39,7 @@ describe('PROJECTS with mappingPermission set to level', () => {
       },
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'level', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'LEVEL', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(false);
   });
 
@@ -52,13 +52,13 @@ describe('PROJECTS with mappingPermission set to level', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'level', teams: [{ teamId: 7, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'LEVEL', teams: [{ teamId: 7, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(true);
   });
 
   it('CAN be mapped by an ADVANCED level USER', () => {
     const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-    const project = { mappingPermission: 'level', teams: [{ teamId: 7, role: 'MAPPER' }] };
+    const project = { mappingPermission: 'LEVEL', teams: [{ teamId: 7, role: 'MAPPER' }] };
     expect(userCanMap(user, project)).toBe(true);
   });
 });
@@ -73,9 +73,9 @@ describe('PROJECTS with mappingPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
-    const project2 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
-    const project3 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project2 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project3 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(true);
     expect(userCanMap(user, project2, userTeams)).toBe(true);
     expect(userCanMap(user, project3, userTeams)).toBe(true);
@@ -90,9 +90,9 @@ describe('PROJECTS with mappingPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
-    const project2 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
-    const project3 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project2 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project3 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(true);
     expect(userCanMap(user, project2, userTeams)).toBe(true);
     expect(userCanMap(user, project3, userTeams)).toBe(true);
@@ -107,7 +107,7 @@ describe('PROJECTS with mappingPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-    const project = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project, userTeams)).toBe(true);
   });
 
@@ -120,7 +120,7 @@ describe('PROJECTS with mappingPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(false);
   });
 
@@ -133,7 +133,7 @@ describe('PROJECTS with mappingPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(false);
   });
 
@@ -146,7 +146,7 @@ describe('PROJECTS with mappingPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(false);
   });
 });
@@ -171,13 +171,13 @@ describe('PROJECTS with mappingPermission set to teamsAndLevel', () => {
       },
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'TEAMS_LEVEL', teams: [{ teamId: 1, role: 'MAPPER' }] };
     const project2 = {
-      mappingPermission: 'teamsAndLevel',
+      mappingPermission: 'TEAMS_LEVEL',
       teams: [{ teamId: 2, role: 'VALIDATOR' }],
     };
     const project3 = {
-      mappingPermission: 'teamsAndLevel',
+      mappingPermission: 'TEAMS_LEVEL',
       teams: [{ teamId: 3, role: 'PROJECT_MANAGER' }],
     };
     expect(userCanMap(user, project1, userTeams)).toBe(false);
@@ -204,13 +204,13 @@ describe('PROJECTS with mappingPermission set to teamsAndLevel', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'TEAMS_LEVEL', teams: [{ teamId: 1, role: 'MAPPER' }] };
     const project2 = {
-      mappingPermission: 'teamsAndLevel',
+      mappingPermission: 'TEAMS_LEVEL',
       teams: [{ teamId: 2, role: 'VALIDATOR' }],
     };
     const project3 = {
-      mappingPermission: 'teamsAndLevel',
+      mappingPermission: 'TEAMS_LEVEL',
       teams: [{ teamId: 3, role: 'PROJECT_MANAGER' }],
     };
     expect(userCanMap(user, project1, userTeams)).toBe(true);
@@ -227,7 +227,7 @@ describe('PROJECTS with mappingPermission set to teamsAndLevel', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'TEAMS_LEVEL', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(false);
   });
 
@@ -240,7 +240,7 @@ describe('PROJECTS with mappingPermission set to teamsAndLevel', () => {
       },
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-    const project = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project = { mappingPermission: 'TEAMS_LEVEL', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project, userTeams)).toBe(true);
   });
 
@@ -253,7 +253,7 @@ describe('PROJECTS with mappingPermission set to teamsAndLevel', () => {
       },
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-    const project = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project = { mappingPermission: 'TEAMS_LEVEL', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project, userTeams)).toBe(false);
   });
 });
@@ -264,7 +264,7 @@ describe('PRIVATE projects', () => {
     const user = { username: 'user1', mappingLevel: 'ADVANCED', role: 'READ_ONLY' };
     const project = {
       private: true,
-      mappingPermission: 'teams',
+      mappingPermission: 'TEAMS',
       allowedUsernames: ['user1'],
       teams: [],
     };
@@ -274,7 +274,7 @@ describe('PRIVATE projects', () => {
   it('can NOT be mapped by an ADVANCED user if their username is NOT ALLOWED', () => {
     const user = { username: 'user3000', mappingLevel: 'ADVANCED', role: 'MAPPER' };
     const project = {
-      mappingPermission: 'teams',
+      mappingPermission: 'TEAMS',
       private: true,
       allowedUsernames: ['user1'],
       teams: [],
@@ -285,7 +285,7 @@ describe('PRIVATE projects', () => {
   it('CAN be mapped by a BEGINNER USER if their username is ALLOWED', () => {
     const user = { username: 'user1', mappingLevel: 'BEGINNER', role: 'MAPPER' };
     const project = {
-      mappingPermission: 'teams',
+      mappingPermission: 'TEAMS',
       private: true,
       allowedUsernames: ['user1'],
       teams: [],
@@ -303,7 +303,7 @@ describe('PRIVATE projects', () => {
     ];
     const user = { username: 'user1', mappingLevel: 'BEGINNER', role: 'MAPPER' };
     const project = {
-      mappingPermission: 'teams',
+      mappingPermission: 'TEAMS',
       private: true,
       allowedUsernames: [],
       teams: [{ teamId: 1, role: 'MAPPER' }],

--- a/frontend/src/utils/tests/permissionsToMap.test.js
+++ b/frontend/src/utils/tests/permissionsToMap.test.js
@@ -1,176 +1,313 @@
 import { userCanMap } from '../projectPermissions';
 
-it('READ_ONLY role USER can NOT map', () => {
+it('READ_ONLY role USER can NOT map any project', () => {
+  const userTeams = [
+    {
+      teamId: 7,
+      name: 'My Private team',
+      role: 'MAPPER',
+    },
+  ];
   const user = { mappingLevel: 'ADVANCED', role: 'READ_ONLY' };
-  const project = { mapperLevel: 'BEGINNER' };
-  expect(userCanMap(user, project)).toBe(false);
+  const project1 = { mappingPermission: 'any', teams: [{ teamId: 7, role: 'MAPPER' }] };
+  const project2 = { mappingPermission: 'teams', teams: [{ teamId: 7, role: 'MAPPER' }] };
+  const project3 = { mappingPermission: 'level', teams: [{ teamId: 7, role: 'MAPPER' }] };
+  const project4 = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 7, role: 'MAPPER' }] };
+  expect(userCanMap(user, project1, userTeams)).toBe(false);
+  expect(userCanMap(user, project2, userTeams)).toBe(false);
+  expect(userCanMap(user, project3, userTeams)).toBe(false);
+  expect(userCanMap(user, project4, userTeams)).toBe(false);
 });
 
-/****  ENFORCED LEVEL PROJECTS  ****/
-it('BEGINNER level USER can map a BEGINNER PROJECT', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-  const project = { restrictMappingLevelToProject: true, mapperLevel: 'BEGINNER' };
-  expect(userCanMap(user, project)).toBe(true);
+describe('PROJECTS with mappingPermission set to any', () => {
+  it('CAN be mapped by a BEGINNER user that is not on a team', () => {
+    const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
+    const project1 = { mappingPermission: 'any', teams: [] };
+    const project2 = { mappingPermission: 'any', teams: [{ teamId: 7, role: 'MAPPER' }] };
+    expect(userCanMap(user, project1)).toBe(true);
+    expect(userCanMap(user, project2)).toBe(true);
+  });
 });
 
-it('INTERMEDIATE level USER can map a BEGINNER PROJECT', () => {
-  const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-  const project = { restrictMappingLevelToProject: true, mapperLevel: 'BEGINNER' };
-  expect(userCanMap(user, project)).toBe(true);
+describe('PROJECTS with mappingPermission set to level', () => {
+  it('can NOT be mapped by a BEGINNER level USER', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'MAPPER',
+      },
+    ];
+    const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
+    const project1 = { mappingPermission: 'level', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    expect(userCanMap(user, project1, userTeams)).toBe(false);
+  });
+
+  it('CAN be mapped by an INTERMEDIATE level USER', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'MAPPER',
+      },
+    ];
+    const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
+    const project1 = { mappingPermission: 'level', teams: [{ teamId: 7, role: 'MAPPER' }] };
+    expect(userCanMap(user, project1, userTeams)).toBe(true);
+  });
+
+  it('CAN be mapped by an ADVANCED level USER', () => {
+    const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
+    const project = { mappingPermission: 'level', teams: [{ teamId: 7, role: 'MAPPER' }] };
+    expect(userCanMap(user, project)).toBe(true);
+  });
 });
 
-it('ADVANCED level USER can map a BEGINNER PROJECT', () => {
-  const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-  const project = { restrictMappingLevelToProject: true, mapperLevel: 'BEGINNER' };
-  expect(userCanMap(user, project)).toBe(true);
+describe('PROJECTS with mappingPermission set as teams', () => {
+  it('CAN be mapped by a BEGINNER level USER if they are member of the team', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'MAPPER',
+      },
+    ];
+    const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
+    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project2 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project3 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    expect(userCanMap(user, project1, userTeams)).toBe(true);
+    expect(userCanMap(user, project2, userTeams)).toBe(true);
+    expect(userCanMap(user, project3, userTeams)).toBe(true);
+  });
+
+  it('CAN be mapped by an INTERMEDIATE level USER if they are member of the team', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'MAPPER',
+      },
+    ];
+    const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
+    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project2 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project3 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    expect(userCanMap(user, project1, userTeams)).toBe(true);
+    expect(userCanMap(user, project2, userTeams)).toBe(true);
+    expect(userCanMap(user, project3, userTeams)).toBe(true);
+  });
+
+  it('CAN be mapped by an ADVANCED level USER', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'MAPPER',
+      },
+    ];
+    const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
+    const project = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    expect(userCanMap(user, project, userTeams)).toBe(true);
+  });
+
+  it('can NOT be mapped by a BEGINNER level USER if they are NOT member of the team', () => {
+    const userTeams = [
+      {
+        teamId: 2,
+        name: 'My Private team',
+        role: 'MAPPER',
+      },
+    ];
+    const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
+    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    expect(userCanMap(user, project1, userTeams)).toBe(false);
+  });
+
+  it('can NOT be mapped by an INTERMEDIATE level USER if they are NOT member of the team', () => {
+    const userTeams = [
+      {
+        teamId: 2,
+        name: 'My Private team',
+        role: 'MAPPER',
+      },
+    ];
+    const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
+    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    expect(userCanMap(user, project1, userTeams)).toBe(false);
+  });
+
+  it('can NOT be mapped by an ADVANCED level USER if they are NOT member of the team', () => {
+    const userTeams = [
+      {
+        teamId: 2,
+        name: 'My Private team',
+        role: 'MAPPER',
+      },
+    ];
+    const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
+    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    expect(userCanMap(user, project1, userTeams)).toBe(false);
+  });
 });
 
-it('BEGINNER level USER can NOT map an INTERMEDIATE PROJECT', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-  const project = { restrictMappingLevelToProject: true, mapperLevel: 'INTERMEDIATE' };
-  expect(userCanMap(user, project)).toBe(false);
-});
+describe('PROJECTS with mappingPermission set to teamsAndLevel', () => {
+  it('can NOT be mapped by a BEGINNER level USER even if they are member of the team', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'MAPPER',
+      },
+      {
+        teamId: 2,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+      {
+        teamId: 3,
+        name: 'My Private team',
+        role: 'PROJECT_MANAGER',
+      },
+    ];
+    const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
+    const project1 = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project2 = {
+      mappingPermission: 'teamsAndLevel',
+      teams: [{ teamId: 2, role: 'VALIDATOR' }],
+    };
+    const project3 = {
+      mappingPermission: 'teamsAndLevel',
+      teams: [{ teamId: 3, role: 'PROJECT_MANAGER' }],
+    };
+    expect(userCanMap(user, project1, userTeams)).toBe(false);
+    expect(userCanMap(user, project2, userTeams)).toBe(false);
+    expect(userCanMap(user, project3, userTeams)).toBe(false);
+  });
 
-it('INTERMEDIATE level USER can map an INTERMEDIATE PROJECT', () => {
-  const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-  const project = { restrictMappingLevelToProject: true, mapperLevel: 'INTERMEDIATE' };
-  expect(userCanMap(user, project)).toBe(true);
-});
+  it('CAN be mapped by an INTERMEDIATE level USER if they are member of the team', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'MAPPER',
+      },
+      {
+        teamId: 2,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+      {
+        teamId: 3,
+        name: 'My Private team',
+        role: 'PROJECT_MANAGER',
+      },
+    ];
+    const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
+    const project1 = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project2 = {
+      mappingPermission: 'teamsAndLevel',
+      teams: [{ teamId: 2, role: 'VALIDATOR' }],
+    };
+    const project3 = {
+      mappingPermission: 'teamsAndLevel',
+      teams: [{ teamId: 3, role: 'PROJECT_MANAGER' }],
+    };
+    expect(userCanMap(user, project1, userTeams)).toBe(true);
+    expect(userCanMap(user, project2, userTeams)).toBe(true);
+    expect(userCanMap(user, project3, userTeams)).toBe(true);
+  });
 
-it('ADVANCED level USER can map an INTERMEDIATE PROJECT', () => {
-  const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-  const project = { restrictMappingLevelToProject: true, mapperLevel: 'INTERMEDIATE' };
-  expect(userCanMap(user, project)).toBe(true);
-});
+  it('can NOT be mapped by an INTERMEDIATE level USER if they are not member of a team', () => {
+    const userTeams = [
+      {
+        teamId: 2,
+        name: 'My Private team',
+        role: 'MAPPER',
+      },
+    ];
+    const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
+    const project1 = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    expect(userCanMap(user, project1, userTeams)).toBe(false);
+  });
 
-it('BEGINNER level USER can NOT map an ADVANCED PROJECT', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-  const project = { restrictMappingLevelToProject: true, mapperLevel: 'ADVANCED' };
-  expect(userCanMap(user, project)).toBe(false);
-});
+  it('CAN be mapped by an ADVANCED level USER if they are member of a team', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'MAPPER',
+      },
+    ];
+    const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
+    const project = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    expect(userCanMap(user, project, userTeams)).toBe(true);
+  });
 
-it('INTERMEDIATE level USER can NOT map an ADVANCED PROJECT', () => {
-  const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-  const project = { restrictMappingLevelToProject: true, mapperLevel: 'ADVANCED' };
-  expect(userCanMap(user, project)).toBe(false);
-});
-
-it('ADVANCED level USER can map an ADVANCED PROJECT', () => {
-  const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-  const project = { restrictMappingLevelToProject: true, mapperLevel: 'ADVANCED' };
-  expect(userCanMap(user, project)).toBe(true);
-});
-
-/* NOT ENFORCED LEVEL PROJECTS */
-it('BEGINNER level USER can map an ADVANCED PROJECT with restrictMappingLevelToProject = false', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-  const project = { restrictMappingLevelToProject: false, mapperLevel: 'ADVANCED' };
-  expect(userCanMap(user, project)).toBe(true);
-});
-
-it('INTERMEDIATE level USER can map an ADVANCED PROJECT with restrictMappingLevelToProject = false', () => {
-  const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-  const project = { restrictMappingLevelToProject: false, mapperLevel: 'ADVANCED' };
-  expect(userCanMap(user, project)).toBe(true);
-});
-
-it('ADVANCED level USER can map an ADVANCED PROJECT with restrictMappingLevelToProject = false', () => {
-  const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-  const project = { restrictMappingLevelToProject: false, mapperLevel: 'ADVANCED' };
-  expect(userCanMap(user, project)).toBe(true);
+  it('can NOT be mapped by an ADVANCED level USER if they are not member of a team', () => {
+    const userTeams = [
+      {
+        teamId: 2,
+        name: 'My Private team',
+        role: 'MAPPER',
+      },
+    ];
+    const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
+    const project = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    expect(userCanMap(user, project, userTeams)).toBe(false);
+  });
 });
 
 /******  PRIVATE PROJECTS  ******/
-it('READ_ONLY role USER can NOT map a PRIVATE project', () => {
-  const user = { username: 'user1', mappingLevel: 'ADVANCED', role: 'READ_ONLY' };
-  const project = { private: true, allowedUsernames: ['user1'], mapperLevel: 'BEGINNER' };
-  expect(userCanMap(user, project)).toBe(false);
-});
+describe('PRIVATE projects', () => {
+  it('can NOT be mapped by a READ_ONLY role USER even if the user is on the list', () => {
+    const user = { username: 'user1', mappingLevel: 'ADVANCED', role: 'READ_ONLY' };
+    const project = {
+      private: true,
+      mappingPermission: 'teams',
+      allowedUsernames: ['user1'],
+      teams: [],
+    };
+    expect(userCanMap(user, project)).toBe(false);
+  });
 
-it('ADVANCED user can NOT map a PRIVATE BEGINNER project if his username is NOT ALLOWED', () => {
-  const user = { username: 'user3000', mappingLevel: 'ADVANCED', role: 'MAPPER' };
-  const project = {
-    restrictMappingLevelToProject: true,
-    private: true,
-    allowedUsernames: ['user1'],
-    mapperLevel: 'BEGINNER',
-  };
-  expect(userCanMap(user, project)).toBe(false);
-});
+  it('can NOT be mapped by an ADVANCED user if their username is NOT ALLOWED', () => {
+    const user = { username: 'user3000', mappingLevel: 'ADVANCED', role: 'MAPPER' };
+    const project = {
+      mappingPermission: 'teams',
+      private: true,
+      allowedUsernames: ['user1'],
+      teams: [],
+    };
+    expect(userCanMap(user, project)).toBe(false);
+  });
 
-it('INTERMEDIATE USER can map a PRIVATE INTERMEDIATE project if his username is ALLOWED', () => {
-  const user = { username: 'user1', mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-  const project = {
-    restrictMappingLevelToProject: true,
-    private: true,
-    allowedUsernames: ['user1'],
-    mapperLevel: 'INTERMEDIATE',
-  };
-  expect(userCanMap(user, project)).toBe(true);
-});
+  it('CAN be mapped by a BEGINNER USER if their username is ALLOWED', () => {
+    const user = { username: 'user1', mappingLevel: 'BEGINNER', role: 'MAPPER' };
+    const project = {
+      mappingPermission: 'teams',
+      private: true,
+      allowedUsernames: ['user1'],
+      teams: [],
+    };
+    expect(userCanMap(user, project)).toBe(true);
+  });
 
-it('INTERMEDIATE USER can NOT map a PRIVATE ADVANCED project if his username is ALLOWED', () => {
-  const user = { username: 'user1', mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-  const project = {
-    restrictMappingLevelToProject: true,
-    private: true,
-    allowedUsernames: ['user1'],
-    mapperLevel: 'ADVANCED',
-  };
-  expect(userCanMap(user, project)).toBe(false);
-});
-
-it('ADVANCED USER can map a PRIVATE ADVANCED project if his username is ALLOWED', () => {
-  const user = { username: 'user1', mappingLevel: 'ADVANCED', role: 'MAPPER' };
-  const project = {
-    restrictMappingLevelToProject: true,
-    private: true,
-    allowedUsernames: ['user1'],
-    mapperLevel: 'ADVANCED',
-  };
-  expect(userCanMap(user, project)).toBe(true);
-});
-
-it('ADVANCED level USER can NOT map a BEGINNER PROJECT with restrictMappingLevelToProject = false if his username is NOT ALLOWED', () => {
-  const user = { username: 'user3000', mappingLevel: 'ADVANCED', role: 'MAPPER' };
-  const project = {
-    restrictMappingLevelToProject: false,
-    private: true,
-    allowedUsernames: ['user1'],
-    mapperLevel: 'BEGINNER',
-  };
-  expect(userCanMap(user, project)).toBe(false);
-});
-
-it('ADVANCED ADMIN USER can NOT map a BEGINNER PROJECT with restrictMappingLevelToProject = false if his username is NOT ALLOWED', () => {
-  const user = { username: 'user3000', mappingLevel: 'ADVANCED', role: 'ADMIN' };
-  const project = {
-    restrictMappingLevelToProject: false,
-    private: true,
-    allowedUsernames: ['user1'],
-    mapperLevel: 'BEGINNER',
-  };
-  expect(userCanMap(user, project)).toBe(false);
-});
-
-it('ADVANCED PROJECT_MANAGER USER can NOT map a BEGINNER PROJECT with restrictMappingLevelToProject = false if his username is NOT ALLOWED', () => {
-  const user = { username: 'user3000', mappingLevel: 'ADVANCED', role: 'PROJECT_MANAGER' };
-  const project = {
-    restrictMappingLevelToProject: false,
-    private: true,
-    allowedUsernames: ['user1'],
-    mapperLevel: 'BEGINNER',
-  };
-  expect(userCanMap(user, project)).toBe(false);
-});
-
-it('ADVANCED VALIDATOR USER can NOT map a BEGINNER PROJECT with restrictMappingLevelToProject = false if his username is NOT ALLOWED', () => {
-  const user = { username: 'user3000', mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
-  const project = {
-    restrictMappingLevelToProject: false,
-    private: true,
-    allowedUsernames: ['user1'],
-    mapperLevel: 'BEGINNER',
-  };
-  expect(userCanMap(user, project)).toBe(false);
+  it('CAN be mapped by a BEGINNER USER if they are part of a team', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'MAPPER',
+      },
+    ];
+    const user = { username: 'user1', mappingLevel: 'BEGINNER', role: 'MAPPER' };
+    const project = {
+      mappingPermission: 'teams',
+      private: true,
+      allowedUsernames: [],
+      teams: [{ teamId: 1, role: 'MAPPER' }],
+    };
+    expect(userCanMap(user, project, userTeams)).toBe(true);
+  });
 });

--- a/frontend/src/utils/tests/permissionsToValidate.test.js
+++ b/frontend/src/utils/tests/permissionsToValidate.test.js
@@ -9,11 +9,11 @@ it('READ_ONLY role USER can NOT validate any project', () => {
     },
   ];
   const user = { mappingLevel: 'ADVANCED', role: 'READ_ONLY' };
-  const project1 = { validationPermission: 'any', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
-  const project2 = { validationPermission: 'teams', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
-  const project3 = { validationPermission: 'level', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+  const project1 = { validationPermission: 'ANY', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+  const project2 = { validationPermission: 'TEAMS', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+  const project3 = { validationPermission: 'LEVEL', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
   const project4 = {
-    validationPermission: 'teamsAndLevel',
+    validationPermission: 'TEAMS_LEVEL',
     teams: [{ teamId: 7, role: 'VALIDATOR' }],
   };
   expect(userCanValidate(user, project1, userTeams)).toBe(false);
@@ -25,8 +25,8 @@ it('READ_ONLY role USER can NOT validate any project', () => {
 describe('PROJECTS with validationPermission set to any', () => {
   it('CAN be validated by a BEGINNER user that is not on a team', () => {
     const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-    const project1 = { validationPermission: 'any', teams: [] };
-    const project2 = { validationPermission: 'any', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'ANY', teams: [] };
+    const project2 = { validationPermission: 'ANY', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project1)).toBe(true);
     expect(userCanValidate(user, project2)).toBe(true);
   });
@@ -42,7 +42,7 @@ describe('PROJECTS with validationPermission set to level', () => {
       },
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
-    const project1 = { validationPermission: 'level', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'LEVEL', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project1, userTeams)).toBe(false);
   });
 
@@ -55,13 +55,13 @@ describe('PROJECTS with validationPermission set to level', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
-    const project1 = { validationPermission: 'level', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'LEVEL', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project1, userTeams)).toBe(true);
   });
 
   it('CAN be validated by an ADVANCED level USER', () => {
     const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
-    const project = { validationPermission: 'level', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+    const project = { validationPermission: 'LEVEL', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project)).toBe(true);
   });
 });
@@ -81,9 +81,9 @@ describe('PROJECTS with validationPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
-    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'TEAMS', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
     const project2 = {
-      validationPermission: 'teams',
+      validationPermission: 'TEAMS',
       teams: [{ teamId: 2, role: 'PROJECT_MANAGER' }],
     };
     expect(userCanValidate(user, project1, userTeams)).toBe(true);
@@ -104,9 +104,9 @@ describe('PROJECTS with validationPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
-    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'TEAMS', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
     const project2 = {
-      validationPermission: 'teams',
+      validationPermission: 'TEAMS',
       teams: [{ teamId: 2, role: 'PROJECT_MANAGER' }],
     };
     expect(userCanValidate(user, project1, userTeams)).toBe(true);
@@ -122,7 +122,7 @@ describe('PROJECTS with validationPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
-    const project = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project = { validationPermission: 'TEAMS', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project, userTeams)).toBe(true);
   });
 
@@ -135,7 +135,7 @@ describe('PROJECTS with validationPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
-    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'TEAMS', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project1, userTeams)).toBe(false);
   });
 
@@ -148,7 +148,7 @@ describe('PROJECTS with validationPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
-    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'TEAMS', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project1, userTeams)).toBe(false);
   });
 
@@ -161,7 +161,7 @@ describe('PROJECTS with validationPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
-    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'TEAMS', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project1, userTeams)).toBe(false);
   });
 });
@@ -177,7 +177,7 @@ describe('PROJECTS with validationPermission set to teamsAndLevel', () => {
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
     const project1 = {
-      validationPermission: 'teamsAndLevel',
+      validationPermission: 'TEAMS_LEVEL',
       teams: [{ teamId: 1, role: 'VALIDATOR' }],
     };
     expect(userCanValidate(user, project1, userTeams)).toBe(false);
@@ -193,7 +193,7 @@ describe('PROJECTS with validationPermission set to teamsAndLevel', () => {
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
     const project1 = {
-      validationPermission: 'teamsAndLevel',
+      validationPermission: 'TEAMS_LEVEL',
       teams: [{ teamId: 1, role: 'VALIDATOR' }],
     };
     expect(userCanValidate(user, project1, userTeams)).toBe(true);
@@ -209,7 +209,7 @@ describe('PROJECTS with validationPermission set to teamsAndLevel', () => {
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
     const project1 = {
-      validationPermission: 'teamsAndLevel',
+      validationPermission: 'TEAMS_LEVEL',
       teams: [{ teamId: 1, role: 'VALIDATOR' }],
     };
     expect(userCanValidate(user, project1, userTeams)).toBe(false);
@@ -225,7 +225,7 @@ describe('PROJECTS with validationPermission set to teamsAndLevel', () => {
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
     const project = {
-      validationPermission: 'teamsAndLevel',
+      validationPermission: 'TEAMS_LEVEL',
       teams: [{ teamId: 1, role: 'VALIDATOR' }],
     };
     expect(userCanValidate(user, project, userTeams)).toBe(true);
@@ -241,7 +241,7 @@ describe('PROJECTS with validationPermission set to teamsAndLevel', () => {
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
     const project = {
-      validationPermission: 'teamsAndLevel',
+      validationPermission: 'TEAMS_LEVEL',
       teams: [{ teamId: 1, role: 'VALIDATOR' }],
     };
     expect(userCanValidate(user, project, userTeams)).toBe(false);
@@ -254,7 +254,7 @@ describe('PRIVATE projects', () => {
     const user = { username: 'user1', mappingLevel: 'ADVANCED', role: 'READ_ONLY' };
     const project = {
       private: true,
-      validationPermission: 'teams',
+      validationPermission: 'TEAMS',
       allowedUsernames: ['user1'],
       teams: [],
     };
@@ -264,7 +264,7 @@ describe('PRIVATE projects', () => {
   it('can NOT be validated by an ADVANCED user if their username is NOT ALLOWED', () => {
     const user = { username: 'user3000', mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
     const project = {
-      validationPermission: 'teams',
+      validationPermission: 'TEAMS',
       private: true,
       allowedUsernames: ['user1'],
       teams: [],
@@ -275,7 +275,7 @@ describe('PRIVATE projects', () => {
   it('CAN be validated by a BEGINNER USER if their username is ALLOWED', () => {
     const user = { username: 'user1', mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
     const project = {
-      validationPermission: 'teams',
+      validationPermission: 'TEAMS',
       private: true,
       allowedUsernames: ['user1'],
       teams: [],
@@ -293,7 +293,7 @@ describe('PRIVATE projects', () => {
     ];
     const user = { username: 'user1', mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
     const project = {
-      validationPermission: 'teams',
+      validationPermission: 'TEAMS',
       private: true,
       allowedUsernames: [],
       teams: [{ teamId: 1, role: 'VALIDATOR' }],

--- a/frontend/src/utils/tests/permissionsToValidate.test.js
+++ b/frontend/src/utils/tests/permissionsToValidate.test.js
@@ -1,212 +1,303 @@
 import { userCanValidate } from '../projectPermissions';
 
-it('READ_ONLY role USER can NOT validate', () => {
+it('READ_ONLY role USER can NOT validate any project', () => {
+  const userTeams = [
+    {
+      teamId: 7,
+      name: 'My Private team',
+      role: 'VALIDATOR',
+    },
+  ];
   const user = { mappingLevel: 'ADVANCED', role: 'READ_ONLY' };
-  const project = { mapperLevel: 'BEGINNER' };
-  expect(userCanValidate(user, project)).toBe(false);
-});
-
-/* ENFORCED VALIDATION ROLE PROJECTS  ****/
-it('BEGINNER MAPPER role USER can NOT validate PROJECT that requires validation role', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: false };
-  expect(userCanValidate(user, project)).toBe(false);
-});
-
-it('INTERMEDIATE MAPPER role USER can NOT validate PROJECT that requires validation role', () => {
-  const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: false };
-  expect(userCanValidate(user, project)).toBe(false);
-});
-
-it('ADVANCED MAPPER role USER can NOT validate PROJECT that requires validation role', () => {
-  const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: false };
-  expect(userCanValidate(user, project)).toBe(false);
-});
-
-it('ADMIN role USER can validate a PROJECT that requires validation role', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'ADMIN' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: false };
-  expect(userCanValidate(user, project)).toBe(true);
-});
-
-it('PROJECT_MANAGER role USER can validate a PROJECT that requires validation role', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'PROJECT_MANAGER' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: false };
-  expect(userCanValidate(user, project)).toBe(true);
-});
-
-it('VALIDATOR role USER can validate a PROJECT that requires validation role', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: false };
-  expect(userCanValidate(user, project)).toBe(true);
-});
-
-/* ENFORCED VALIDATION ROLE & ENFORCE INTERMEDIATE/ADVANCED VALIDATOR LEVEL PROJECTS */
-it('BEGINNER MAPPER role USER can NOT validate PROJECT that requires a role and level', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(false);
-});
-
-it('INTERMEDIATE MAPPER role USER can NOT validate PROJECT that requires a role and level', () => {
-  const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(false);
-});
-
-it('ADVANCED MAPPER role USER can NOT validate PROJECT that requires a role and level', () => {
-  const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(false);
-});
-
-it('BEGINNER ADMIN role USER can NOT validate a PROJECT that requires a role and level', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'ADMIN' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(false);
-});
-
-it('INTERMEDIATE ADMIN role USER can validate PROJECT that requires a role and level', () => {
-  const user = { mappingLevel: 'INTERMEDIATE', role: 'ADMIN' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(true);
-});
-
-it('ADVANCED ADMIN role USER can validate PROJECT that requires a role and level', () => {
-  const user = { mappingLevel: 'ADVANCED', role: 'ADMIN' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(true);
-});
-
-it('BEGINNER PROJECT_MANAGER role USER can NOT validate a PROJECT that requires a role and level', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'PROJECT_MANAGER' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(false);
-});
-
-it('INTERMEDIATE PROJECT_MANAGER role USER can validate PROJECT that requires a role and level', () => {
-  const user = { mappingLevel: 'INTERMEDIATE', role: 'PROJECT_MANAGER' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(true);
-});
-
-it('ADVANCED PROJECT_MANAGER role USER can validate PROJECT that requires a role and level', () => {
-  const user = { mappingLevel: 'ADVANCED', role: 'PROJECT_MANAGER' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(true);
-});
-
-it('BEGINNER VALIDATOR role USER can NOT validate a PROJECT that requires a role and level', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(false);
-});
-
-it('INTERMEDIATE VALIDATOR role USER can validate PROJECT that requires a role and level', () => {
-  const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(true);
-});
-
-it('ADVANCED VALIDATOR role USER can validate PROJECT that requires a role and level', () => {
-  const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
-  const project = { restrictValidationRole: true, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(true);
-});
-
-/* NOT ENFORCED VALIDATION ROLE & NOT ENFORCE INTERMEDIATE/ADVANCED VALIDATOR LEVEL PROJECTS */
-
-it('BEGINNER MAPPER role USER can validate PROJECT with restrictValidationRole = false', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-  const project = { restrictValidationRole: false, restrictValidationLevelIntermediate: false };
-  expect(userCanValidate(user, project)).toBe(true);
-});
-
-it('INTERMEDIATE MAPPER role USER can validate PROJECT with restrictValidationRole = false', () => {
-  const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-  const project = { restrictValidationRole: false, restrictValidationLevelIntermediate: false };
-  expect(userCanValidate(user, project)).toBe(true);
-});
-
-it('ADVANCED MAPPER role USER can validate PROJECT with restrictValidationRole = false', () => {
-  const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-  const project = { restrictValidationRole: false, restrictValidationLevelIntermediate: false };
-  expect(userCanValidate(user, project)).toBe(true);
-});
-
-/* NOT ENFORCED VALIDATION ROLE & ENFORCE INTERMEDIATE/ADVANCED VALIDATOR LEVEL PROJECTS */
-it('BEGINNER MAPPER role USER can NOT validate PROJECT that requires INTERMEDIATE level', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-  const project = { restrictValidationRole: false, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(false);
-});
-
-it('INTERMEDIATE MAPPER role USER can validate PROJECT that requires INTERMEDIATE level', () => {
-  const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-  const project = { restrictValidationRole: false, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(true);
-});
-
-it('ADVANCED MAPPER role USER can validate PROJECT that requires INTERMEDIATE level', () => {
-  const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-  const project = { restrictValidationRole: false, restrictValidationLevelIntermediate: true };
-  expect(userCanValidate(user, project)).toBe(true);
-});
-
-/* PRIVATE PROJECTS */
-it('BEGINNER VALIDATOR role USER can NOT validate PRIVATE PROJECT even if username is ALLOWED', () => {
-  const user = { username: 'user1', mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
-  const project = {
-    private: true,
-    allowedUsernames: ['user1'],
-    restrictValidationRole: true,
-    restrictValidationLevelIntermediate: true,
+  const project1 = { validationPermission: 'any', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+  const project2 = { validationPermission: 'teams', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+  const project3 = { validationPermission: 'level', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+  const project4 = {
+    validationPermission: 'teamsAndLevel',
+    teams: [{ teamId: 7, role: 'VALIDATOR' }],
   };
-  expect(userCanValidate(user, project)).toBe(false);
+  expect(userCanValidate(user, project1, userTeams)).toBe(false);
+  expect(userCanValidate(user, project2, userTeams)).toBe(false);
+  expect(userCanValidate(user, project3, userTeams)).toBe(false);
+  expect(userCanValidate(user, project4, userTeams)).toBe(false);
 });
 
-it('INTERMEDIATE VALIDATOR role USER can NOT validate PROJECT if their username is NOT ALLOWED', () => {
-  const user = { username: 'user3000', mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
-  const project = {
-    private: true,
-    allowedUsernames: ['user1'],
-    restrictValidationRole: true,
-    restrictValidationLevelIntermediate: true,
-  };
-  expect(userCanValidate(user, project)).toBe(false);
+describe('PROJECTS with validationPermission set to any', () => {
+  it('CAN be validated by a BEGINNER user that is not on a team', () => {
+    const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
+    const project1 = { validationPermission: 'any', teams: [] };
+    const project2 = { validationPermission: 'any', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+    expect(userCanValidate(user, project1)).toBe(true);
+    expect(userCanValidate(user, project2)).toBe(true);
+  });
 });
 
-it('INTERMEDIATE VALIDATOR role USER can validate PROJECT if their username is ALLOWED', () => {
-  const user = { username: 'user1', mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
-  const project = {
-    private: true,
-    allowedUsernames: ['user1'],
-    restrictValidationRole: true,
-    restrictValidationLevelIntermediate: true,
-  };
-  expect(userCanValidate(user, project)).toBe(true);
+describe('PROJECTS with validationPermission set to level', () => {
+  it('can NOT be validated by a BEGINNER level USER', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+    ];
+    const user = { mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
+    const project1 = { validationPermission: 'level', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    expect(userCanValidate(user, project1, userTeams)).toBe(false);
+  });
+
+  it('CAN be validated by an INTERMEDIATE level USER', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+    ];
+    const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
+    const project1 = { validationPermission: 'level', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+    expect(userCanValidate(user, project1, userTeams)).toBe(true);
+  });
+
+  it('CAN be validated by an ADVANCED level USER', () => {
+    const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
+    const project = { validationPermission: 'level', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+    expect(userCanValidate(user, project)).toBe(true);
+  });
 });
 
-it('ADVANCED VALIDATOR role USER can NOT validate PROJECT if their username is NOT ALLOWED', () => {
-  const user = { username: 'user3000', mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
-  const project = {
-    private: true,
-    allowedUsernames: ['user1'],
-    restrictValidationRole: true,
-    restrictValidationLevelIntermediate: true,
-  };
-  expect(userCanValidate(user, project)).toBe(false);
+describe('PROJECTS with validationPermission set as teams', () => {
+  it('CAN be validated by a BEGINNER level USER if they are member of the team', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+      {
+        teamId: 2,
+        name: 'My Private team',
+        role: 'PROJECT_MANAGER',
+      },
+    ];
+    const user = { mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
+    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project2 = {
+      validationPermission: 'teams',
+      teams: [{ teamId: 2, role: 'PROJECT_MANAGER' }],
+    };
+    expect(userCanValidate(user, project1, userTeams)).toBe(true);
+    expect(userCanValidate(user, project2, userTeams)).toBe(true);
+  });
+
+  it('CAN be validated by an INTERMEDIATE level USER if they are member of the team', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+      {
+        teamId: 2,
+        name: 'My Private team',
+        role: 'PROJECT_MANAGER',
+      },
+    ];
+    const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
+    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project2 = {
+      validationPermission: 'teams',
+      teams: [{ teamId: 2, role: 'PROJECT_MANAGER' }],
+    };
+    expect(userCanValidate(user, project1, userTeams)).toBe(true);
+    expect(userCanValidate(user, project2, userTeams)).toBe(true);
+  });
+
+  it('CAN be validated by an ADVANCED level USER', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+    ];
+    const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
+    const project = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    expect(userCanValidate(user, project, userTeams)).toBe(true);
+  });
+
+  it('can NOT be validated by a BEGINNER level USER if they are NOT member of the team', () => {
+    const userTeams = [
+      {
+        teamId: 2,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+    ];
+    const user = { mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
+    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    expect(userCanValidate(user, project1, userTeams)).toBe(false);
+  });
+
+  it('can NOT be validated by an INTERMEDIATE level USER if they are NOT member of the team', () => {
+    const userTeams = [
+      {
+        teamId: 2,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+    ];
+    const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
+    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    expect(userCanValidate(user, project1, userTeams)).toBe(false);
+  });
+
+  it('can NOT be validated by an ADVANCED level USER if they are NOT member of the team', () => {
+    const userTeams = [
+      {
+        teamId: 2,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+    ];
+    const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
+    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    expect(userCanValidate(user, project1, userTeams)).toBe(false);
+  });
 });
 
-it('ADVANCED VALIDATOR role USER can validate PROJECT if their username is ALLOWED', () => {
-  const user = { username: 'user1', mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
-  const project = {
-    private: true,
-    allowedUsernames: ['user1'],
-    restrictValidationRole: true,
-    restrictValidationLevelIntermediate: true,
-  };
-  expect(userCanValidate(user, project)).toBe(true);
+describe('PROJECTS with validationPermission set to teamsAndLevel', () => {
+  it('can NOT be validated by a BEGINNER level USER even if they are member of the team', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+    ];
+    const user = { mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
+    const project1 = {
+      validationPermission: 'teamsAndLevel',
+      teams: [{ teamId: 1, role: 'VALIDATOR' }],
+    };
+    expect(userCanValidate(user, project1, userTeams)).toBe(false);
+  });
+
+  it('CAN be validated by an INTERMEDIATE level USER if they are member of the team', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+    ];
+    const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
+    const project1 = {
+      validationPermission: 'teamsAndLevel',
+      teams: [{ teamId: 1, role: 'VALIDATOR' }],
+    };
+    expect(userCanValidate(user, project1, userTeams)).toBe(true);
+  });
+
+  it('can NOT be validated by an INTERMEDIATE level USER if they are not member of a team', () => {
+    const userTeams = [
+      {
+        teamId: 2,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+    ];
+    const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
+    const project1 = {
+      validationPermission: 'teamsAndLevel',
+      teams: [{ teamId: 1, role: 'VALIDATOR' }],
+    };
+    expect(userCanValidate(user, project1, userTeams)).toBe(false);
+  });
+
+  it('CAN be validated by an ADVANCED level USER if they are member of a team', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+    ];
+    const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
+    const project = {
+      validationPermission: 'teamsAndLevel',
+      teams: [{ teamId: 1, role: 'VALIDATOR' }],
+    };
+    expect(userCanValidate(user, project, userTeams)).toBe(true);
+  });
+
+  it('can NOT be validated by an ADVANCED level USER if they are not member of a team', () => {
+    const userTeams = [
+      {
+        teamId: 2,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+    ];
+    const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
+    const project = {
+      validationPermission: 'teamsAndLevel',
+      teams: [{ teamId: 1, role: 'VALIDATOR' }],
+    };
+    expect(userCanValidate(user, project, userTeams)).toBe(false);
+  });
+});
+
+/******  PRIVATE PROJECTS  ******/
+describe('PRIVATE projects', () => {
+  it('can NOT be validated by a READ_ONLY role USER even if the user is on the list', () => {
+    const user = { username: 'user1', mappingLevel: 'ADVANCED', role: 'READ_ONLY' };
+    const project = {
+      private: true,
+      validationPermission: 'teams',
+      allowedUsernames: ['user1'],
+      teams: [],
+    };
+    expect(userCanValidate(user, project)).toBe(false);
+  });
+
+  it('can NOT be validated by an ADVANCED user if their username is NOT ALLOWED', () => {
+    const user = { username: 'user3000', mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
+    const project = {
+      validationPermission: 'teams',
+      private: true,
+      allowedUsernames: ['user1'],
+      teams: [],
+    };
+    expect(userCanValidate(user, project)).toBe(false);
+  });
+
+  it('CAN be validated by a BEGINNER USER if their username is ALLOWED', () => {
+    const user = { username: 'user1', mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
+    const project = {
+      validationPermission: 'teams',
+      private: true,
+      allowedUsernames: ['user1'],
+      teams: [],
+    };
+    expect(userCanValidate(user, project)).toBe(true);
+  });
+
+  it('CAN be validated by a BEGINNER USER if they are part of a team', () => {
+    const userTeams = [
+      {
+        teamId: 1,
+        name: 'My Private team',
+        role: 'VALIDATOR',
+      },
+    ];
+    const user = { username: 'user1', mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
+    const project = {
+      validationPermission: 'teams',
+      private: true,
+      allowedUsernames: [],
+      teams: [{ teamId: 1, role: 'VALIDATOR' }],
+    };
+    expect(userCanValidate(user, project, userTeams)).toBe(true);
+  });
 });

--- a/frontend/src/utils/tests/taskAction.test.js
+++ b/frontend/src/utils/tests/taskAction.test.js
@@ -62,7 +62,9 @@ it('READY TASK selected and USER able to map returns mapSelectedTask', () => {
     percentMapped: 40,
     percentBadImagery: 0,
     percentValidated: 0,
-    mapperLevel: 'BEGINNER',
+    mappingPermission: 'any',
+    validationPermission: 'teamsAndLevel',
+    teams: [],
   };
   const taskStatus = 'READY';
   expect(getTaskAction(user, project, taskStatus)).toBe('mapSelectedTask');
@@ -74,22 +76,23 @@ it('READY TASK selected and USER unable to map returns selectAnotherProject', ()
     percentMapped: 40,
     percentBadImagery: 0,
     percentValidated: 0,
-    mapperLevel: 'INTERMEDIATE',
-    restrictMappingLevelToProject: true,
-    restrictValidationRole: true,
+    mappingPermission: 'teams',
+    validationPermission: 'teams',
+    teams: [],
   };
   const taskStatus = 'READY';
   expect(getTaskAction(user, project, taskStatus)).toBe('selectAnotherProject');
 });
 
-it('MAPPED TASK selected and USER able to map returns mapAnotherTask', () => {
+it('MAPPED TASK selected and USER able to map, but unable to validate, returns mapAnotherTask', () => {
   const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
   const project = {
     percentMapped: 40,
     percentBadImagery: 0,
     percentValidated: 0,
-    mapperLevel: 'BEGINNER',
-    restrictValidationRole: true,
+    mappingPermission: 'any',
+    validationPermission: 'level',
+    teams: [],
   };
   const taskStatus = 'MAPPED';
   expect(getTaskAction(user, project, taskStatus)).toBe('mapAnotherTask');
@@ -101,62 +104,64 @@ it('MAPPED TASK selected and USER able to validate returns validatedSelectedTask
     percentMapped: 100,
     percentValidated: 50,
     percentBadImagery: 0,
-    mapperLevel: 'BEGINNER',
-    restrictMappingLevelToProject: false,
-    restrictValidationRole: false,
+    mappingPermission: 'any',
+    validationPermission: 'any',
+    teams: [],
   };
   const taskStatus = 'MAPPED';
   expect(getTaskAction(user, project, taskStatus)).toBe('validateSelectedTask');
 });
 
 it('No tasks selected and USER able to validate returns validatedATask', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
+  const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
   const project = {
     percentMapped: 100,
     percentValidated: 50,
     percentBadImagery: 0,
-    mapperLevel: 'BEGINNER',
-    restrictMappingLevelToProject: false,
-    restrictValidationRole: false,
+    mappingPermission: 'level',
+    validationPermission: 'level',
+    teams: [],
   };
   expect(getTaskAction(user, project, null)).toBe('validateATask');
 });
 
 it('completely mapped project returns mappingIsComplete message to a user that can not validate', () => {
-  const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
+  const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
   const project = {
     percentMapped: 100,
     percentValidated: 50,
     percentBadImagery: 0,
-    mapperLevel: 'INTERMEDIATE',
-    restrictValidationRole: true,
+    mappingPermission: 'level',
+    validationPermission: 'teams',
+    teams: [],
   };
   const taskStatus = 'MAPPED';
   expect(getTaskAction(user, project, taskStatus)).toBe('mappingIsComplete');
 });
 
-it('completely mapped and validated project returns projectIsComplete to MAPPER', () => {
+it('completely mapped and validated project returns projectIsComplete to user able to map', () => {
   const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
   const project = {
     percentMapped: 100,
     percentValidated: 100,
     percentBadImagery: 0,
-    mapperLevel: 'INTERMEDIATE',
-    restrictMappingLevelToProject: true,
+    mappingPermission: 'any',
+    validationPermission: 'any',
+    teams: [],
   };
   const taskStatus = 'VALIDATED';
   expect(getTaskAction(user, project, taskStatus)).toBe('projectIsComplete');
 });
 
-it('completely mapped and validated project returns projectIsComplete to VALIDATOR', () => {
+it('completely mapped and validated project returns projectIsComplete to user able to validate', () => {
   const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
   const project = {
     percentMapped: 100,
     percentValidated: 100,
     percentBadImagery: 0,
-    mapperLevel: 'INTERMEDIATE',
-    restrictMappingLevelToProject: true,
-    restrictValidationRole: false,
+    mappingPermission: 'any',
+    validationPermission: 'any',
+    teams: [],
   };
   const taskStatus = 'VALIDATED';
   expect(getTaskAction(user, project, taskStatus)).toBe('projectIsComplete');

--- a/frontend/src/utils/tests/taskAction.test.js
+++ b/frontend/src/utils/tests/taskAction.test.js
@@ -62,8 +62,8 @@ it('READY TASK selected and USER able to map returns mapSelectedTask', () => {
     percentMapped: 40,
     percentBadImagery: 0,
     percentValidated: 0,
-    mappingPermission: 'any',
-    validationPermission: 'teamsAndLevel',
+    mappingPermission: 'ANY',
+    validationPermission: 'TEAMS_LEVEL',
     teams: [],
   };
   const taskStatus = 'READY';
@@ -76,8 +76,8 @@ it('READY TASK selected and USER unable to map returns selectAnotherProject', ()
     percentMapped: 40,
     percentBadImagery: 0,
     percentValidated: 0,
-    mappingPermission: 'teams',
-    validationPermission: 'teams',
+    mappingPermission: 'TEAMS',
+    validationPermission: 'TEAMS',
     teams: [],
   };
   const taskStatus = 'READY';
@@ -90,8 +90,8 @@ it('MAPPED TASK selected and USER able to map, but unable to validate, returns m
     percentMapped: 40,
     percentBadImagery: 0,
     percentValidated: 0,
-    mappingPermission: 'any',
-    validationPermission: 'level',
+    mappingPermission: 'ANY',
+    validationPermission: 'LEVEL',
     teams: [],
   };
   const taskStatus = 'MAPPED';
@@ -104,8 +104,8 @@ it('MAPPED TASK selected and USER able to validate returns validatedSelectedTask
     percentMapped: 100,
     percentValidated: 50,
     percentBadImagery: 0,
-    mappingPermission: 'any',
-    validationPermission: 'any',
+    mappingPermission: 'ANY',
+    validationPermission: 'ANY',
     teams: [],
   };
   const taskStatus = 'MAPPED';
@@ -118,8 +118,8 @@ it('No tasks selected and USER able to validate returns validatedATask', () => {
     percentMapped: 100,
     percentValidated: 50,
     percentBadImagery: 0,
-    mappingPermission: 'level',
-    validationPermission: 'level',
+    mappingPermission: 'LEVEL',
+    validationPermission: 'LEVEL',
     teams: [],
   };
   expect(getTaskAction(user, project, null)).toBe('validateATask');
@@ -131,8 +131,8 @@ it('completely mapped project returns mappingIsComplete message to a user that c
     percentMapped: 100,
     percentValidated: 50,
     percentBadImagery: 0,
-    mappingPermission: 'level',
-    validationPermission: 'teams',
+    mappingPermission: 'LEVEL',
+    validationPermission: 'TEAMS',
     teams: [],
   };
   const taskStatus = 'MAPPED';
@@ -145,8 +145,8 @@ it('completely mapped and validated project returns projectIsComplete to user ab
     percentMapped: 100,
     percentValidated: 100,
     percentBadImagery: 0,
-    mappingPermission: 'any',
-    validationPermission: 'any',
+    mappingPermission: 'ANY',
+    validationPermission: 'ANY',
     teams: [],
   };
   const taskStatus = 'VALIDATED';
@@ -159,8 +159,8 @@ it('completely mapped and validated project returns projectIsComplete to user ab
     percentMapped: 100,
     percentValidated: 100,
     percentBadImagery: 0,
-    mappingPermission: 'any',
-    validationPermission: 'any',
+    mappingPermission: 'ANY',
+    validationPermission: 'ANY',
     teams: [],
   };
   const taskStatus = 'VALIDATED';

--- a/frontend/src/views/projectEdit.js
+++ b/frontend/src/views/projectEdit.js
@@ -50,7 +50,7 @@ export function ProjectEdit({ id }) {
     mappingTypes: [],
     mappingEditors: [],
     validationEditors: [],
-    projectTeams: [],
+    teams: [],
     projectInfoLocales: [
       {
         locale: '',

--- a/migrations/versions/c40e1fdf6b70_.py
+++ b/migrations/versions/c40e1fdf6b70_.py
@@ -1,0 +1,122 @@
+"""empty message
+
+Revision ID: c40e1fdf6b70
+Revises: 84c793a951b2
+Create Date: 2020-02-04 22:23:22.457001
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c40e1fdf6b70"
+down_revision = "84c793a951b2"
+branch_labels = None
+depends_on = None
+
+
+class Determiner:
+    def determine_mapping_permission(self, val, reverse=False):
+        # restrict_mapping_level_to_project=True => LEVEL = 1
+        # restrict_mapping_level_to_project=False => ANY = 0
+        permissions = {True: 1, False: 0}
+        if reverse:
+            return list(permissions.keys())[list(permissions.values()).index(val)]
+        return permissions.get(val)
+
+    def determine_validation_permission(self, val, reverse=False):
+        # (restrict_validation_role=True, restrict_validation_level_intermediate=True) => TEAMS_LEVEL = 3
+        # (restrict_validation_role=True, restrict_validation_level_intermediate=False) => TEAMS = 2
+        # (restrict_validation_role=False, restrict_validation_level_intermediate=True) => LEVEL = 1
+        # (restrict_validation_role=False, restrict_validation_level_intermediate=False) => ANY = 0
+        permissions = {
+            "True,True": 3,
+            "True,False": 2,
+            "False,True": 1,
+            "False,False": 0,
+        }
+        if reverse:
+            return list(permissions.keys())[list(permissions.values()).index(val)]
+        return permissions.get(val)
+
+
+def upgrade():
+    conn = op.get_bind()
+    conn.execute("ALTER TABLE projects ADD mapping_permission Integer;")
+    conn.execute("ALTER TABLE projects ADD validation_permission Integer;")
+    fetch_all_projects = "select id, restrict_mapping_level_to_project, \
+                           restrict_validation_role, restrict_validation_level_intermediate from projects;"
+    all_projects = conn.execute(fetch_all_projects)
+    for project in all_projects:
+        mapping_permission = None
+        validation_permission = None
+        project_id = project[0]
+        mapping_restriction = project[1]
+        validation_role_restriction = project[2]
+        validation_level_restriction = project[3]
+
+        # Map existing restrictions to V4 permission integers
+        d = Determiner()
+        mapping_permission = d.determine_mapping_permission(mapping_restriction)
+        validation_restriction = (
+            str(validation_role_restriction) + "," + str(validation_level_restriction)
+        )
+        validation_permission = d.determine_validation_permission(
+            validation_restriction
+        )
+
+        update_query = (
+            "update projects set mapping_permission = '"
+            + str(mapping_permission)
+            + "', validation_permission = '"
+            + str(validation_permission)
+            + "' where id = "
+            + str(project_id)
+        )
+        op.execute(update_query)
+    op.drop_column("projects", "restrict_mapping_level_to_project")
+    op.drop_column("projects", "restrict_validation_role")
+    op.drop_column("projects", "restrict_validation_level_intermediate")
+
+
+def downgrade():
+    conn = op.get_bind()
+    conn.execute("ALTER TABLE projects ADD restrict_mapping_level_to_project boolean;")
+    conn.execute("ALTER TABLE projects ADD restrict_validation_role boolean;")
+    conn.execute(
+        "ALTER TABLE projects ADD restrict_validation_level_intermediate boolean;"
+    )
+    fetch_all_projects = (
+        "select id, mapping_permission, validation_permission from projects;"
+    )
+    all_projects = conn.execute(fetch_all_projects)
+    for project in all_projects:
+        project_id = project[0]
+        mapping_permission = project[1]
+        validation_permission = project[2]
+        mapping_restriction = None
+        validation_role_restriction = None
+        validation_level_restriction = None
+
+        # Reverse map V4 permission integers to V3 restrictions
+        d = Determiner()
+        mapping_restriction = d.determine_mapping_permission(mapping_permission, True)
+        validation_restriction = d.determine_validation_permission(
+            validation_permission, True
+        ).split(",")
+        validation_role_restriction = validation_restriction[0]
+        validation_level_restriction = validation_restriction[1]
+
+        update_query = (
+            "update projects set restrict_mapping_level_to_project = '"
+            + str(mapping_restriction)
+            + "', restrict_validation_role = '"
+            + str(validation_role_restriction)
+            + "', restrict_validation_level_intermediate = '"
+            + str(validation_level_restriction)
+            + "' where id = "
+            + str(project_id)
+        )
+        op.execute(update_query)
+
+    op.drop_column("projects", "mapping_permission")
+    op.drop_column("projects", "validation_permission")

--- a/server/models/dtos/project_dto.py
+++ b/server/models/dtos/project_dto.py
@@ -219,7 +219,7 @@ class ProjectDTO(Model):
         validators=[is_known_task_creation_mode],
         serialize_when_none=False,
     )
-    project_teams = ListType(ModelType(ProjectTeamDTO), serialized_name="projectTeams")
+    project_teams = ListType(ModelType(ProjectTeamDTO), serialized_name="teams")
     mapping_editors = ListType(
         StringType,
         min_size=1,
@@ -456,6 +456,7 @@ class ProjectSummary(Model):
     )
     private = BooleanType(serialized_name="private")
     allowed_users = ListType(StringType, serialized_name="allowedUsernames", default=[])
+    project_teams = ListType(ModelType(ProjectTeamDTO), serialized_name="teams")
     project_info = ModelType(
         ProjectInfoDTO, serialized_name="projectInfo", serialize_when_none=False
     )

--- a/server/models/dtos/project_dto.py
+++ b/server/models/dtos/project_dto.py
@@ -19,6 +19,8 @@ from server.models.postgis.statuses import (
     MappingTypes,
     TaskCreationMode,
     Editors,
+    MappingPermission,
+    ValidationPermission,
 )
 from server.models.dtos.campaign_dto import CampaignDTO
 
@@ -99,6 +101,31 @@ def is_known_task_creation_mode(value):
         )
 
 
+def is_known_mapping_permission(value):
+    """ Validates Mapping Permission String """
+    try:
+        print("value: ", value)
+        MappingPermission[value.upper()]
+    except KeyError:
+        raise ValidationError(
+            f"Unknown mappingPermission: {value} Valid values are {MappingPermission.ANY.name}, "
+            f"{MappingPermission.LEVEL.name}"
+        )
+
+
+def is_known_validation_permission(value):
+    """ Validates Validation Permission String """
+    try:
+        print("value: ", value)
+        ValidationPermission[value.upper()]
+    except KeyError:
+        raise ValidationError(
+            f"Unknown validationPermission: {value} Valid values are {ValidationPermission.ANY.name}, "
+            f"{ValidationPermission.LEVEL.name}, {ValidationPermission.TEAMS.name}, "
+            f"{ValidationPermission.TEAMS_LEVEL.name}"
+        )
+
+
 class DraftProjectDTO(Model):
     """ Describes JSON model used for creating draft project """
 
@@ -167,20 +194,20 @@ class ProjectDTO(Model):
         serialized_name="mapperLevel",
         validators=[is_known_mapping_level],
     )
-    restrict_mapping_level_to_project = BooleanType(
-        required=True, default=False, serialized_name="restrictMappingLevelToProject"
+    mapping_permission = StringType(
+        required=True,
+        serialized_name="mapping_permission",
+        validators=[is_known_mapping_permission],
     )
-    restrict_validation_role = BooleanType(
-        required=True, default=False, serialized_name="restrictValidationRole"
+    validation_permission = StringType(
+        required=True,
+        serialized_name="validation_permission",
+        validators=[is_known_validation_permission],
     )
     enforce_random_task_selection = BooleanType(
         required=False, default=False, serialized_name="enforceRandomTaskSelection"
     )
-    restrict_validation_level_intermediate = BooleanType(
-        required=False,
-        default=False,
-        serialized_name="restrictValidationLevelIntermediate",
-    )
+
     private = BooleanType(required=True)
     entities_to_map = StringType(serialized_name="entitiesToMap")
     changeset_comment = StringType(serialized_name="changesetComment")
@@ -444,15 +471,15 @@ class ProjectSummary(Model):
     percent_bad_imagery = IntType(serialized_name="percentBadImagery")
     aoi_centroid = BaseType(serialized_name="aoiCentroid")
     mapper_level = StringType(serialized_name="mapperLevel")
-    restrict_mapping_level_to_project = BooleanType(
-        serialized_name="restrictMappingLevelToProject"
+    mapping_permission = IntType(
+        serialized_name="mappingPermission", validators=[is_known_mapping_permission]
     )
-    restrict_validation_role = BooleanType(serialized_name="restrictValidationRole")
+    validation_permission = IntType(
+        serialized_name="validationPermission",
+        validators=[is_known_validation_permission],
+    )
     random_task_selection_enforced = BooleanType(
         required=False, default=False, serialized_name="enforceRandomTaskSelection"
-    )
-    restrict_validation_level_intermediate = BooleanType(
-        serialized_name="restrictValidationLevelIntermediate"
     )
     private = BooleanType(serialized_name="private")
     allowed_users = ListType(StringType, serialized_name="allowedUsernames", default=[])

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -44,6 +44,8 @@ from server.models.postgis.statuses import (
     TaskCreationMode,
     Editors,
     TeamRoles,
+    MappingPermission,
+    ValidationPermission,
 )
 from server.models.postgis.task import Task, TaskHistory
 from server.models.postgis.team import Team
@@ -131,14 +133,13 @@ class Project(db.Model):
     mapper_level = db.Column(
         db.Integer, default=2, nullable=False, index=True
     )  # Mapper level project is suitable for
-    restrict_mapping_level_to_project = db.Column(db.Boolean, default=False)
-    restrict_validation_role = db.Column(
-        db.Boolean, default=False
+    mapping_permission = db.Column(db.Integer, default=MappingPermission.ANY.value)
+    validation_permission = db.Column(
+        db.Integer, default=ValidationPermission.ANY.value
     )  # Means only users with validator role can validate
     enforce_random_task_selection = db.Column(
         db.Boolean, default=False
     )  # Force users to edit at random to avoid mapping "easy" tasks
-    restrict_validation_level_intermediate = db.Column(db.Boolean, default=False)
     private = db.Column(db.Boolean, default=False)  # Only allowed users can validate
     featured = db.Column(
         db.Boolean, default=False
@@ -340,12 +341,8 @@ class Project(db.Model):
         cloned_project.priority = original_project.priority
         cloned_project.default_locale = original_project.default_locale
         cloned_project.mapper_level = original_project.mapper_level
-        cloned_project.restrict_mapping_level_to_project = (
-            original_project.restrict_mapping_level_to_project
-        )
-        cloned_project.restrict_validation_role = (
-            original_project.restrict_validation_role
-        )
+        cloned_project.mapping_permission = original_project.mapping_permission
+        cloned_project.validation_permission = original_project.validation_permission
         cloned_project.enforce_random_task_selection = (
             original_project.enforce_random_task_selection
         )
@@ -387,14 +384,13 @@ class Project(db.Model):
         self.status = ProjectStatus[project_dto.project_status].value
         self.priority = ProjectPriority[project_dto.project_priority].value
         self.default_locale = project_dto.default_locale
-        self.restrict_mapping_level_to_project = (
-            project_dto.restrict_mapping_level_to_project
-        )
-        self.restrict_validation_role = project_dto.restrict_validation_role
+        self.mapping_permission = MappingPermission[
+            project_dto.mapping_permission.upper()
+        ].value
+        self.validation_permission = ValidationPermission[
+            project_dto.validation_permission.upper()
+        ].value
         self.enforce_random_task_selection = project_dto.enforce_random_task_selection
-        self.restrict_validation_level_intermediate = (
-            project_dto.restrict_validation_level_intermediate
-        )
         self.private = project_dto.private
         self.mapper_level = MappingLevel[project_dto.mapper_level.upper()].value
         self.entities_to_map = project_dto.entities_to_map
@@ -730,14 +726,11 @@ class Project(db.Model):
         summary.last_updated = self.last_updated
         summary.due_date = self.due_date
         summary.mapper_level = MappingLevel(self.mapper_level).name
-        summary.restrict_mapping_level_to_project = (
-            self.restrict_mapping_level_to_project
-        )
-        summary.restrict_validation_role = self.restrict_validation_role
+        summary.mapping_permission = MappingPermission(self.mapping_permission).name
+        summary.validation_permission = ValidationPermission(
+            self.validation_permission
+        ).name
         summary.random_task_selection_enforced = self.enforce_random_task_selection
-        summary.restrict_validation_level_intermediate = (
-            self.restrict_validation_level_intermediate
-        )
         summary.private = self.private
         summary.status = ProjectStatus(self.status).name
         summary.entities_to_map = self.entities_to_map
@@ -875,14 +868,11 @@ class Project(db.Model):
         base_dto.project_priority = ProjectPriority(self.priority).name
         base_dto.area_of_interest = self.get_aoi_geometry_as_geojson()
         base_dto.aoi_bbox = shape(base_dto.area_of_interest).bounds
-        base_dto.restrict_mapping_level_to_project = (
-            self.restrict_mapping_level_to_project
-        )
-        base_dto.restrict_validation_role = self.restrict_validation_role
+        base_dto.mapping_permission = MappingPermission(self.mapping_permission).name
+        base_dto.validation_permission = ValidationPermission(
+            self.validation_permission
+        ).name
         base_dto.enforce_random_task_selection = self.enforce_random_task_selection
-        base_dto.restrict_validation_level_intermediate = (
-            self.restrict_validation_level_intermediate
-        )
         base_dto.private = self.private
         base_dto.mapper_level = MappingLevel(self.mapper_level).name
         base_dto.entities_to_map = self.entities_to_map
@@ -979,7 +969,6 @@ class Project(db.Model):
     def as_dto_for_mapping(self, locale: str, abbrev: bool) -> Optional[ProjectDTO]:
         """ Creates a Project DTO suitable for transmitting to mapper users """
         project, project_dto = self._get_project_and_base_dto()
-
         if abbrev is False:
             project_dto.tasks = Task.get_tasks_as_geojson_feature_collection(
                 self.id, None
@@ -991,7 +980,6 @@ class Project(db.Model):
         project_dto.project_info = ProjectInfo.get_dto_for_locale(
             self.id, locale, project.default_locale
         )
-
         if project.organisation_id:
             project_dto.organisation = project.organisation.id
             project_dto.organisation_name = project.organisation.name

--- a/server/models/postgis/project.py
+++ b/server/models/postgis/project.py
@@ -804,6 +804,16 @@ class Project(db.Model):
             self.tasks_validated,
             self.tasks_bad_imagery,
         )
+        summary.project_teams = [
+            ProjectTeamDTO(
+                dict(
+                    team_id=t.team.id,
+                    team_name=t.team.name,
+                    role=TeamRoles(t.role).name,
+                )
+            )
+            for t in self.teams
+        ]
 
         project_info = ProjectInfo.get_dto_for_locale(
             self.id, preferred_locale, self.default_locale

--- a/server/models/postgis/statuses.py
+++ b/server/models/postgis/statuses.py
@@ -64,6 +64,9 @@ class MappingNotAllowed(Enum):
     USER_NOT_ACCEPTED_LICENSE = 102
     USER_NOT_ON_ALLOWED_LIST = 103
     PROJECT_NOT_PUBLISHED = 104
+    USER_NOT_TEAM_MEMBER = 105
+    PROJECT_HAS_NO_TEAM = 106
+    NOT_A_MAPPING_TEAM = 107
 
 
 class ValidatingNotAllowed(Enum):
@@ -74,6 +77,9 @@ class ValidatingNotAllowed(Enum):
     USER_NOT_ON_ALLOWED_LIST = 102
     PROJECT_NOT_PUBLISHED = 103
     USER_IS_BEGINNER = 104
+    NOT_A_VALIDATION_TEAM = 105
+    USER_NOT_TEAM_MEMBER = 106
+    PROJECT_HAS_NO_TEAM = 107
 
 
 class UserGender(Enum):
@@ -127,3 +133,21 @@ class TeamMemberFunctions(Enum):
     EDITOR = 0
     MANAGER = 1
     MEMBER = 2
+
+
+class MappingPermission(Enum):
+    """ Describes a set of permissions for mapping on a project """
+
+    ANY = 0
+    LEVEL = 1
+    TEAMS = 2
+    TEAMS_LEVEL = 3
+
+
+class ValidationPermission(Enum):
+    """ Describes a set of permissions for validating on a project """
+
+    ANY = 0
+    LEVEL = 1
+    TEAMS = 2
+    TEAMS_LEVEL = 3

--- a/server/services/messaging/message_service.py
+++ b/server/services/messaging/message_service.py
@@ -13,11 +13,11 @@ from server.models.dtos.stats_dto import Pagination
 from server.models.postgis.message import Message, MessageType, NotFound
 from server.models.postgis.notification import Notification
 from server.models.postgis.project_info import ProjectInfo
+from server.models.postgis.project import Project
 from server.models.postgis.task import TaskStatus
 from server.services.messaging.smtp_service import SMTPService
 from server.services.messaging.template_service import get_template, get_profile_url
 from server.services.users.user_service import UserService, User
-from server.services.project_service import Project
 
 
 message_cache = TTLCache(maxsize=512, ttl=30)

--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -14,11 +14,18 @@ from server.models.dtos.project_dto import (
 
 from server.models.postgis.organisation import Organisation
 from server.models.postgis.project import Project, ProjectStatus, MappingLevel
-from server.models.postgis.statuses import MappingNotAllowed, ValidatingNotAllowed
+from server.models.postgis.statuses import (
+    MappingNotAllowed,
+    ValidatingNotAllowed,
+    MappingPermission,
+    ValidationPermission,
+    TeamRoles,
+)
 from server.models.postgis.task import Task, TaskHistory, TaskAction
 from server.models.postgis.utils import NotFound
 from server.services.users.user_service import UserService
 from server.services.project_search_service import ProjectSearchService
+from server.services.team_service import TeamService
 from sqlalchemy import func, or_
 from sqlalchemy.sql.expression import true
 
@@ -37,7 +44,6 @@ class ProjectService:
     @staticmethod
     def get_project_by_id(project_id: int) -> Project:
         project = Project.get(project_id)
-
         if project is None:
             raise NotFound()
 
@@ -46,7 +52,6 @@ class ProjectService:
     @staticmethod
     def get_project_by_name(project_id: int) -> Project:
         project = Project.get(project_id)
-
         if project is None:
             raise NotFound()
 
@@ -170,12 +175,76 @@ class ProjectService:
         return task_dtos
 
     @staticmethod
+    def evaluate_mapping_permission(
+        project_id: int,
+        user_id: int,
+        mapping_permission: int,
+        project_mapper_level: int,
+    ):
+        # mapping_permission = 1(level),2(teams),3(teamsAndLevel)
+        if mapping_permission == MappingPermission.TEAMS.value:
+            teams_dto = TeamService.get_project_teams_as_dto(project_id)
+
+            if len(teams_dto.teams):
+                for team_dto in teams_dto.teams:
+                    team_id = team_dto.team_id
+                    team_role = team_dto.role
+                    if not (
+                        team_role
+                        in [
+                            TeamRoles.MAPPER.value,
+                            TeamRoles.VALIDATOR.value,
+                            TeamRoles.PROJECT_MANAGER.value,
+                        ]
+                    ):
+                        return False, MappingNotAllowed.NOT_A_MAPPING_TEAM
+                    if not (TeamService.is_user_member_of_team(team_id, user_id)):
+                        return False, MappingNotAllowed.USER_NOT_TEAM_MEMBER
+            else:
+                return False, MappingNotAllowed.PROJECT_HAS_NO_TEAM
+
+        elif mapping_permission == MappingPermission.LEVEL.value:
+            if not (
+                ProjectService._is_user_mapping_level_at_or_above_level_requests(
+                    MappingLevel(project_mapper_level), user_id
+                )
+            ):
+                return False, MappingNotAllowed.USER_NOT_CORRECT_MAPPING_LEVEL
+
+        elif mapping_permission == MappingPermission.TEAMS_LEVEL.value:
+            teams_dto = TeamService.get_project_teams_as_dto(project_id)
+            if len(teams_dto.teams):
+                for team_dto in teams_dto.teams:
+                    team_id = team_dto.team_id
+                    team_role = team_dto.role
+                    if team_role not in [
+                        TeamRoles.MAPPER.value,
+                        TeamRoles.VALIDATOR.value,
+                        TeamRoles.PROJECT_MANAGER.value,
+                    ]:
+                        return False, MappingNotAllowed.NOT_A_MAPPING_TEAM
+
+                    if not (TeamService.is_user_member_of_team(team_id, user_id)):
+                        return False, MappingNotAllowed.USER_NOT_TEAM_MEMBER
+
+                    if not (
+                        ProjectService._is_user_mapping_level_at_or_above_level_requests(
+                            MappingLevel(project_mapper_level), user_id
+                        )
+                    ):
+                        return False, MappingNotAllowed.USER_NOT_CORRECT_MAPPING_LEVEL
+            else:
+                return False, MappingNotAllowed.PROJECT_HAS_NO_TEAM
+
+    @staticmethod
     def is_user_permitted_to_map(project_id: int, user_id: int):
         """ Check if the user is allowed to map the on the project in scope """
         if UserService.is_user_blocked(user_id):
             return False, MappingNotAllowed.USER_NOT_ON_ALLOWED_LIST
 
         project = ProjectService.get_project_by_id(project_id)
+        mapping_permission = project.mapping_permission
+        project_mapper_level = project.mapper_level
 
         if ProjectStatus(
             project.status
@@ -183,29 +252,31 @@ class ProjectService:
             user_id
         ):
             return False, MappingNotAllowed.PROJECT_NOT_PUBLISHED
-
         tasks = Task.get_locked_tasks_for_user(user_id)
-        print(tasks)
-
         if len(tasks.locked_tasks) > 0:
             return False, MappingNotAllowed.USER_ALREADY_HAS_TASK_LOCKED
-
-        if project.restrict_mapping_level_to_project:
-            if not ProjectService._is_user_mapping_level_at_or_above_level_requests(
-                MappingLevel(project.mapper_level), user_id
-            ):
-                return False, MappingNotAllowed.USER_NOT_CORRECT_MAPPING_LEVEL
-
-        if project.license_id:
-            if not UserService.has_user_accepted_license(user_id, project.license_id):
-                return False, MappingNotAllowed.USER_NOT_ACCEPTED_LICENSE
-
         if project.private:
             # Check user is in allowed users
             try:
                 next(user for user in project.allowed_users if user.id == user_id)
             except StopIteration:
                 return False, MappingNotAllowed.USER_NOT_ON_ALLOWED_LIST
+            is_restriction = ProjectService.evaluate_mapping_permission(
+                project_id, user_id, mapping_permission, project_mapper_level
+            )
+            if is_restriction:
+                return is_restriction
+
+        if project.mapping_permission:
+            is_restriction = ProjectService.evaluate_mapping_permission(
+                project_id, user_id, mapping_permission, project_mapper_level
+            )
+            if is_restriction:
+                return is_restriction
+
+        if project.license_id:
+            if not UserService.has_user_accepted_license(user_id, project.license_id):
+                return False, MappingNotAllowed.USER_NOT_ACCEPTED_LICENSE
 
         return True, "User allowed to map"
 
@@ -213,7 +284,6 @@ class ProjectService:
     def _is_user_mapping_level_at_or_above_level_requests(requested_level, user_id):
         """ Helper method to determine if user level at or above requested level """
         user_mapping_level = UserService.get_mapping_level(user_id)
-
         if requested_level == MappingLevel.INTERMEDIATE:
             if user_mapping_level not in [
                 MappingLevel.INTERMEDIATE,
@@ -227,12 +297,73 @@ class ProjectService:
         return True
 
     @staticmethod
+    def evaluate_validation_permission(
+        project_id: int,
+        user_id: int,
+        validation_permission: int,
+        user_mapper_level: int,
+    ):
+        # validation_permission = 1(level),2(teams),3(teamsAndLevel)
+        if validation_permission == ValidationPermission.TEAMS.value:
+            teams_dto = TeamService.get_project_teams_as_dto(project_id)
+
+            if len(teams_dto.teams):
+                for team_dto in teams_dto.teams:
+                    team_id = team_dto.team_id
+                    team_role = team_dto.role
+                    if team_role not in [
+                        TeamRoles.VALIDATOR.value,
+                        TeamRoles.PROJECT_MANAGER.value,
+                    ]:
+                        return False, ValidatingNotAllowed.NOT_A_VALIDATION_TEAM
+                    if not (TeamService.is_user_member_of_team(team_id, user_id)):
+                        return False, ValidatingNotAllowed.USER_NOT_TEAM_MEMBER
+            else:
+                # Fallback to handle initial rollout
+                if not UserService.is_user_validator(user_id):
+                    return False, ValidatingNotAllowed.USER_NOT_VALIDATOR
+
+        elif validation_permission == ValidationPermission.LEVEL.value:
+            if user_mapper_level not in (
+                MappingLevel.INTERMEDIATE.value,
+                MappingLevel.ADVANCED.value,
+            ):
+                return False, ValidatingNotAllowed.USER_IS_BEGINNER
+
+        elif validation_permission == ValidationPermission.TEAMS_LEVEL.value:
+            teams_dto = TeamService.get_project_teams_as_dto(project_id)
+
+            if len(teams_dto.teams):
+                for team_dto in teams_dto.teams:
+                    team_id = team_dto.team_id
+                    team_role = team_dto.role
+                    if team_role not in [
+                        TeamRoles.VALIDATOR.value,
+                        TeamRoles.PROJECT_MANAGER.value,
+                    ]:
+                        return False, ValidatingNotAllowed.NOT_A_VALIDATION_TEAM
+                    if not (TeamService.is_user_member_of_team(team_id, user_id)):
+                        return False, ValidatingNotAllowed.USER_NOT_TEAM_MEMBER
+            else:
+                # Fallback
+                if not UserService.is_user_validator(user_id):
+                    return False, ValidatingNotAllowed.USER_NOT_VALIDATOR
+            if user_mapper_level not in (
+                MappingLevel.INTERMEDIATE.value,
+                MappingLevel.ADVANCED.value,
+            ):
+                return False, ValidatingNotAllowed.USER_IS_BEGINNER
+
+    @staticmethod
     def is_user_permitted_to_validate(project_id, user_id):
         """ Check if the user is allowed to validate on the project in scope """
         if UserService.is_user_blocked(user_id):
             return False, ValidatingNotAllowed.USER_NOT_ON_ALLOWED_LIST
 
         project = ProjectService.get_project_by_id(project_id)
+        validation_permission = project.validation_permission
+        user = UserService.get_user_by_id(user_id)
+        user_mapper_level = user.mapper_level
 
         if ProjectStatus(
             project.status
@@ -246,15 +377,6 @@ class ProjectService:
         if len(tasks.locked_tasks) > 0:
             return False, ValidatingNotAllowed.USER_ALREADY_HAS_TASK_LOCKED
 
-        if project.restrict_validation_role and not UserService.is_user_validator(
-            user_id
-        ):
-            return False, ValidatingNotAllowed.USER_NOT_VALIDATOR
-
-        if project.license_id:
-            if not UserService.has_user_accepted_license(user_id, project.license_id):
-                return False, ValidatingNotAllowed.USER_NOT_ACCEPTED_LICENSE
-
         if project.private:
             # Check user is in allowed users
             try:
@@ -262,14 +384,22 @@ class ProjectService:
             except StopIteration:
                 return False, ValidatingNotAllowed.USER_NOT_ON_ALLOWED_LIST
 
-        # Restrict validation by non-beginners users only
-        if project.restrict_validation_level_intermediate is True:
-            user = UserService.get_user_by_id(user_id)
-            if user.mapping_level not in (
-                MappingLevel.INTERMEDIATE.value,
-                MappingLevel.ADVANCED.value,
-            ):
-                return False, ValidatingNotAllowed.USER_IS_BEGINNER
+            is_restriction = ProjectService.evaluate_validation_permission(
+                project_id, user_id, validation_permission, user_mapper_level
+            )
+            if is_restriction:
+                return is_restriction
+
+        if project.validation_permission:
+            is_restriction = ProjectService.evaluate_validation_permission(
+                project_id, user_id, validation_permission, user_mapper_level
+            )
+            if is_restriction:
+                return is_restriction
+
+        if project.license_id:
+            if not UserService.has_user_accepted_license(user_id, project.license_id):
+                return False, ValidatingNotAllowed.USER_NOT_ACCEPTED_LICENSE
 
         return True, "User allowed to validate"
 

--- a/server/services/team_service.py
+++ b/server/services/team_service.py
@@ -326,7 +326,9 @@ class TeamService:
     @staticmethod
     def get_project_teams_as_dto(project_id: int) -> TeamsListDTO:
         """ Gets all the campaigns for a specified project """
-        project_teams = ProjectTeams.query.filter(project_id == project_id).all()
+        project_teams = ProjectTeams.query.filter(
+            ProjectTeams.project_id == project_id
+        ).all()
         teams_list_dto = TeamsListDTO()
 
         for project_team in project_teams:

--- a/tests/server/unit/services/test_project_service.py
+++ b/tests/server/unit/services/test_project_service.py
@@ -27,11 +27,7 @@ class TestProjectService(unittest.TestCase):
         mock_level.return_value = MappingLevel.BEGINNER
 
         # Act / Assert
-        self.assertFalse(
-            ProjectService._is_user_mapping_level_at_or_above_level_requests(
-                MappingLevel.INTERMEDIATE, 1
-            )
-        )
+        self.assertFalse(ProjectService._is_user_intermediate_or_advanced(1))
 
     @patch.object(UserService, "get_mapping_level")
     def test_user_is_allowed_to_map_if_level_enforced(self, mock_level):
@@ -39,11 +35,7 @@ class TestProjectService(unittest.TestCase):
         mock_level.return_value = MappingLevel.ADVANCED
 
         # Act / Assert
-        self.assertTrue(
-            ProjectService._is_user_mapping_level_at_or_above_level_requests(
-                MappingLevel.ADVANCED, 1
-            )
-        )
+        self.assertTrue(ProjectService._is_user_intermediate_or_advanced(1))
 
     @patch.object(Task, "get_locked_tasks_for_user")
     @patch.object(Project, "get")


### PR DESCRIPTION
- update permissions on the frontend to the new schema based on teams and/or level
- add teams to project summary endpoint
- rename `projectTeams` field to `teams` on the projectsDTO
- update project edit and project code views to fit the new field name

:stop_sign:  To be merged and to work, we depend on some changes on the backend.