### PR TITLE
multiple tasks validation + show all tasks on map/validate page

### DIFF
--- a/frontend/src/components/taskSelection/footer.js
+++ b/frontend/src/components/taskSelection/footer.js
@@ -72,9 +72,7 @@ const TaskSelectionFooter = props => {
     }
     if (['mapSelectedTask', 'mapAnotherTask', 'mapATask'].includes(props.taskAction)) {
       fetchLocalJSONAPI(
-        `projects/${props.project.projectId}/tasks/actions/lock-for-mapping/${
-          props.selectedTasks[0]
-        }/`,
+        `projects/${props.project.projectId}/tasks/actions/lock-for-mapping/${props.selectedTasks[0]}/`,
         token,
         'POST',
       )
@@ -84,10 +82,14 @@ const TaskSelectionFooter = props => {
         .catch(e => lockFailed(windowObjectReference));
     }
     if (['resumeMapping', 'resumeValidation'].includes(props.taskAction)) {
-      openEditor(editor, props.project, props.tasks, props.selectedTasks, [
-        window.innerWidth,
-        window.innerHeight,
-      ]);
+      openEditor(
+        editor,
+        props.project,
+        props.tasks,
+        props.selectedTasks,
+        [window.innerWidth, window.innerHeight],
+        windowObjectReference,
+      );
       const endpoint = props.taskAction === 'resumeMapping' ? 'map' : 'validate';
       navigate(`/projects/${props.project.projectId}/${endpoint}/`);
     }

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -313,6 +313,10 @@ export default defineMessages({
     id: 'project.tasks.action.submit_task',
     defaultMessage: 'Submit task',
   },
+  submitTasks: {
+    id: 'project.tasks.action.submit_tasks',
+    defaultMessage: 'Submit tasks',
+  },
   taskActivity: {
     id: 'project.tasks.history.title',
     defaultMessage: 'Task activity',

--- a/frontend/src/components/taskSelection/taskList.js
+++ b/frontend/src/components/taskSelection/taskList.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import Popup from 'reactjs-popup';
 import { useQueryParam, NumberParam, StringParam } from 'use-query-params';
@@ -300,13 +300,22 @@ function PaginatedList({
     setPage(1);
   }
 
+  const latestItems = useRef(items);
+  useEffect(() => {
+    latestItems.current = items;
+  });
+  // the useEffect above avoids the next one to run everytime the items change
   useEffect(() => {
     // switch the taskList page to always show the selected task.
     // Only do it if there is only one task selected
     if (selected.length === 1) {
-      setPage(Math.ceil((items.findIndex(task => task.taskId === selected[0]) + 1) / pageSize));
+      setPage(
+        Math.ceil(
+          (latestItems.current.findIndex(task => task.taskId === selected[0]) + 1) / pageSize,
+        ),
+      );
     }
-  }, [selected, items, pageSize, setPage]);
+  }, [selected, latestItems, setPage, pageSize]);
 
   return (
     <>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -478,6 +478,7 @@
   "project.tasks.action.split_task": "Split task",
   "project.tasks.action.select_another_task": "Select another task",
   "project.tasks.action.submit_task": "Submit task",
+  "project.tasks.action.submit_tasks": "Submit tasks",
   "project.tasks.history.title": "Task activity",
   "project.tasks.activity.data.links": "Task data",
   "project.tasks.activity.overpass.download": "Download from Overpass",

--- a/frontend/src/views/taskAction.js
+++ b/frontend/src/views/taskAction.js
@@ -100,14 +100,18 @@ export function TaskActionPossible({ project, tasks, action, editor }) {
   );
   useEffect(() => {
     if (project && tasks) {
-      fetchLocalJSONAPI(
-        `projects/${project}/tasks/?tasks=${tasks.map(i => i.taskId).join(',')}`,
-      ).then(res => setTasksGeojson(res));
+      fetchLocalJSONAPI(`projects/${project}/tasks/`).then(res => setTasksGeojson(res));
     }
   }, [project, tasks]);
   return (
     <div className="cf">
-      <TaskMapAction project={projectData} tasks={tasksGeojson} action={action} editor={editor} />
+      <TaskMapAction
+        project={projectData}
+        tasks={tasksGeojson}
+        activeTasks={tasks}
+        action={action}
+        editor={editor}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Resolves https://github.com/hotosm/tasking-manager/issues/2017, resolves https://github.com/hotosm/tasking-manager/issues/2344

Plus:
- fixes bug: editor was not opening when user was going to resume mapping/validation.
- avoid the pagination to return automatically to the selected task page when the tasks status are updated