### PR TITLE
Fix documentation links

### DIFF
--- a/docs/contributing-code.md
+++ b/docs/contributing-code.md
@@ -22,7 +22,7 @@ All of the Tasking Manager development is going to happen in the [projects repos
   - `hotfix/ISSUENUMBER-SHORT-TITLE-SEPARATED-BY-HYPHENS` for important bug fixes that need to go into the main releases as soon as possible
 (e.g. for a normal feature feature/893-restrict-available-editors).
 * Make sure your PR is always up to date and rebased with the latest develop branch.
-* Let’s build a nice and understandable commit history of the project. Please use [meaningful commit messages](https://code.likeagirl.io/useful-tips-for-writing-better-git-commit-messages-808770609503?gi=d287cc406699) and try to unite/squash related work into one commit. Eventually we will squash commits before merging a new feature or hotfix into the main branches (develop and master).
+* Let’s build a nice and understandable commit history of the project. Please use [meaningful commit messages](https://medium.com/@nawarpianist/git-commit-best-practices-dab8d722de99) and try to unite/squash related work into one commit. Eventually we will squash commits before merging a new feature or hotfix into the main branches (develop and master).
 * Give meaningful and understandable testing instructions in your PR. Highlight important preconditions and try to make life easy for the reviewer.
 
 ### Comments

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,7 +13,7 @@ There are many ways to contribute to a project, below are some examples:
 
 ## Code of Conduct
 
-All of HOT's projects fall under the general [HOT Community Code of Conduct](https://www.hotosm.org/hot_code_of_conduct), which is in part based on the well known [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/1/4/code-of-conduct.md).
+All of HOT's projects fall under the general [HOT Community Code of Conduct](https://www.hotosm.org/hot_code_of_conduct), which is in part based on the well known [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
 
 The short version is:
 

--- a/docs/customize.md
+++ b/docs/customize.md
@@ -4,11 +4,11 @@ This guide intends to walk you through the process of customizing the Tasking Ma
 
 ## CSS
 
-The frontend site CSS is built from the files at https://github.com/hotosm/tasking-manager/tree/develop/client/assets/styles/sass.
+The frontend site CSS is built from the files at https://github.com/hotosm/tasking-manager/tree/develop/frontend/src/assets/styles.
 
 ## Images
 
-Logos are stored at https://github.com/hotosm/tasking-manager/tree/develop/client/assets/img for the site frontend and at https://github.com/hotosm/tasking-manager/tree/develop/server/web/static/swagger-ui/images for the API site.
+Logos are stored at https://github.com/hotosm/tasking-manager/tree/develop/frontend/src/assets/img for the site frontend.
 
 ## Configuration (site URL, hashtags, contact)
 

--- a/docs/migration-from-tm2.md
+++ b/docs/migration-from-tm2.md
@@ -12,7 +12,7 @@ Ensure everything is met to start the migration: For this lunch the new Tasking 
 
 With the empty database for new Tasking Manager created, we can now migrate all the data from the TM2 installation. A [database migration script is included](../scripts/database/migration-from-tm2-postgres.sql) to assist in this process. The beginning of this file contains important information regarding the assumptions of your prior database name and permissions, so please read it. That text will walk you through backing up your old TM2 database and creating a new temporary database for your TM2 data--though not required, it is recommended.
 
-The database migration script is available at https://github.com/hotosm/tasking-manager/blob/master/scripts/database/migration-from-tm2-postgres.sql
+The database migration script is available at https://github.com/hotosm/tasking-manager/blob/develop/scripts/database/migration-from-tm2-postgres.sql.
 
 ## After Migration
 

--- a/docs/setup-development.md
+++ b/docs/setup-development.md
@@ -118,7 +118,7 @@ python3 manage.py db upgrade
 
 #### Migrating your data from TM2
 
-You can use [this script](../scripts/tm2-pg-migration/migrationscripts.sql) to migrate your data from the prior tasking manager version (v2) to the current one. Please see [this documentation page](./migration-tm2-to-tm3.md) for important information about this process.
+You can use [this script](../scripts/database/migration-from-tm2-postgres.sql) to migrate your data from the prior tasking manager version (v2) to the current one. Please see [this documentation page](../scripts/database/README.md) for important information about this process.
 
 #### Set permissions to create a task
 
@@ -134,7 +134,7 @@ If you plan to only work on the API you only have to build the server architectu
 python3 manage.py runserver -d -r
 `
 
-You can access the API documentation on [http://localhost:5000/api-docs](http://localhost:5000/api-docs), it also allows you to execute requests on your local TM instance. The API docs is also available on our [production](https://tasks.hotosm.org/api-docs/) and [staging](https://tasks-stage.hotosm.org) instances.
+You can access the API documentation on [http://localhost:5000/api-docs](http://localhost:5000/api-docs), it also allows you to execute requests on your local TM instance. The API docs is also available on our [production](https://tasks.hotosm.org/api-docs) and [staging](https://tasks-stage.hotosm.org/api-docs/) instances.
 
 #### API Authentication
 

--- a/docs/setup-docker.md
+++ b/docs/setup-docker.md
@@ -15,7 +15,7 @@ The Tasking Manager uses OpenStreetMap accounts for users to login.
 
 In order to configure this connection you have to go to `https://www.openstreetmap.org/user/<Your_OSM_UserName>/oauth_clients/new` and fill in the form:
 
-<img width="300" alt="Required OSM OAuth settings" src="docs/assets/osm-oauth-settings.jpg">
+<img width="300" alt="Required OSM OAuth settings" src="./assets/osm-oauth-settings.jpg">
 
 Afterwards copy the consumer key and secret from OpenStreetMap into your configuration file `tasking-manager.env`, and set the two variables: `TM_CONSUMER_KEY` and `TM_CONSUMER_SECRET`.
 
@@ -29,7 +29,7 @@ The **easiest way** to run the Tasking Manager requires [Docker](https://docs.do
 For stopping this command do the job: `docker-compose stop`
 And you can check the logs with `docker-compose logs -f`
 
-**Alternatively** you can review how to install a [development setup](./docs/setup-development.md).
+**Alternatively** you can review how to install a [development setup](./setup-development.md).
 
 ### Working with the setup
 


### PR DESCRIPTION
Closes #2432
As discussed in this [issue](https://github.com/hotosm/tasking-manager/issues/2432), fix some links that are broken in the documentation.

Errors fixed:

* [`contributing-code.md`](https://github.com/hotosm/tasking-manager/blob/8f05eef7cb008c680a82dc9884ab7a83a12ab1f8/docs/contributing-code.md): The link for `meaningful commit messages` is not working, I suggest another article like this [one](https://medium.com/@nawarpianist/git-commit-best-practices-dab8d722de99) or a suggestion from the maintainers.
https://github.com/hotosm/tasking-manager/blob/8f05eef7cb008c680a82dc9884ab7a83a12ab1f8/docs/contributing-code.md#L25

* [`contributing.md`](https://github.com/hotosm/tasking-manager/blob/8f05eef7cb008c680a82dc9884ab7a83a12ab1f8/docs/contributing.md): The `Contributor Covenant Code of Conduct` is not up to date. I updated the link for the [newest version](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).

https://github.com/hotosm/tasking-manager/blob/8f05eef7cb008c680a82dc9884ab7a83a12ab1f8/docs/contributing.md#L16

* [`customize.md`](https://github.com/hotosm/tasking-manager/blob/8f05eef7cb008c680a82dc9884ab7a83a12ab1f8/docs/customize.md): The logos and swagger-ui images links are not working. The same for the frontend site css. I updated the links for the `frontend site css` and `logos`, but couldn't find the where are the swagger-ui images or if this no longer exists in the repository, so I removed the text that mentioned this images.

https://github.com/hotosm/tasking-manager/blob/8f05eef7cb008c680a82dc9884ab7a83a12ab1f8/docs/customize.md#L11

* [`migration-from-tm2.md`](https://github.com/hotosm/tasking-manager/blob/8f05eef7cb008c680a82dc9884ab7a83a12ab1f8/docs/migration-from-tm2.md): The script's path is not correct. Updated the link for the script's new folder located [here](https://github.com/hotosm/tasking-manager/blob/develop/scripts/database/migration-from-tm2-postgres.sql)

https://github.com/hotosm/tasking-manager/blob/8f05eef7cb008c680a82dc9884ab7a83a12ab1f8/docs/migration-from-tm2.md#L15

* [`setup-development.md`](https://github.com/hotosm/tasking-manager/blob/8f05eef7cb008c680a82dc9884ab7a83a12ab1f8/docs/setup-development.md): Updated the database migration script path for `../scripts/database/migration-from-tm2-postgres.sql`, documentation page for `../scripts/database/README.md`. Also, updated the API docs for staging and production, as staging is redirecting for the website homepage and production link is redirecting for a 404 page.

https://github.com/hotosm/tasking-manager/blob/8f05eef7cb008c680a82dc9884ab7a83a12ab1f8/docs/setup-development.md#L121

https://github.com/hotosm/tasking-manager/blob/8f05eef7cb008c680a82dc9884ab7a83a12ab1f8/docs/setup-development.md#L137

* [`setup-docker.md`](https://github.com/hotosm/tasking-manager/blob/8f05eef7cb008c680a82dc9884ab7a83a12ab1f8/docs/setup-docker.md): The image for filling the form is not working. Also, the link for the `development setup` file was broken. Updated the paths for both: the image `./assets/osm-oauth-settings.jpg` and the `development setup` file `./setup-development.md`.

https://github.com/hotosm/tasking-manager/blob/8f05eef7cb008c680a82dc9884ab7a83a12ab1f8/docs/setup-docker.md#L18

https://github.com/hotosm/tasking-manager/blob/8f05eef7cb008c680a82dc9884ab7a83a12ab1f8/docs/setup-docker.md#L32