### PR TITLE
Fix contributor count on  project sort 

### DIFF
--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -827,6 +827,20 @@ class Project(db.Model):
         )
         return project_info.name
 
+    @staticmethod
+    def get_project_total_contributions(project_id: int) -> int:
+
+        project_contributors_count = (
+            TaskHistory.query.with_entities(TaskHistory.user_id)
+            .filter(
+                TaskHistory.project_id == project_id, TaskHistory.action != "COMMENT"
+            )
+            .distinct(TaskHistory.user_id)
+            .count()
+        )
+
+        return project_contributors_count
+
     def get_aoi_geometry_as_geojson(self):
         """ Helper which returns the AOI geometry as a geojson object """
         aoi_geojson = db.engine.execute(self.geometry.ST_AsGeoJSON()).scalar()

--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -169,15 +169,19 @@ class ProjectSearchService:
         dto.map_results = feature_collection
 
         # Get all total contributions for each paginated project.
-        contrib_counts = ProjectSearchService.get_total_contributions(
-            paginated_results.items
-        )
+        # contrib_counts = ProjectSearchService.get_total_contributions(
+        #     paginated_results.items
+        # )
 
-        zip_items = zip(paginated_results.items, contrib_counts)
+        # zip_items = zip(paginated_results.items, contrib_counts)
 
         dto.results = [
-            ProjectSearchService.create_result_dto(p, search_dto.preferred_locale, t)
-            for p, t in zip_items
+            ProjectSearchService.create_result_dto(
+                p,
+                search_dto.preferred_locale,
+                Project.get_project_total_contributions(p[0]),
+            )
+            for p in paginated_results.items
         ]
         dto.pagination = Pagination(paginated_results)
 


### PR DESCRIPTION
From #2454:
* Introduced a new function to compute per project distinct user ID count
* Commented out earlier method call which returns an ascending list of contributor count irrespective of the sort order in the API call. This resulted in count mixup between projects