### PR TITLE
improve user filtering on task selection page list

### DIFF
--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -227,6 +227,7 @@ export function TaskSelection({ project, type, loading }: Object) {
                       tasks={activities || initialActivities}
                       selectTask={selectTask}
                       selected={selected}
+                      userContributions={contributions.userContributions}
                     />
                   ) : null}
                   {activeSection === 'instructions' ? (

--- a/frontend/src/components/taskSelection/taskList.js
+++ b/frontend/src/components/taskSelection/taskList.js
@@ -140,7 +140,14 @@ export function TaskFilter({ project, statusFilter, setStatusFn }: Object) {
   return <></>;
 }
 
-export function TaskList({ project, tasks, activeFilter, selectTask, selected }: Object) {
+export function TaskList({
+  project,
+  tasks,
+  activeFilter,
+  selectTask,
+  selected,
+  userContributions,
+}: Object) {
   const user = useSelector(state => state.auth.get('userDetails'));
   const [readyTasks, setTasks] = useState([]);
   const [textSearch, setTextSearch] = useQueryParam('search', StringParam);
@@ -157,15 +164,23 @@ export function TaskList({ project, tasks, activeFilter, selectTask, selected }:
         newTasks = newTasks.filter(task => ['MAPPED', 'BADIMAGERY'].includes(task.taskStatus));
       }
       if (textSearch) {
-        newTasks = newTasks.filter(
-          task =>
-            task.taskId === Number(textSearch) ||
-            (task.actionBy && task.actionBy.includes(textSearch)),
-        );
+        if (Number(textSearch)) {
+          newTasks = newTasks.filter(
+            task =>
+              task.taskId === Number(textSearch) ||
+              (task.actionBy && task.actionBy.includes(textSearch)),
+          );
+        } else {
+          const usersTaskIds = userContributions
+            .filter(user => user.username.includes(textSearch))
+            .map(user => user.taskIds)
+            .flat();
+          newTasks = newTasks.filter(task => usersTaskIds.includes(task.taskId));
+        }
       }
       setTasks(newTasks);
     }
-  }, [textSearch, statusFilter, tasks]);
+  }, [textSearch, statusFilter, tasks, userContributions]);
 
   function updateSortingOption(data: Object) {
     if (data) {

--- a/frontend/src/views/userDetail.js
+++ b/frontend/src/views/userDetail.js
@@ -58,7 +58,7 @@ export const UserDetail = ({ username, withHeader = true }) => {
           </ReactPlaceholder>
         </div>
       )}
-      <div className={withHeader && 'w-100 ph6-l ph4-m ph2 cf pb3'}>
+      <div className={withHeader ? 'w-100 ph6-l ph4-m ph2 cf pb3' : ''}>
         <div className="mv4">
           <ElementsMapped userStats={userStats} osmStats={osmStats} />
         </div>


### PR DESCRIPTION
The search by username on the task selection page was considering only the last user that interacted with that task, so I changed it in order to return all the tasks a user has contributed to.