### PR TITLE
fix initial height of id-container div to solve scrolling problems

### DIFF
--- a/frontend/src/components/editor.js
+++ b/frontend/src/components/editor.js
@@ -51,5 +51,5 @@ export default function Editor({ editorRef, setEditorRef, setDisable }) {
     }
   }, [session, editorRef, setDisable]);
 
-  return <div style={{ height: '1000px' }} id="id-container"></div>;
+  return <div className="w-100 vh-minus-122-ns" id="id-container"></div>;
 }


### PR DESCRIPTION
This addresses feedback we got during the testing:

> Scale bar: When I'm training, or giving feedback I instruct the mappers to make sure they zoom in so that the scale bar reads 20 meters before they try to do any mapping, however there is no scale bar visible on my screen at the moment. The scale at which new people try to map is an important point in my opinion, and I've seen new mappers fail to zoom in enough and then map many buildings as one large building because they couldn't see to do anything different.
