### PR TITLE
Notif popup

### DIFF
--- a/frontend/src/components/header/notificationBell.js
+++ b/frontend/src/components/header/notificationBell.js
@@ -5,6 +5,7 @@ import { TopNavLink } from './NavLink';
 import { BellIcon } from '../svgIcons';
 import { NotificationPopout } from '../../views/notifications';
 import { useFetch, useFetchIntervaled } from '../../hooks/UseFetch';
+import { useOnClickOutside } from '../../hooks/UseOnClickOutside';
 import useForceUpdate from '../../hooks/UseForceUpdate';
 import { useInboxQueryAPI } from '../../hooks/UseInboxQueryAPI';
 
@@ -13,9 +14,13 @@ export const NotificationBell = props => {
   const [forceUpdated, forceUpdate] = useForceUpdate();
 
   /* these below make the references stable so hooks doesn't re-request forever */
-  const nothing = useRef(null);
+  const notificationBellRef = useRef(null);
   const sortByRead = useRef({ sortBy: 'read' });
-  const [notificationState] = useInboxQueryAPI(nothing.current, sortByRead.current, forceUpdated);
+  const [notificationState] = useInboxQueryAPI(
+    notificationBellRef.current,
+    sortByRead.current,
+    forceUpdated,
+  );
 
   const [isPopoutFocus, setPopoutFocus] = useState(false);
   /*TODO Replace this backend with websockets, eventsource or RESTSockets
@@ -29,6 +34,8 @@ export const NotificationBell = props => {
     30000,
     trigger,
   );
+
+  useOnClickOutside(notificationBellRef, () => setPopoutFocus(false));
 
   const isNotificationBellActive = ({ isCurrent }) => {
     return isCurrent
@@ -50,13 +57,13 @@ export const NotificationBell = props => {
       unreadNotifsStart.unread);
 
   return (
-    <>
+    <span ref={notificationBellRef}>
       <TopNavLink
         to={'inbox/'}
         onClick={e => {
           e.preventDefault();
           e.stopPropagation();
-          setPopoutFocus(true);
+          setPopoutFocus(!isPopoutFocus);
         }}
         isActive={isNotificationBellActive}
       >
@@ -72,6 +79,6 @@ export const NotificationBell = props => {
         setPopoutFocus={setPopoutFocus}
         liveUnreadCount={liveUnreadCount}
       />
-    </>
+    </span>
   );
 };

--- a/frontend/src/components/notifications/notificationCard.js
+++ b/frontend/src/components/notifications/notificationCard.js
@@ -152,7 +152,7 @@ export function NotificationCardMini({
           ></div>
           <div className={`pl2 blue-grey f7`}>
             {/* <FormattedRelativeTime value={value} unit={unit}/> */}
-            <FormattedRelative value={new Date(sentDate + '+00:00')} />
+            <FormattedRelative value={new Date(sentDate)} />
           </div>
         </div>
       </article>

--- a/frontend/src/views/notifications.js
+++ b/frontend/src/views/notifications.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 
 import { useInboxQueryAPI, useInboxQueryParams } from '../hooks/UseInboxQueryAPI';
 
@@ -15,16 +15,10 @@ import { NotificationBodyModal } from '../components/notifications/notificationB
 import { ProjectCardPaginator } from '../components/projects/projectCardPaginator';
 
 import { useFetch } from '../hooks/UseFetch';
-import { useOnClickOutside } from '../hooks/UseOnClickOutside';
 
 export const NotificationPopout = props => {
-  const miniNotificationRef = useRef(null);
-
-  useOnClickOutside(miniNotificationRef, () => props.setPopoutFocus(false));
-
   return (
     <div
-      ref={miniNotificationRef}
       style={{ minWidth: '390px', width: '390px', zIndex: '100', right: '4rem' }}
       className={`fr ${props.isPopoutFocus ? '' : 'dn'} mt2 br2 absolute shadow-2 ph4 pb3 bg-white`}
     >


### PR DESCRIPTION
What these changes intend to do:
[Commit 1]: Corrects the wrong datetime format fed to `<FormattedRelative />`.
[Commit 2]: The `useOnClickOutside` function initially checked if the click was outside popup, so clicking the bell was considered out-click. Which toggled the 'isOpen` state twice.

Now if the popup is opened and the bell icon is clicked, it closes !
Fixes #2412 
@willemarcel  please review !