### PR TITLE
Replace health check path with working endpoint

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -518,7 +518,7 @@ const Resources = {
       HealthCheckTimeoutSeconds: 10,
       HealthyThresholdCount: 3,
       UnhealthyThresholdCount: 3,
-      // HealthCheckPath: '/api/v2/system/heartbeat/', TODO get working path
+      HealthCheckPath: '/api/v2/system/heartbeat/',
       Port: 8000,
       Protocol: 'HTTP',
       VpcId: cf.importValue(cf.join('-', ['hotosm-network-production', 'default-vpc', cf.region])),


### PR DESCRIPTION
Fixes #2556 

I have tested this on an AWS stack and can confirm it works:
![image](https://user-images.githubusercontent.com/1847818/77355281-92effc80-6d1a-11ea-845e-b7d675986529.png)
