### PR TITLE
Improvements to install scripts

### DIFF
--- a/example.env
+++ b/example.env
@@ -48,12 +48,12 @@ TM_EDITS_API_URL=https://osm-stats-production-api.azurewebsites.net/stats/hotosm
 # A freely definable secret. Gives authorization to the front- and and back-end
 # to talk to each other.
 #
-TM_SECRET=s0m3l0ngr4nd0mstr1ng-b3cr34tiv3&h4v3fun
+TM_SECRET=s0m3l0ngr4nd0mstr1ng-b3cr34tiv3
 
 # OpenStreetMap OAuth consumer key and secret (required)
 #
 TM_CONSUMER_KEY=foo
-TM_CONSUMER_SECRET=s0m3l0ngr4nd0mstr1ng-b3cr34tiv3&h4v3fun
+TM_CONSUMER_SECRET=s0m3l0ngr4nd0mstr1ng-b3cr34tiv3
 
 # The default tag used in the OSM changeset comment
 # IMPORTANT! This must be unique on your instance

--- a/scripts/install/install_on_debian_10_buster.sh
+++ b/scripts/install/install_on_debian_10_buster.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Script to install the Tasking Manager on Debian 10 Buster
-#
+# The script must be executed from the root of the project
 
 # Ensure being run on the supported operating system
 distribution=$(lsb_release -si)
@@ -37,15 +37,35 @@ pip install -r requirements.txt &&
 
 # Set up configuration
 # Sets db endpoint to localhost.
-cp example.env tasking-manager.env &&
+if ! test -f tasking-manager.env
+	then
+    cp example.env tasking-manager.env
+fi
+. ./tasking-manager.env &&
 sed -i '/POSTGRES_ENDPOINT/s/^# //g' tasking-manager.env &&
 
 # Set up data base
-sudo -u postgres psql -c "CREATE USER tm WITH PASSWORD 'tm';" &&
-sudo -u postgres createdb -T template0 tasking-manager -E UTF8 -O tm &&
-sudo -u postgres psql -d tasking-manager -c "CREATE EXTENSION postgis;" &&
+if ! sudo -u postgres psql -c "SELECT u.usename FROM pg_catalog.pg_user u;" | grep -w -q $POSTGRES_USER
+	then
+		sudo -u postgres psql -c "CREATE USER $POSTGRES_USER WITH PASSWORD '$POSTGRES_PASSWORD';"
+fi
+if ! sudo -u postgres psql -c "SELECT datname FROM pg_database WHERE datistemplate = false;" | grep -w -q $POSTGRES_DB
+	then
+    sudo -u postgres createdb -T template0 $POSTGRES_DB -E UTF8 -O $POSTGRES_USER &&
+    sudo -u postgres psql -d $POSTGRES_DB -c "CREATE EXTENSION postgis;"
+fi
 
-# Initiate database
+
+# Populate database
+cd tests/database/ &&
+sudo -u postgres psql -d $POSTGRES_DB -c "\i tasking-manager.sql" &&
+for tbl in `sudo -u postgres psql -qAt -c "select tablename from pg_tables where schemaname = 'public';" $POSTGRES_DB`;
+do  sudo -u postgres psql -c "alter table \"$tbl\" owner to $POSTGRES_USER" $POSTGRES_DB ; done &&
+for tbl in `sudo -u postgres psql -qAt -c "select tablename from pg_tables where schemaname = 'topology';" $POSTGRES_DB`;
+do  sudo -u postgres psql -c "alter table \"$tbl\" owner to $POSTGRES_USER" $POSTGRES_DB ; done &&
+cd ../../ &&
+
+# Upgrade database
 ./venv/bin/python3 manage.py db upgrade &&
 
 # Assamble the tasking manager interface


### PR DESCRIPTION
closes #2592 

Verify if the contributor already made a copy of `example.env`, before it was always copying the `example.env` for a `tasking-manager.env` even if the user already had a copy. 
Before:
https://github.com/hotosm/tasking-manager/blob/1b3e39c1c6cdf631257a9464507b5854f083464c/scripts/install/install_on_debian_10_buster.sh#L40
Now:
```sh
if ! test -f tasking-manager.env
	then
    cp example.env tasking-manager.env
fi
``` 

Export the environment variables. I may be wrong, but when I checked the source code the environment variables weren't being used, so I exported it to use later in the script.

```sh
. ./tasking-manager.env
``` 

That's the main part and why I wanted to improve the script. As mentioned before the script was always creating the database with hard coded user and database name, not using the environment variables. I also added some validations in cases of existing users or databases, which cause failure on the script.

Before:
https://github.com/hotosm/tasking-manager/blob/1b3e39c1c6cdf631257a9464507b5854f083464c/scripts/install/install_on_debian_10_buster.sh#L43-L46

Now:
```sh
if ! sudo -u postgres psql -c "SELECT u.usename FROM pg_catalog.pg_user u;" | grep -w -q $POSTGRES_USER
	then
		sudo -u postgres psql -c "CREATE USER $POSTGRES_USER WITH PASSWORD '$POSTGRES_PASSWORD';"
fi
if ! sudo -u postgres psql -c "SELECT datname FROM pg_database WHERE datistemplate = false;" | grep -w -q $POSTGRES_DB
	then
    sudo -u postgres createdb -T template0 $POSTGRES_DB -E UTF8 -O $POSTGRES_USER &&
    sudo -u postgres psql -d $POSTGRES_DB -c "CREATE EXTENSION postgis;"
fi
```

Here I populated the database with the script in `tests/database`, for this I had to make the new user owner of the database tables. 

Before:
https://github.com/hotosm/tasking-manager/blob/1b3e39c1c6cdf631257a9464507b5854f083464c/scripts/install/install_on_debian_10_buster.sh#L49

Now:
```sh
cd tests/database/ &&
sudo -u postgres psql -d $POSTGRES_DB -c "\i tasking-manager.sql" &&
for tbl in `sudo -u postgres psql -qAt -c "select tablename from pg_tables where schemaname = 'public';" $POSTGRES_DB`;
do  sudo -u postgres psql -c "alter table \"$tbl\" owner to $POSTGRES_USER" $POSTGRES_DB ; done &&
for tbl in `sudo -u postgres psql -qAt -c "select tablename from pg_tables where schemaname = 'topology';" $POSTGRES_DB`;
do  sudo -u postgres psql -c "alter table \"$tbl\" owner to $POSTGRES_USER" $POSTGRES_DB ; done &&
cd ../../ &&

# Upgrade database
./venv/bin/python3 manage.py db upgrade &&
``` 

After that, the contributor should have a local instance with a dump for local testing.