### PR TITLE
avoid maps from loading in the wrong location

### DIFF
--- a/frontend/src/components/projectCreate/projectCreationMap.js
+++ b/frontend/src/components/projectCreate/projectCreationMap.js
@@ -23,7 +23,8 @@ const ProjectCreationMap = ({ mapObj, setMapObj, metadata, updateMetadata }) => 
       map: new mapboxgl.Map({
         container: mapRef.current,
         style: MAP_STYLE,
-        zoom: 0,
+        center: [0, 0],
+        zoom: 1,
         attributionControl: false,
       })
         .addControl(new mapboxgl.AttributionControl({ compact: false }))

--- a/frontend/src/components/projectEdit/priorityAreasForm.js
+++ b/frontend/src/components/projectEdit/priorityAreasForm.js
@@ -52,7 +52,8 @@ export const PriorityAreasForm = () => {
       new mapboxgl.Map({
         container: mapRef.current,
         style: MAP_STYLE,
-        zoom: 0,
+        center: [0, 0],
+        zoom: 1,
         attributionControl: false,
       })
         .addControl(new mapboxgl.AttributionControl({ compact: false }))

--- a/frontend/src/components/projects/projectsMap.js
+++ b/frontend/src/components/projects/projectsMap.js
@@ -128,7 +128,8 @@ export const ProjectsMap = ({
       new mapboxgl.Map({
         container: mapRef.current,
         style: MAP_STYLE,
-        zoom: 0,
+        center: [0, 0],
+        zoom: 0.5,
         attributionControl: false,
       })
         .addControl(new mapboxgl.AttributionControl({ compact: false }))

--- a/frontend/src/components/taskSelection/map.js
+++ b/frontend/src/components/taskSelection/map.js
@@ -43,8 +43,8 @@ export const TasksMap = ({
       new mapboxgl.Map({
         container: mapRef.current,
         style: MAP_STYLE,
-        zoom: 2,
-        minZoom: 2,
+        center: [0, 0],
+        zoom: 1,
         attributionControl: false,
       })
         .addControl(new mapboxgl.AttributionControl({ compact: false }))

--- a/frontend/src/components/userDetail/countriesMapped.js
+++ b/frontend/src/components/userDetail/countriesMapped.js
@@ -35,7 +35,8 @@ const UserCountriesMap = ({ projects }) => {
       new mapboxgl.Map({
         container: mapRef.current,
         style: MAP_STYLE,
-        zoom: 0,
+        center: [0, 0],
+        zoom: 0.5,
         attributionControl: false,
       })
         .addControl(new mapboxgl.AttributionControl({ compact: false }))


### PR DESCRIPTION
We had a problem with center location of the Mapbox Style we are using. The style will be fixed, but in order to avoid problems with other styles, I found a solution (and probably a bug in mapbox-gl-js: https://github.com/mapbox/mapbox-gl-js/issues/9299).