### PR TITLE
Improve tasking manager IAM profiles

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -432,6 +432,11 @@ const Resources = {
           Action: [ "sts:AssumeRole" ]
         }]
       },
+      ManagedPolicyArns: [
+          'arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforAWSCodeDeploy',
+          'arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy',
+          'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
+      ],
       Policies: [{
         PolicyName: "RDSPolicy",
         PolicyDocument: {
@@ -455,30 +460,8 @@ const Resources = {
             Resource: ['arn:aws:cloudformation:*']
           }]
         }
-      }, {
-        PolicyName: "CloudwatchAgentPermissions",
-        PolicyDocument: {
-          Version: "2012-10-17",
-          Statement: [{
-            Effect: "Allow",
-            Action: [
-              "logs:CreateLogGroup",
-              "logs:CreateLogStream",
-              "logs:PutLogEvents",
-              "logs:DescribeLogStreams"
-            ],
-            Resource: ["arn:aws:logs:*:*:*"]
-          }, {
-            Effect: "Allow",
-            Action: [
-              "s3:GetObject"
-            ],
-            Resource: [
-              "arn:aws:s3:::tasking-manager/*"
-            ]
-          }]
-        }
-      }],
+      }
+      ],
       RoleName: cf.join('-', [cf.stackName, 'ec2', 'role'])
     }
   },


### PR DESCRIPTION
Improve instance profile for tasking manager instances by replacing
inline policies with AWS Managed IAM Policies wherever possible.

Add additional policies to facilitate better management and monitoring.

Policies:
- AWS SSM Managed Instance Core Policy
- CloudWatch Agent Server Policy
- CodeDeploy EC2 Role Policy
- RDS Describe Instances (left intact)
- CloudFormation signalling permissions (left intact)