### PR TITLE
Fix resume mapping and task status updation.

### DIFF
--- a/frontend/src/components/taskSelection/action.js
+++ b/frontend/src/components/taskSelection/action.js
@@ -20,6 +20,7 @@ import { TaskHistory } from './taskActivity';
 
 import DueDateBox from '../projectcard/dueDateBox';
 import { UserFetchTextarea } from '../projectDetail/questionsAndComments';
+import { useFetchLockedTasks } from '../../hooks/UseLockedTasks';
 
 const Editor = React.lazy(() => import('../editor'));
 
@@ -253,6 +254,7 @@ function CompletionTabForMapping({ project, tasksIds, disabled }: Object) {
   const [taskComment, setTaskComment] = useState('');
   const [showMapChangesModal, setShowMapChangesModal] = useState(false);
   const radioInput = 'radio-input input-reset pointer v-mid dib h2 w2 mr2 br-100 ba b--blue-light';
+  const fetchLockedTasks = useFetchLockedTasks();
 
   const splitTask = () => {
     if (!disabled) {
@@ -293,9 +295,10 @@ function CompletionTabForMapping({ project, tasksIds, disabled }: Object) {
         url = `projects/${project.projectId}/tasks/actions/unlock-after-mapping/${tasksIds[0]}/`;
         payload.status = 'BADIMAGERY';
       }
-      pushToLocalJSONAPI(url, JSON.stringify(payload), token).then((r) =>
-        navigate(`/projects/${project.projectId}/tasks/`),
-      );
+      pushToLocalJSONAPI(url, JSON.stringify(payload), token).then((r) => {
+        fetchLockedTasks();
+        navigate(`/projects/${project.projectId}/tasks/`);
+      });
     }
   };
 


### PR DESCRIPTION
Closes #2601 : 
After mapping task as either of ['BADIMAGERY', 'READY', 'MAPPED'] the variable `lockedTasks` must update. But the function `fetchLockedTasks` which is responsible for the above, is never invoked due to which `Resume Mapping` wasn't working.

Closes #2577 : 
**Initially**, the api calls were as follows : 
- BADIMAGERY: hit `/stop-mapping` and restore the previous status.
- READY: hit `/stop-mapping` and restore the previous status.
- MAPPED: hit `unlock-after-mapping` and unlock it.
Here `/stop-mapping` prevented the updation in status to ['BADIMAGERY', 'READY'] coz it just restored the previous status.

@xamanu @willemarcel please correct me if I missed something or am wrong !