### PR TITLE
Optimize autoscaling for TM4

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -11,7 +11,7 @@ const Parameters = {
   AutoscalingPolicy: {
     Type: 'String',
     AllowedValues: ['development', 'demo', 'production'],
-    Description: "development: min 1, max 1 instance; demo: min 1 max 3 instances; production: min 3 max 12 instances"
+    Description: "development: min 1, max 1 instance; demo: min 1 max 3 instances; production: min 2 max 9 instances"
   },
   DBSnapshot: {
     Type: 'String',
@@ -123,10 +123,10 @@ const Resources = {
     Type: 'AWS::AutoScaling::AutoScalingGroup',
     Properties: {
       AutoScalingGroupName: cf.stackName,
-      Cooldown: 600,
-      MinSize: cf.if('IsTaskingManagerProduction', 3, 1),
-      DesiredCapacity: cf.if('IsTaskingManagerProduction', 3, 1),
-      MaxSize: cf.if('IsTaskingManagerProduction', 12, cf.if('IsTaskingManagerDemo', 3, 1)),
+      Cooldown: 300,
+      MinSize: cf.if('IsTaskingManagerProduction', 2, 1),
+      DesiredCapacity: cf.if('IsTaskingManagerProduction', 2, 1),
+      MaxSize: cf.if('IsTaskingManagerProduction', 9, cf.if('IsTaskingManagerDemo', 3, 1)),
       HealthCheckGracePeriod: 600,
       LaunchConfigurationName: cf.ref('TaskingManagerLaunchConfiguration'),
       TargetGroupARNs: [ cf.ref('TaskingManagerTargetGroup') ],
@@ -146,7 +146,7 @@ const Resources = {
         AutoScalingGroupName: cf.ref('TaskingManagerASG'),
         PolicyType: 'TargetTrackingScaling',
         TargetTrackingConfiguration: {
-          TargetValue: 600,
+          TargetValue: 500,
           PredefinedMetricSpecification: {
             PredefinedMetricType: 'ALBRequestCountPerTarget',
             ResourceLabel: cf.join('/', [
@@ -163,7 +163,7 @@ const Resources = {
             ])
           }
         },
-        Cooldown: 600
+        Cooldown: 300
       }
   },
   TaskingManagerLaunchConfiguration: {

--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -113,7 +113,7 @@ const Parameters = {
 const Conditions = {
   UseASnapshot: cf.notEquals(cf.ref('DBSnapshot'), ''),
   DatabaseDumpFileGiven: cf.notEquals(cf.ref('DatabaseDump'), ''),
-  IsTaskingManagerProduction: cf.equals(cf.ref('AutoscalingPolicy'), 'Production (max 12)'),
+  IsTaskingManagerProduction: cf.equals(cf.ref('AutoscalingPolicy'), 'production'),
   IsTaskingManagerDemo: cf.equals(cf.ref('AutoscalingPolicy'), 'Demo (max 3)')
 };
 


### PR DESCRIPTION
Closes #2557

After running some load tests on the TM4 instance, I think the following configuration will work well for the release- it should more than handle a user load similar to the current capacity on TM3, with room to improve on after launch. 

Production Capacity (number of instances):
- min 2
- max 9

Autoscaling Tracking Target:
RequestsPerTarget: 500

Cooldown: 300s

The cooldown reduction from 600 should speed up the autoscaling process. 