### PR TITLE
Fix projects touched error code for no mapping

### DIFF
--- a/server/api/projects/resources.py
+++ b/server/api/projects/resources.py
@@ -755,7 +755,7 @@ class ProjectsQueriesTouchedAPI(Resource):
             200:
                 description: Mapped projects found
             404:
-                description: No mapped projects found
+                description: User not found
             500:
                 description: Internal Server Error
         """
@@ -768,7 +768,7 @@ class ProjectsQueriesTouchedAPI(Resource):
             user_dto = UserService.get_mapped_projects(username, locale)
             return user_dto.to_primitive(), 200
         except NotFound:
-            return {"Error": "User or mapping not found"}, 404
+            return {"Error": "User not found"}, 404
         except Exception as e:
             error_msg = f"User GET - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)

--- a/server/models/postgis/user.py
+++ b/server/models/postgis/user.py
@@ -271,9 +271,6 @@ class User(db.Model):
 
         results = db.engine.execute(text(sql), user_id=user_id)
 
-        if results.rowcount == 0:
-            raise NotFound()
-
         mapped_projects_dto = UserMappedProjectsDTO()
         for row in results:
             mapped_project = MappedProject()


### PR DESCRIPTION
On `projects/queries/<string:username>/touched/`:
* return 404 for a user not found
* return empty array when the user has not touched any project. This is similar to how we handle projects with zero task activity