### PR TITLE
Change TM4 autoscaling policy to production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,7 +429,7 @@ workflows:
           - build
         stack_name: "tm4"
         environment_name: "production"
-        autoscaling_policy: "demo"
+        autoscaling_policy: "production"
         postgres_db: POSTGRES_DB_TM4
         postgres_password: POSTGRES_PASSWORD_TM4
         postgres_user: POSTGRES_USER_TM4


### PR DESCRIPTION
With this single line change to the CircleCI configuration, we can adjust the autoscaling policy for the TM4 AWS infrastructure. After this test is complete, let's revert back to the `demo` setting until necessary. 