### PR TITLE
Consistency in table names

### DIFF
--- a/backend/models/postgis/interests.py
+++ b/backend/models/postgis/interests.py
@@ -3,16 +3,16 @@ from backend.models.dtos.interests_dto import InterestDTO
 from backend.models.postgis.utils import NotFound
 
 # Secondary table defining many-to-many join for interests of a user.
-users_interests = db.Table(
-    "users_interests",
+user_interests = db.Table(
+    "user_interests",
     db.metadata,
     db.Column("interest_id", db.Integer, db.ForeignKey("interests.id")),
     db.Column("user_id", db.BigInteger, db.ForeignKey("users.id")),
 )
 
 # Secondary table defining many-to-many join for interests of a project.
-projects_interests = db.Table(
-    "projects_interests",
+project_interests = db.Table(
+    "project_interests",
     db.metadata,
     db.Column("interest_id", db.Integer, db.ForeignKey("interests.id")),
     db.Column("project_id", db.BigInteger, db.ForeignKey("projects.id")),

--- a/backend/models/postgis/licenses.py
+++ b/backend/models/postgis/licenses.py
@@ -3,8 +3,8 @@ from backend.models.postgis.utils import NotFound
 from backend import db
 
 # Secondary table defining the many-to-many join
-users_licenses_table = db.Table(
-    "users_licenses",
+user_licenses_table = db.Table(
+    "user_licenses",
     db.metadata,
     db.Column("user", db.BigInteger, db.ForeignKey("users.id")),
     db.Column("license", db.Integer, db.ForeignKey("licenses.id")),
@@ -23,7 +23,7 @@ class License(db.Model):
 
     projects = db.relationship("Project", backref="license")
     users = db.relationship(
-        "License", secondary=users_licenses_table
+        "License", secondary=user_licenses_table
     )  # Many to Many relationship
 
     @staticmethod

--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -65,7 +65,7 @@ from backend.models.postgis.utils import (
     ST_Y,
 )
 from backend.services.grid.grid_service import GridService
-from backend.models.postgis.interests import Interest, projects_interests
+from backend.models.postgis.interests import Interest, project_interests
 
 # Secondary table defining many-to-many join for projects that were favorited by users.
 project_favorites = db.Table(
@@ -227,7 +227,7 @@ class Project(db.Model):
         Campaign, secondary=campaign_projects, backref="projects"
     )
     interests = db.relationship(
-        Interest, secondary=projects_interests, backref="projects"
+        Interest, secondary=project_interests, backref="projects"
     )
 
     def create_draft_project(self, draft_project_dto: DraftProjectDTO):

--- a/backend/models/postgis/user.py
+++ b/backend/models/postgis/user.py
@@ -12,7 +12,7 @@ from backend.models.dtos.user_dto import (
     ProjectParticipantUser,
     ListedUser,
 )
-from backend.models.postgis.licenses import License, users_licenses_table
+from backend.models.postgis.licenses import License, user_licenses_table
 from backend.models.postgis.project_info import ProjectInfo
 from backend.models.postgis.statuses import (
     MappingLevel,
@@ -21,7 +21,7 @@ from backend.models.postgis.statuses import (
     UserGender,
 )
 from backend.models.postgis.utils import NotFound, timestamp
-from backend.models.postgis.interests import Interest, users_interests
+from backend.models.postgis.interests import Interest, user_interests
 
 
 class User(db.Model):
@@ -63,8 +63,8 @@ class User(db.Model):
     last_validation_date = db.Column(db.DateTime, default=timestamp)
 
     # Relationships
-    accepted_licenses = db.relationship("License", secondary=users_licenses_table)
-    interests = db.relationship(Interest, secondary=users_interests, backref="users")
+    accepted_licenses = db.relationship("License", secondary=user_licenses_table)
+    interests = db.relationship(Interest, secondary=user_interests, backref="users")
 
     @property
     def missing_maps_profile_url(self):

--- a/backend/services/interests_service.py
+++ b/backend/services/interests_service.py
@@ -11,8 +11,8 @@ from backend.models.dtos.interests_dto import (
 from backend.models.postgis.task import TaskHistory
 from backend.models.postgis.interests import (
     Interest,
-    projects_interests,
-    users_interests,
+    project_interests,
+    user_interests,
 )
 from backend.services.project_service import ProjectService
 from backend.services.users.user_service import UserService
@@ -52,14 +52,14 @@ class InterestService:
             Interest.query.with_entities(
                 Interest.id,
                 Interest.name,
-                func.count(distinct(users_interests.c.user_id)).label("count_users"),
-                func.count(distinct(projects_interests.c.project_id)).label(
+                func.count(distinct(user_interests.c.user_id)).label("count_users"),
+                func.count(distinct(project_interests.c.project_id)).label(
                     "count_projects"
                 ),
             )
-            .outerjoin(users_interests, Interest.id == users_interests.c.interest_id)
+            .outerjoin(user_interests, Interest.id == user_interests.c.interest_id)
             .outerjoin(
-                projects_interests, Interest.id == projects_interests.c.interest_id
+                project_interests, Interest.id == project_interests.c.interest_id
             )
             .group_by(Interest.id)
             .order_by(Interest.id)
@@ -120,12 +120,12 @@ class InterestService:
         res = (
             db.session.query(
                 Interest.name,
-                func.count(projects_interests.c.interest_id)
-                / func.sum(func.count(projects_interests.c.interest_id)).over(),
+                func.count(project_interests.c.interest_id)
+                / func.sum(func.count(project_interests.c.interest_id)).over(),
             )
-            .group_by(projects_interests.c.interest_id, Interest.name)
-            .filter(projects_interests.c.project_id.in_(stmt))
-            .join(Interest, Interest.id == projects_interests.c.interest_id)
+            .group_by(project_interests.c.interest_id, Interest.name)
+            .filter(project_interests.c.project_id.in_(stmt))
+            .join(Interest, Interest.id == project_interests.c.interest_id)
         )
 
         rates = [InterestrateDTO({"name": r[0], "rate": r[1]}) for r in res.all()]

--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -26,7 +26,7 @@ from backend.models.postgis.utils import (
     ST_Area,
 )
 
-from backend.models.postgis.interests import projects_interests
+from backend.models.postgis.interests import project_interests
 from backend.services.users.user_service import UserService
 
 from backend import db
@@ -206,8 +206,8 @@ class ProjectSearchService:
             )
         if search_dto.interests:
             query = query.join(
-                projects_interests, projects_interests.c.project_id == Project.id
-            ).filter(projects_interests.c.interest_id.in_(search_dto.interests))
+                project_interests, project_interests.c.project_id == Project.id
+            ).filter(project_interests.c.interest_id.in_(search_dto.interests))
         query = query.filter(Project.status.in_(project_status_array))
         if search_dto.created_by:
             query = query.filter(Project.author_id == search_dto.created_by)

--- a/backend/services/users/user_service.py
+++ b/backend/services/users/user_service.py
@@ -17,7 +17,7 @@ from backend.models.dtos.user_dto import (
     UserCountriesContributed,
 )
 from backend.models.dtos.interests_dto import InterestsDTO, InterestDTO
-from backend.models.postgis.interests import Interest, projects_interests
+from backend.models.postgis.interests import Interest, project_interests
 from backend.models.postgis.message import Message
 from backend.models.postgis.project import Project
 from backend.models.postgis.user import User, UserRole, MappingLevel, UserEmail
@@ -196,15 +196,15 @@ class UserService:
             Interest.query.with_entities(
                 Interest.id,
                 Interest.name,
-                func.count(distinct(projects_interests.c.project_id)).label(
+                func.count(distinct(project_interests.c.project_id)).label(
                     "count_projects"
                 ),
             )
             .outerjoin(
-                projects_interests,
+                project_interests,
                 and_(
-                    Interest.id == projects_interests.c.interest_id,
-                    projects_interests.c.project_id.in_(stmt),
+                    Interest.id == project_interests.c.interest_id,
+                    project_interests.c.project_id.in_(stmt),
                 ),
             )
             .group_by(Interest.id)

--- a/migrations/versions/2d6a7ad4e1eb_.py
+++ b/migrations/versions/2d6a7ad4e1eb_.py
@@ -1,7 +1,7 @@
 """empty message
 
 Revision ID: 2d6a7ad4e1eb
-Revises: c40e1fdf6b70
+Revises: 14340f1e0d6b
 Create Date: 2020-03-23 12:10:20.120500
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "2d6a7ad4e1eb"
-down_revision = "c40e1fdf6b70"
+down_revision = "14340f1e0d6b"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/2d6a7ad4e1eb_.py
+++ b/migrations/versions/2d6a7ad4e1eb_.py
@@ -1,0 +1,27 @@
+"""empty message
+
+Revision ID: 2d6a7ad4e1eb
+Revises: c40e1fdf6b70
+Create Date: 2020-03-23 12:10:20.120500
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "2d6a7ad4e1eb"
+down_revision = "c40e1fdf6b70"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.rename_table("users_licenses", "user_licenses")
+    op.rename_table("projects_interests", "project_interests")
+    op.rename_table("users_interests", "user_interests")
+
+
+def downgrade():
+    op.rename_table("user_licenses", "users_licenses")
+    op.rename_table("project_interests", "projects_interests")
+    op.rename_table("user_interests", "users_interests")


### PR DESCRIPTION
* Introduce a migration to rename tables:
    * `users_license` -> `user_license`
    * `projects_interests` -> `project_interests`
    * `users_interests` -> `user_interests`