### PR TITLE
Remove project check during login

### DIFF
--- a/server/api/system/statistics.py
+++ b/server/api/system/statistics.py
@@ -1,5 +1,7 @@
 from flask_restful import Resource, current_app
 from server.services.stats_service import StatsService
+from flask_restful import request
+from distutils.util import strtobool
 
 
 class SystemStatisticsAPI(Resource):
@@ -11,6 +13,12 @@ class SystemStatisticsAPI(Resource):
           - system
         produces:
           - application/json
+        parameters:
+        - in: query
+          name: abbreviated
+          type: boolean
+          description: Set to false if complete details on projects including total area, campaigns, orgs are required
+          default: True
         responses:
             200:
                 description: Project stats
@@ -18,7 +26,13 @@ class SystemStatisticsAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            stats = StatsService.get_homepage_stats()
+            abbreviated = (
+                strtobool(request.args.get("abbreviated"))
+                if request.args.get("abbreviated")
+                else True
+            )
+
+            stats = StatsService.get_homepage_stats(abbreviated)
             return stats.to_primitive(), 200
         except Exception as e:
             error_msg = f"Unhandled error: {str(e)}"

--- a/server/models/dtos/stats_dto.py
+++ b/server/models/dtos/stats_dto.py
@@ -114,7 +114,7 @@ class HomePageStatsDTO(Model):
     # total_area = FloatType(serialized_name='totalArea')
     total_mapped_area = FloatType(serialized_name="totalMappedArea")
     total_validated_area = FloatType(serialized_name="totalValidatedArea")
-    total_organisations = IntType(serialized_name="totalOrganizations")
+    total_organisations = IntType(serialized_name="totalOrganisations")
     total_campaigns = IntType(serialized_name="totalCampaigns")
     # avg_completion_time = IntType(serialized_name='averageCompletionTime')
     organisations = ListType(ModelType(OrganizationStatsDTO))

--- a/server/models/dtos/user_dto.py
+++ b/server/models/dtos/user_dto.py
@@ -55,10 +55,6 @@ class UserDTO(Model):
         serialized_name="mappingLevel", validators=[is_known_mapping_level]
     )
     date_registered = UTCDateTimeType(serialized_name="dateRegistered")
-    total_time_spent = IntType(serialized_name="totalTimeSpent")
-    time_spent_mapping = IntType(serialized_name="timeSpentMapping")
-    time_spent_validating = IntType(serialized_name="timeSpentValidating")
-    projects_mapped = IntType(serialized_name="projectsMapped")
     tasks_mapped = IntType(serialized_name="tasksMapped")
     tasks_validated = IntType(serialized_name="tasksValidated")
     tasks_invalidated = IntType(serialized_name="tasksInvalidated")

--- a/server/models/postgis/task.py
+++ b/server/models/postgis/task.py
@@ -5,7 +5,7 @@ import json
 from enum import Enum
 from flask import current_app
 from sqlalchemy.types import Float, Text
-from sqlalchemy import text, desc, cast, func
+from sqlalchemy import text, desc, cast
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from sqlalchemy.orm.session import make_transient
 from geoalchemy2 import Geometry
@@ -815,16 +815,16 @@ class Task(db.Model):
         :status: task status id to filter by
         :return: geojson.FeatureCollection
         """
-        subquery = (
-            db.session.query(func.max(TaskHistory.action_date))
-            .filter(
-                Task.id == TaskHistory.task_id,
-                Task.project_id == TaskHistory.project_id,
-            )
-            .correlate(Task)
-            .group_by(Task.id)
-            .label("update_date")
-        )
+        # subquery = (
+        #     db.session.query(func.max(TaskHistory.action_date))
+        #     .filter(
+        #         Task.id == TaskHistory.task_id,
+        #         Task.project_id == TaskHistory.project_id,
+        #     )
+        #     .correlate(Task)
+        #     .group_by(Task.id)
+        #     .label("update_date")
+        # )
         query = db.session.query(
             Task.id,
             Task.x,
@@ -833,7 +833,7 @@ class Task(db.Model):
             Task.is_square,
             Task.task_status,
             Task.geometry.ST_AsGeoJSON().label("geojson"),
-            subquery,
+            # subquery,
         )
 
         filters = [Task.project_id == project_id]
@@ -874,11 +874,11 @@ class Task(db.Model):
                         Float,
                     )
                 )
-        elif order_by == "last_updated":
-            if order_by_type == "DESC":
-                query = query.filter(*filters).order_by(desc("update_date"))
-            else:
-                query = query.filter(*filters).order_by("update_date")
+        # elif order_by == "last_updated":
+        #     if order_by_type == "DESC":
+        #         query = query.filter(*filters).order_by(desc("update_date"))
+        #     else:
+        #         query = query.filter(*filters).order_by("update_date")
         else:
             query = query.filter(*filters)
 

--- a/server/services/users/authentication_service.py
+++ b/server/services/users/authentication_service.py
@@ -80,7 +80,6 @@ class AuthenticationService:
         try:
             UserService.get_user_by_id(osm_id)
             UserService.update_user(osm_id, username, user_picture)
-            MessageService.send_favorite_project_activities(osm_id)
         except NotFound:
             # User not found, so must be new user
             changesets = osm_user.find("changesets")

--- a/tests/server/unit/services/users/test_authentication_service.py
+++ b/tests/server/unit/services/users/test_authentication_service.py
@@ -32,8 +32,7 @@ class TestAuthenticationService(unittest.TestCase):
             AuthenticationService().login_user(osm_response, None, "wont-find")
 
     @patch.object(UserService, "get_user_by_id")
-    @patch.object(MessageService, "send_favorite_project_activities")
-    def test_if_user_get_called_with_osm_id(self, mock_user_get, mock_message_act):
+    def test_if_user_get_called_with_osm_id(self, mock_user_get):
         # Arrange
         osm_response = get_canned_osm_user_details()
 
@@ -62,8 +61,7 @@ class TestAuthenticationService(unittest.TestCase):
         )
 
     @patch.object(UserService, "get_user_by_id")
-    @patch.object(MessageService, "send_favorite_project_activities")
-    def test_valid_auth_request_gets_token(self, mock_user_get, mock_message_act):
+    def test_valid_auth_request_gets_token(self, mock_user_get):
         # Arrange
         osm_response = get_canned_osm_user_details()
 


### PR DESCRIPTION
Per chat w/ @willemarcel: 
* removed the `send_favorite_project_activities` function call during login. This should make the login very quick. 
* Also removed the `projectsMapped` field from UserDTO. This is still available under `UserStatsDTO`
* removed time computations from userDTO. These are available through userStats
* removed order by last update on tasks as part of project/id endpoint. This should save some time on project load