### PR TITLE
Transform zoom level value to integer in project creation view

### DIFF
--- a/frontend/src/components/projectCreate/setAOI.js
+++ b/frontend/src/components/projectCreate/setAOI.js
@@ -19,10 +19,10 @@ export default function SetAOI({ mapObj, metadata, updateMetadata, setErr }) {
   const layer_name = 'aoi';
 
   const setDataGeom = geom => {
-    const geomArea = area(geom) / 1e6;
-    const zoomLevel = mapObj.map.getZoom() + 4;
-    const grid = makeGrid(geom, zoomLevel, {});
     mapObj.map.fitBounds(bbox(geom), { padding: 20 });
+    const geomArea = area(geom) / 1e6;
+    const zoomLevel = parseInt(mapObj.map.getZoom()) + 4;
+    const grid = makeGrid(geom, zoomLevel, {});
     updateMetadata({
       ...metadata,
       geom: geom,


### PR DESCRIPTION
The split problem comes from the zoom level value given in the project creation section. Zoom level must be an integer in order to generate correctly the taskGrid an a successfull task split.

I have tested using different aoi geometries and zoom levels. 

**How to test**:
- Create and edit a project.
- Select a task for mapping/validating.
- Click Task Split.

This pr fixed the splitting bug for new projects created. However, does not solve the issue for old projects