### PR TITLE
[FIX]: This PR fixes the malfunctioning of project search on entering…

### DIFF
--- a/frontend/src/components/contributions/messages.js
+++ b/frontend/src/components/contributions/messages.js
@@ -8,6 +8,10 @@ export default defineMessages({
     id: 'mytasks.mainSection.title',
     defaultMessage: 'My Tasks',
   },
+  myContributions: {
+    id: 'mytasks.filter.my_contributions',
+    defaultMessage: 'My contributions',
+  },
   contribution: {
     id: 'mytasks.contribution',
     defaultMessage: 'Contribution',

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,6 +1,7 @@
 {
   "mytasks.mainSection.title": "My Tasks",
   "mytasks.contribution": "Contribution",
+  "mytasks.filter.my_contributions": "My contributions",
   "mytasks.filter.all": "All",
   "mytasks.filter.mapped": "Mapped",
   "mytasks.filter.validated": "Validated",


### PR DESCRIPTION
The problem was not with backend, as it returned 500, internal server error, as it was supposed to.
The problem was that in file `taskResults.js` on line 42 `messages.myContributions` is used but not defined in `messages.js`, which fed empty value to a `<FormattedMessage/>` causing it to throw error. !
Fixes #2358 
@xamanu please review!