### PR TITLE
Check list endpoints to not return 404 errors

### DIFF
--- a/frontend/src/components/localeSelect.js
+++ b/frontend/src/components/localeSelect.js
@@ -48,9 +48,6 @@ const mapStateToProps = state => ({
   token: state.auth.get('token'),
 });
 
-const LocaleSelector = connect(
-  mapStateToProps,
-  { setLocale },
-)(LocaleSelect);
+const LocaleSelector = connect(mapStateToProps, { setLocale })(LocaleSelect);
 
 export { LocaleSelector };

--- a/frontend/src/components/taskSelection/contributions.js
+++ b/frontend/src/components/taskSelection/contributions.js
@@ -6,8 +6,6 @@ import { injectIntl } from 'react-intl';
 import messages from './messages.js';
 import { UserAvatar } from '../user/avatar';
 import { CheckCircle } from '../checkCircle';
-import ProjectProgressBar from '../projectcard/projectProgressBar';
-import { computeCompleteness } from '../../utils/projectCompletenessCalc';
 
 const Contributions = props => {
   const mappingLevels = [
@@ -18,7 +16,8 @@ const Contributions = props => {
   ];
 
   const [level, setLevel] = useState(mappingLevels[0]);
-  const { percentMapped, percentValidated } = computeCompleteness(props.tasks);
+  const [activeStatus, setActiveStatus] = useState(null);
+  const [activeUser, setActiveUser] = useState(null);
 
   const MappingLevelSelect = () => {
     return (
@@ -33,13 +32,13 @@ const Contributions = props => {
   };
 
   const checkActiveUserAndStatus = (status, username) =>
-    props.activeStatus === status && props.activeUser === username
-      ? 'bg-blue-dark'
-      : 'bg-grey-light';
+    activeStatus === status && activeUser === username ? 'bg-blue-dark' : 'bg-grey-light';
 
   const displayTasks = (taskIds, status, user) => {
-    if (props.activeStatus === status && user === props.activeUser) {
+    if (activeStatus === status && user === activeUser) {
       props.selectTask([]);
+      setActiveStatus(null);
+      setActiveUser(null);
     } else {
       let filteredTasksByStatus = props.tasks.features;
       if (status === 'MAPPED') {
@@ -55,7 +54,9 @@ const Contributions = props => {
       const ids = filteredTasksByStatus
         .filter(t => taskIds.includes(t.properties.taskId))
         .map(f => f.properties.taskId);
-      props.selectTask(ids, status, user);
+      props.selectTask(ids, status);
+      setActiveUser(user);
+      setActiveStatus(status);
     }
   };
 
@@ -67,11 +68,6 @@ const Contributions = props => {
   return (
     <div className="w-100 f5 pr4-l pr2 cf blue-dark bg-white">
       <div className="w-100 fr cf">
-        <ProjectProgressBar
-          percentMapped={percentMapped}
-          percentValidated={percentValidated}
-          className="pt1 pb3"
-        />
         <MappingLevelSelect />
       </div>
       <div className="w-100 fl cf">
@@ -85,7 +81,7 @@ const Contributions = props => {
             return (
               <div
                 className={`w-100 cf pv3 ph3-ns ph1 ba bw1 mb2 ${
-                  props.activeUser === user.username ? 'b--blue-dark' : 'b--tan'
+                  activeUser === user.username ? 'b--blue-dark' : 'b--tan'
                 }`}
               >
                 <div className="w-30 fl dib truncate">

--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -239,6 +239,8 @@ export function TaskSelection({ project, type, loading }: Object) {
                       selectTask={selectTask}
                       tasks={tasks}
                       contribsData={contributions}
+                      activeUser={activeUser}
+                      activeStatus={activeStatus}
                     />
                   ) : null}
                 </div>

--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -239,8 +239,6 @@ export function TaskSelection({ project, type, loading }: Object) {
                       selectTask={selectTask}
                       tasks={tasks}
                       contribsData={contributions}
-                      activeUser={activeUser}
-                      activeStatus={activeStatus}
                     />
                   ) : null}
                 </div>

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -382,15 +382,15 @@ export default defineMessages({
     defaultMessage: 'All levels',
   },
   mappingLevelADVANCED: {
-    id: 'project.level.advanced',
+    id: 'mapping.level.advanced',
     defaultMessage: 'Advanced',
   },
   mappingLevelINTERMEDIATE: {
-    id: 'project.level.intermediate',
+    id: 'mapping.level.intermediate',
     defaultMessage: 'Intermediate',
   },
   mappingLevelBEGINNER: {
-    id: 'project.level.beginner',
+    id: 'mapping.level.beginner',
     defaultMessage: 'Beginner',
   },
 });

--- a/frontend/src/utils/internationalization.js
+++ b/frontend/src/utils/internationalization.js
@@ -145,9 +145,6 @@ const mapStateToProps = state => ({
   locale: state.preferences.locale || navigator.language,
 });
 
-ConnectedIntl = connect(
-  mapStateToProps,
-  { setLocale },
-)(ConnectedIntl);
+ConnectedIntl = connect(mapStateToProps, { setLocale })(ConnectedIntl);
 
 export { ConnectedIntl, supportedLocales, getSupportedLocale, getTranslatedMessages };

--- a/frontend/src/utils/projectPermissions.js
+++ b/frontend/src/utils/projectPermissions.js
@@ -17,21 +17,21 @@ export function userCanMap(user, project, userTeams = []) {
     }
   }
 
-  // if mappingPermission is ANY, all users can map
-  if (project.mappingPermission === 'ANY') return true;
+  // if mappingPermission is any, all users can map
+  if (project.mappingPermission === 'any') return true;
 
   // if mappingPermission is level, only INTERMEDIATE and ADVANCED users can map
-  if (project.mappingPermission === 'LEVEL') {
+  if (project.mappingPermission === 'level') {
     return isUserExperienced;
   }
 
   // if mappingPermission is team, only members of a project team can map
-  if (project.mappingPermission === 'TEAMS') {
+  if (project.mappingPermission === 'teams') {
     return isUserMemberOfATeam;
   }
 
   // if mappingPermission is team, only INTERMEDIATE and ADVANCED members of a project team can map
-  if (project.mappingPermission === 'TEAMS_LEVEL') {
+  if (project.mappingPermission === 'teamsAndLevel') {
     return isUserMemberOfATeam && isUserExperienced;
   }
 }
@@ -55,21 +55,21 @@ export function userCanValidate(user, project, userTeams = []) {
     }
   }
 
-  // if validationPermission is ANY, all users can validate
-  if (project.validationPermission === 'ANY') return true;
+  // if validationPermission is any, all users can validate
+  if (project.validationPermission === 'any') return true;
 
   // if validationPermission is level, only INTERMEDIATE and ADVANCED users can validate
-  if (project.validationPermission === 'LEVEL') {
+  if (project.validationPermission === 'level') {
     return isUserExperienced;
   }
 
   // if validationPermission is team, only members of a project team can validate
-  if (project.validationPermission === 'TEAMS') {
+  if (project.validationPermission === 'teams') {
     return isUserMemberOfATeam;
   }
 
   // if validationPermission is team, only INTERMEDIATE and ADVANCED members of a project team can validate
-  if (project.validationPermission === 'TEAMS_LEVEL') {
+  if (project.validationPermission === 'teamsAndLevel') {
     return isUserMemberOfATeam && isUserExperienced;
   }
 }

--- a/frontend/src/utils/tests/permissionsToMap.test.js
+++ b/frontend/src/utils/tests/permissionsToMap.test.js
@@ -9,10 +9,10 @@ it('READ_ONLY role USER can NOT map any project', () => {
     },
   ];
   const user = { mappingLevel: 'ADVANCED', role: 'READ_ONLY' };
-  const project1 = { mappingPermission: 'ANY', teams: [{ teamId: 7, role: 'MAPPER' }] };
-  const project2 = { mappingPermission: 'TEAMS', teams: [{ teamId: 7, role: 'MAPPER' }] };
-  const project3 = { mappingPermission: 'LEVEL', teams: [{ teamId: 7, role: 'MAPPER' }] };
-  const project4 = { mappingPermission: 'TEAMS_LEVEL', teams: [{ teamId: 7, role: 'MAPPER' }] };
+  const project1 = { mappingPermission: 'any', teams: [{ teamId: 7, role: 'MAPPER' }] };
+  const project2 = { mappingPermission: 'teams', teams: [{ teamId: 7, role: 'MAPPER' }] };
+  const project3 = { mappingPermission: 'level', teams: [{ teamId: 7, role: 'MAPPER' }] };
+  const project4 = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 7, role: 'MAPPER' }] };
   expect(userCanMap(user, project1, userTeams)).toBe(false);
   expect(userCanMap(user, project2, userTeams)).toBe(false);
   expect(userCanMap(user, project3, userTeams)).toBe(false);
@@ -22,8 +22,8 @@ it('READ_ONLY role USER can NOT map any project', () => {
 describe('PROJECTS with mappingPermission set to any', () => {
   it('CAN be mapped by a BEGINNER user that is not on a team', () => {
     const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'ANY', teams: [] };
-    const project2 = { mappingPermission: 'ANY', teams: [{ teamId: 7, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'any', teams: [] };
+    const project2 = { mappingPermission: 'any', teams: [{ teamId: 7, role: 'MAPPER' }] };
     expect(userCanMap(user, project1)).toBe(true);
     expect(userCanMap(user, project2)).toBe(true);
   });
@@ -39,7 +39,7 @@ describe('PROJECTS with mappingPermission set to level', () => {
       },
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'LEVEL', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'level', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(false);
   });
 
@@ -52,13 +52,13 @@ describe('PROJECTS with mappingPermission set to level', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'LEVEL', teams: [{ teamId: 7, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'level', teams: [{ teamId: 7, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(true);
   });
 
   it('CAN be mapped by an ADVANCED level USER', () => {
     const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-    const project = { mappingPermission: 'LEVEL', teams: [{ teamId: 7, role: 'MAPPER' }] };
+    const project = { mappingPermission: 'level', teams: [{ teamId: 7, role: 'MAPPER' }] };
     expect(userCanMap(user, project)).toBe(true);
   });
 });
@@ -73,9 +73,9 @@ describe('PROJECTS with mappingPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
-    const project2 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
-    const project3 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project2 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project3 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(true);
     expect(userCanMap(user, project2, userTeams)).toBe(true);
     expect(userCanMap(user, project3, userTeams)).toBe(true);
@@ -90,9 +90,9 @@ describe('PROJECTS with mappingPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
-    const project2 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
-    const project3 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project2 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project3 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(true);
     expect(userCanMap(user, project2, userTeams)).toBe(true);
     expect(userCanMap(user, project3, userTeams)).toBe(true);
@@ -107,7 +107,7 @@ describe('PROJECTS with mappingPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-    const project = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project, userTeams)).toBe(true);
   });
 
@@ -120,7 +120,7 @@ describe('PROJECTS with mappingPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(false);
   });
 
@@ -133,7 +133,7 @@ describe('PROJECTS with mappingPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(false);
   });
 
@@ -146,7 +146,7 @@ describe('PROJECTS with mappingPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'TEAMS', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'teams', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(false);
   });
 });
@@ -171,13 +171,13 @@ describe('PROJECTS with mappingPermission set to teamsAndLevel', () => {
       },
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'TEAMS_LEVEL', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
     const project2 = {
-      mappingPermission: 'TEAMS_LEVEL',
+      mappingPermission: 'teamsAndLevel',
       teams: [{ teamId: 2, role: 'VALIDATOR' }],
     };
     const project3 = {
-      mappingPermission: 'TEAMS_LEVEL',
+      mappingPermission: 'teamsAndLevel',
       teams: [{ teamId: 3, role: 'PROJECT_MANAGER' }],
     };
     expect(userCanMap(user, project1, userTeams)).toBe(false);
@@ -204,13 +204,13 @@ describe('PROJECTS with mappingPermission set to teamsAndLevel', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'TEAMS_LEVEL', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
     const project2 = {
-      mappingPermission: 'TEAMS_LEVEL',
+      mappingPermission: 'teamsAndLevel',
       teams: [{ teamId: 2, role: 'VALIDATOR' }],
     };
     const project3 = {
-      mappingPermission: 'TEAMS_LEVEL',
+      mappingPermission: 'teamsAndLevel',
       teams: [{ teamId: 3, role: 'PROJECT_MANAGER' }],
     };
     expect(userCanMap(user, project1, userTeams)).toBe(true);
@@ -227,7 +227,7 @@ describe('PROJECTS with mappingPermission set to teamsAndLevel', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'MAPPER' };
-    const project1 = { mappingPermission: 'TEAMS_LEVEL', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project1 = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project1, userTeams)).toBe(false);
   });
 
@@ -240,7 +240,7 @@ describe('PROJECTS with mappingPermission set to teamsAndLevel', () => {
       },
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-    const project = { mappingPermission: 'TEAMS_LEVEL', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project, userTeams)).toBe(true);
   });
 
@@ -253,7 +253,7 @@ describe('PROJECTS with mappingPermission set to teamsAndLevel', () => {
       },
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'MAPPER' };
-    const project = { mappingPermission: 'TEAMS_LEVEL', teams: [{ teamId: 1, role: 'MAPPER' }] };
+    const project = { mappingPermission: 'teamsAndLevel', teams: [{ teamId: 1, role: 'MAPPER' }] };
     expect(userCanMap(user, project, userTeams)).toBe(false);
   });
 });
@@ -264,7 +264,7 @@ describe('PRIVATE projects', () => {
     const user = { username: 'user1', mappingLevel: 'ADVANCED', role: 'READ_ONLY' };
     const project = {
       private: true,
-      mappingPermission: 'TEAMS',
+      mappingPermission: 'teams',
       allowedUsernames: ['user1'],
       teams: [],
     };
@@ -274,7 +274,7 @@ describe('PRIVATE projects', () => {
   it('can NOT be mapped by an ADVANCED user if their username is NOT ALLOWED', () => {
     const user = { username: 'user3000', mappingLevel: 'ADVANCED', role: 'MAPPER' };
     const project = {
-      mappingPermission: 'TEAMS',
+      mappingPermission: 'teams',
       private: true,
       allowedUsernames: ['user1'],
       teams: [],
@@ -285,7 +285,7 @@ describe('PRIVATE projects', () => {
   it('CAN be mapped by a BEGINNER USER if their username is ALLOWED', () => {
     const user = { username: 'user1', mappingLevel: 'BEGINNER', role: 'MAPPER' };
     const project = {
-      mappingPermission: 'TEAMS',
+      mappingPermission: 'teams',
       private: true,
       allowedUsernames: ['user1'],
       teams: [],
@@ -303,7 +303,7 @@ describe('PRIVATE projects', () => {
     ];
     const user = { username: 'user1', mappingLevel: 'BEGINNER', role: 'MAPPER' };
     const project = {
-      mappingPermission: 'TEAMS',
+      mappingPermission: 'teams',
       private: true,
       allowedUsernames: [],
       teams: [{ teamId: 1, role: 'MAPPER' }],

--- a/frontend/src/utils/tests/permissionsToValidate.test.js
+++ b/frontend/src/utils/tests/permissionsToValidate.test.js
@@ -9,11 +9,11 @@ it('READ_ONLY role USER can NOT validate any project', () => {
     },
   ];
   const user = { mappingLevel: 'ADVANCED', role: 'READ_ONLY' };
-  const project1 = { validationPermission: 'ANY', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
-  const project2 = { validationPermission: 'TEAMS', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
-  const project3 = { validationPermission: 'LEVEL', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+  const project1 = { validationPermission: 'any', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+  const project2 = { validationPermission: 'teams', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+  const project3 = { validationPermission: 'level', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
   const project4 = {
-    validationPermission: 'TEAMS_LEVEL',
+    validationPermission: 'teamsAndLevel',
     teams: [{ teamId: 7, role: 'VALIDATOR' }],
   };
   expect(userCanValidate(user, project1, userTeams)).toBe(false);
@@ -25,8 +25,8 @@ it('READ_ONLY role USER can NOT validate any project', () => {
 describe('PROJECTS with validationPermission set to any', () => {
   it('CAN be validated by a BEGINNER user that is not on a team', () => {
     const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
-    const project1 = { validationPermission: 'ANY', teams: [] };
-    const project2 = { validationPermission: 'ANY', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'any', teams: [] };
+    const project2 = { validationPermission: 'any', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project1)).toBe(true);
     expect(userCanValidate(user, project2)).toBe(true);
   });
@@ -42,7 +42,7 @@ describe('PROJECTS with validationPermission set to level', () => {
       },
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
-    const project1 = { validationPermission: 'LEVEL', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'level', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project1, userTeams)).toBe(false);
   });
 
@@ -55,13 +55,13 @@ describe('PROJECTS with validationPermission set to level', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
-    const project1 = { validationPermission: 'LEVEL', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'level', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project1, userTeams)).toBe(true);
   });
 
   it('CAN be validated by an ADVANCED level USER', () => {
     const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
-    const project = { validationPermission: 'LEVEL', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
+    const project = { validationPermission: 'level', teams: [{ teamId: 7, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project)).toBe(true);
   });
 });
@@ -81,9 +81,9 @@ describe('PROJECTS with validationPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
-    const project1 = { validationPermission: 'TEAMS', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
     const project2 = {
-      validationPermission: 'TEAMS',
+      validationPermission: 'teams',
       teams: [{ teamId: 2, role: 'PROJECT_MANAGER' }],
     };
     expect(userCanValidate(user, project1, userTeams)).toBe(true);
@@ -104,9 +104,9 @@ describe('PROJECTS with validationPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
-    const project1 = { validationPermission: 'TEAMS', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
     const project2 = {
-      validationPermission: 'TEAMS',
+      validationPermission: 'teams',
       teams: [{ teamId: 2, role: 'PROJECT_MANAGER' }],
     };
     expect(userCanValidate(user, project1, userTeams)).toBe(true);
@@ -122,7 +122,7 @@ describe('PROJECTS with validationPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
-    const project = { validationPermission: 'TEAMS', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project, userTeams)).toBe(true);
   });
 
@@ -135,7 +135,7 @@ describe('PROJECTS with validationPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
-    const project1 = { validationPermission: 'TEAMS', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project1, userTeams)).toBe(false);
   });
 
@@ -148,7 +148,7 @@ describe('PROJECTS with validationPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
-    const project1 = { validationPermission: 'TEAMS', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project1, userTeams)).toBe(false);
   });
 
@@ -161,7 +161,7 @@ describe('PROJECTS with validationPermission set as teams', () => {
       },
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
-    const project1 = { validationPermission: 'TEAMS', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
+    const project1 = { validationPermission: 'teams', teams: [{ teamId: 1, role: 'VALIDATOR' }] };
     expect(userCanValidate(user, project1, userTeams)).toBe(false);
   });
 });
@@ -177,7 +177,7 @@ describe('PROJECTS with validationPermission set to teamsAndLevel', () => {
     ];
     const user = { mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
     const project1 = {
-      validationPermission: 'TEAMS_LEVEL',
+      validationPermission: 'teamsAndLevel',
       teams: [{ teamId: 1, role: 'VALIDATOR' }],
     };
     expect(userCanValidate(user, project1, userTeams)).toBe(false);
@@ -193,7 +193,7 @@ describe('PROJECTS with validationPermission set to teamsAndLevel', () => {
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
     const project1 = {
-      validationPermission: 'TEAMS_LEVEL',
+      validationPermission: 'teamsAndLevel',
       teams: [{ teamId: 1, role: 'VALIDATOR' }],
     };
     expect(userCanValidate(user, project1, userTeams)).toBe(true);
@@ -209,7 +209,7 @@ describe('PROJECTS with validationPermission set to teamsAndLevel', () => {
     ];
     const user = { mappingLevel: 'INTERMEDIATE', role: 'VALIDATOR' };
     const project1 = {
-      validationPermission: 'TEAMS_LEVEL',
+      validationPermission: 'teamsAndLevel',
       teams: [{ teamId: 1, role: 'VALIDATOR' }],
     };
     expect(userCanValidate(user, project1, userTeams)).toBe(false);
@@ -225,7 +225,7 @@ describe('PROJECTS with validationPermission set to teamsAndLevel', () => {
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
     const project = {
-      validationPermission: 'TEAMS_LEVEL',
+      validationPermission: 'teamsAndLevel',
       teams: [{ teamId: 1, role: 'VALIDATOR' }],
     };
     expect(userCanValidate(user, project, userTeams)).toBe(true);
@@ -241,7 +241,7 @@ describe('PROJECTS with validationPermission set to teamsAndLevel', () => {
     ];
     const user = { mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
     const project = {
-      validationPermission: 'TEAMS_LEVEL',
+      validationPermission: 'teamsAndLevel',
       teams: [{ teamId: 1, role: 'VALIDATOR' }],
     };
     expect(userCanValidate(user, project, userTeams)).toBe(false);
@@ -254,7 +254,7 @@ describe('PRIVATE projects', () => {
     const user = { username: 'user1', mappingLevel: 'ADVANCED', role: 'READ_ONLY' };
     const project = {
       private: true,
-      validationPermission: 'TEAMS',
+      validationPermission: 'teams',
       allowedUsernames: ['user1'],
       teams: [],
     };
@@ -264,7 +264,7 @@ describe('PRIVATE projects', () => {
   it('can NOT be validated by an ADVANCED user if their username is NOT ALLOWED', () => {
     const user = { username: 'user3000', mappingLevel: 'ADVANCED', role: 'VALIDATOR' };
     const project = {
-      validationPermission: 'TEAMS',
+      validationPermission: 'teams',
       private: true,
       allowedUsernames: ['user1'],
       teams: [],
@@ -275,7 +275,7 @@ describe('PRIVATE projects', () => {
   it('CAN be validated by a BEGINNER USER if their username is ALLOWED', () => {
     const user = { username: 'user1', mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
     const project = {
-      validationPermission: 'TEAMS',
+      validationPermission: 'teams',
       private: true,
       allowedUsernames: ['user1'],
       teams: [],
@@ -293,7 +293,7 @@ describe('PRIVATE projects', () => {
     ];
     const user = { username: 'user1', mappingLevel: 'BEGINNER', role: 'VALIDATOR' };
     const project = {
-      validationPermission: 'TEAMS',
+      validationPermission: 'teams',
       private: true,
       allowedUsernames: [],
       teams: [{ teamId: 1, role: 'VALIDATOR' }],

--- a/frontend/src/utils/tests/taskAction.test.js
+++ b/frontend/src/utils/tests/taskAction.test.js
@@ -62,8 +62,8 @@ it('READY TASK selected and USER able to map returns mapSelectedTask', () => {
     percentMapped: 40,
     percentBadImagery: 0,
     percentValidated: 0,
-    mappingPermission: 'ANY',
-    validationPermission: 'TEAMS_LEVEL',
+    mappingPermission: 'any',
+    validationPermission: 'teamsAndLevel',
     teams: [],
   };
   const taskStatus = 'READY';
@@ -76,8 +76,8 @@ it('READY TASK selected and USER unable to map returns selectAnotherProject', ()
     percentMapped: 40,
     percentBadImagery: 0,
     percentValidated: 0,
-    mappingPermission: 'TEAMS',
-    validationPermission: 'TEAMS',
+    mappingPermission: 'teams',
+    validationPermission: 'teams',
     teams: [],
   };
   const taskStatus = 'READY';
@@ -90,8 +90,8 @@ it('MAPPED TASK selected and USER able to map, but unable to validate, returns m
     percentMapped: 40,
     percentBadImagery: 0,
     percentValidated: 0,
-    mappingPermission: 'ANY',
-    validationPermission: 'LEVEL',
+    mappingPermission: 'any',
+    validationPermission: 'level',
     teams: [],
   };
   const taskStatus = 'MAPPED';
@@ -104,8 +104,8 @@ it('MAPPED TASK selected and USER able to validate returns validatedSelectedTask
     percentMapped: 100,
     percentValidated: 50,
     percentBadImagery: 0,
-    mappingPermission: 'ANY',
-    validationPermission: 'ANY',
+    mappingPermission: 'any',
+    validationPermission: 'any',
     teams: [],
   };
   const taskStatus = 'MAPPED';
@@ -118,8 +118,8 @@ it('No tasks selected and USER able to validate returns validatedATask', () => {
     percentMapped: 100,
     percentValidated: 50,
     percentBadImagery: 0,
-    mappingPermission: 'LEVEL',
-    validationPermission: 'LEVEL',
+    mappingPermission: 'level',
+    validationPermission: 'level',
     teams: [],
   };
   expect(getTaskAction(user, project, null)).toBe('validateATask');
@@ -131,8 +131,8 @@ it('completely mapped project returns mappingIsComplete message to a user that c
     percentMapped: 100,
     percentValidated: 50,
     percentBadImagery: 0,
-    mappingPermission: 'LEVEL',
-    validationPermission: 'TEAMS',
+    mappingPermission: 'level',
+    validationPermission: 'teams',
     teams: [],
   };
   const taskStatus = 'MAPPED';
@@ -145,8 +145,8 @@ it('completely mapped and validated project returns projectIsComplete to user ab
     percentMapped: 100,
     percentValidated: 100,
     percentBadImagery: 0,
-    mappingPermission: 'ANY',
-    validationPermission: 'ANY',
+    mappingPermission: 'any',
+    validationPermission: 'any',
     teams: [],
   };
   const taskStatus = 'VALIDATED';
@@ -159,8 +159,8 @@ it('completely mapped and validated project returns projectIsComplete to user ab
     percentMapped: 100,
     percentValidated: 100,
     percentBadImagery: 0,
-    mappingPermission: 'ANY',
-    validationPermission: 'ANY',
+    mappingPermission: 'any',
+    validationPermission: 'any',
     teams: [],
   };
   const taskStatus = 'VALIDATED';

--- a/frontend/src/views/authorized.js
+++ b/frontend/src/views/authorized.js
@@ -46,8 +46,5 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-Authorized = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(Authorized);
+Authorized = connect(mapStateToProps, mapDispatchToProps)(Authorized);
 export { Authorized };

--- a/frontend/src/views/projectEdit.js
+++ b/frontend/src/views/projectEdit.js
@@ -213,9 +213,7 @@ export function ProjectEdit({ id }) {
             setError: setError,
           }}
         >
-          <div className="fl w-70-l w-100 ph0-l ph4-m ph2">
-            {renderForm(option)}
-          </div>
+          <div className="fl w-70-l w-100 ph0-l ph4-m ph2">{renderForm(option)}</div>
         </StateContext.Provider>
       </ReactPlaceholder>
     </div>

--- a/server/api/annotations/resources.py
+++ b/server/api/annotations/resources.py
@@ -35,10 +35,7 @@ class AnnotationsRestAPI(Resource):
             500:
                 description: Internal Server Error
         """
-        try:
-            ProjectService.get_project_by_id(project_id)
-        except NotFound as e:
-            current_app.logger.error(f"Error validating project: {str(e)}")
+        if not ProjectService.exists(project_id):
             return {"Error": "Project not found"}, 404
 
         try:

--- a/server/api/comments/resources.py
+++ b/server/api/comments/resources.py
@@ -111,7 +111,7 @@ class CommentsProjectsRestAPI(Resource):
             project_messages = ChatService.get_messages(project_id, page, per_page)
             return project_messages.to_primitive(), 200
         except NotFound:
-            return {"Error": "No chat messages found for project"}, 404
+            return {"Error": "Project not found"}, 404
         except Exception as e:
             error_msg = f"Chat GET - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)

--- a/server/api/projects/activities.py
+++ b/server/api/projects/activities.py
@@ -1,4 +1,5 @@
 from flask_restful import Resource, current_app, request
+from server.services.project_service import ProjectService
 from server.services.stats_service import StatsService, NotFound
 
 
@@ -30,12 +31,12 @@ class ProjectsActivitiesAPI(Resource):
             500:
                 description: Internal Server Error
         """
+        if not ProjectService.exists(project_id):
+            return {"Error": "Project not found"}, 404
         try:
             page = int(request.args.get("page")) if request.args.get("page") else 1
             activity = StatsService.get_latest_activity(project_id, page)
             return activity.to_primitive(), 200
-        except NotFound:
-            return {"Error": "No activity on project"}, 404
         except Exception as e:
             error_msg = f"User GET - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)

--- a/server/api/projects/contributions.py
+++ b/server/api/projects/contributions.py
@@ -28,6 +28,8 @@ class ProjectsContributionsAPI(Resource):
             500:
                 description: Internal Server Error
         """
+        if not ProjectService.exists(project_id):
+            return {"Error": "Project not found"}, 404
         try:
             contributions = StatsService.get_user_contributions(project_id)
             return contributions.to_primitive(), 200

--- a/server/models/postgis/task_annotation.py
+++ b/server/models/postgis/task_annotation.py
@@ -81,9 +81,9 @@ class TaskAnnotation(db.Model):
             project_id=project_id, annotation_type=annotation_type
         ).all()
 
+        project_task_annotations_dto = ProjectTaskAnnotationsDTO()
+        project_task_annotations_dto.project_id = project_id
         if project_task_annotations:
-            project_task_annotations_dto = ProjectTaskAnnotationsDTO()
-            project_task_annotations_dto.project_id = project_id
             for row in project_task_annotations:
                 task_annotation_dto = TaskAnnotationDTO()
                 task_annotation_dto.task_id = row.task_id
@@ -93,9 +93,7 @@ class TaskAnnotation(db.Model):
                 task_annotation_dto.annotation_markdown = row.annotation_markdown
                 project_task_annotations_dto.tasks.append(task_annotation_dto)
 
-            return project_task_annotations_dto
-        else:
-            raise NotFound
+        return project_task_annotations_dto
 
     @staticmethod
     def get_task_annotations_by_project_id(project_id):
@@ -104,9 +102,9 @@ class TaskAnnotation(db.Model):
             project_id=project_id
         ).all()
 
+        project_task_annotations_dto = ProjectTaskAnnotationsDTO()
+        project_task_annotations_dto.project_id = project_id
         if project_task_annotations:
-            project_task_annotations_dto = ProjectTaskAnnotationsDTO()
-            project_task_annotations_dto.project_id = project_id
             for row in project_task_annotations:
                 task_annotation_dto = TaskAnnotationDTO()
                 task_annotation_dto.task_id = row.task_id
@@ -115,6 +113,4 @@ class TaskAnnotation(db.Model):
                 task_annotation_dto.annotation_source = row.annotation_source
                 project_task_annotations_dto.tasks.append(task_annotation_dto)
 
-            return project_task_annotations_dto
-        else:
-            raise NotFound
+        return project_task_annotations_dto

--- a/server/models/postgis/task_annotation.py
+++ b/server/models/postgis/task_annotation.py
@@ -1,4 +1,4 @@
-from server.models.postgis.utils import timestamp, NotFound
+from server.models.postgis.utils import timestamp
 from server import db
 from server.models.dtos.task_annotation_dto import TaskAnnotationDTO
 from server.models.dtos.project_dto import ProjectTaskAnnotationsDTO

--- a/server/services/project_service.py
+++ b/server/services/project_service.py
@@ -1,6 +1,7 @@
 import datetime
 from cachetools import TTLCache, cached
 from flask import current_app
+from server import db
 from server.models.dtos.mapping_dto import TaskDTOs
 from server.models.dtos.project_dto import (
     ProjectDTO,
@@ -48,6 +49,11 @@ class ProjectService:
             raise NotFound()
 
         return project
+
+    @staticmethod
+    def exists(project_id: int) -> bool:
+        query = Project.query.filter_by(id=project_id).exists()
+        return db.session.query(query).scalar()
 
     @staticmethod
     def get_project_by_name(project_id: int) -> Project:

--- a/server/services/stats_service.py
+++ b/server/services/stats_service.py
@@ -21,7 +21,7 @@ from server.models.dtos.project_dto import ProjectSearchResultsDTO
 from server.models.postgis.project import Project
 from server.models.postgis.statuses import TaskStatus, MappingLevel
 from server.models.postgis.task import TaskHistory, User, Task, TaskAction
-from server.models.postgis.utils import timestamp, NotFound
+from server.models.postgis.utils import timestamp
 from server.services.project_service import ProjectService
 from server.services.project_search_service import ProjectSearchService
 from server.services.users.user_service import UserService
@@ -130,9 +130,6 @@ class StatsService:
             .order_by(TaskHistory.action_date.desc())
             .paginate(page, 10, True)
         )
-
-        if results.total == 0:
-            raise NotFound()
 
         activity_dto = ProjectActivityDTO()
         for item in results.items:


### PR DESCRIPTION
Closes #2047 

Fix `Activities` and `Contributions` endpoints which were returning 404 errors if the project exists, but without activity or contribution associated to them.

Following the work done by @fitoria, I've added this if statement in the `ProjectsContributionsAPI` class in the `/server/api/contributions.py` file

```py
class ProjectsContributionsAPI(Resource):
    def get(self, project_id)
        if not ProjectService.exists(project_id):
            return {"Error": "Project not found"}, 404
```

And the same for the  `ProjectsActivitiesAPI` class in the `/server/api/contributions.py` file.

```py
class ProjectsActivitiesAPI(Resource):
    def get(self, project_id):
        if not ProjectService.exists(project_id):
            return {"Error": "Project not found"}, 404
```
https://github.com/hotosm/tasking-manager/blob/4ff9c4c1653b8c3f2b6024b8867f9dcb0b71e840/server/services/stats_service.py#L113-L135

Also, I thought that the Exception `Not Found` found in both `ProjectsContributionsAPI`, `ProjectsActivitiesAPI` classes should be removed, as this part of the code would be unreachable.

https://github.com/hotosm/tasking-manager/blob/4ff9c4c1653b8c3f2b6024b8867f9dcb0b71e840/server/api/projects/activities.py#L37-L38

https://github.com/hotosm/tasking-manager/blob/4ff9c4c1653b8c3f2b6024b8867f9dcb0b71e840/server/api/projects/contributions.py#L34-L35
