### PR TITLE
Fix non-admin contributions display.

### DIFF
--- a/frontend/src/components/teamsAndOrgs/organisations.js
+++ b/frontend/src/components/teamsAndOrgs/organisations.js
@@ -17,13 +17,9 @@ export function OrgsManagement({ organisations, userDetails }: Object) {
       showAddButton={isAdmin}
       managementView={true}
     >
-      {isAdmin ? (
-        organisations.map((org, n) => <OrganisationCard details={org} key={n} />)
-      ) : (
-        <div>
-          <FormattedMessage {...messages.notAllowed} />
-        </div>
-      )}
+      {organisations.map((org, n) => (
+        <OrganisationCard details={org} key={n} />
+      ))}
     </Management>
   );
 }
@@ -79,7 +75,7 @@ export function OrganisationForm(props) {
 
   return (
     <Form
-      onSubmit={values => props.updateOrg(values)}
+      onSubmit={(values) => props.updateOrg(values)}
       initialValues={props.organisation}
       render={({ handleSubmit, pristine, form, submitting, values }) => {
         return (


### PR DESCRIPTION
Closes #2550 
isAdmin should be used to determine whether the user has permission to add organization which is accomplished here. Since any user can be org-manager there is no use of `you are not authorized` message.
@ramyaragupathy hope this helps !