### PR TITLE
Fix project filters

### DIFF
--- a/frontend/src/components/projects/myProjectNav.js
+++ b/frontend/src/components/projects/myProjectNav.js
@@ -101,12 +101,8 @@ export const MyProjectNav = (props) => {
         {props.management && (userDetails.role === 'ADMIN' || isOrgManager) && (
           <>
             <Link
-              to={`./?managedByMe=1`}
-              className={`di mh1 ${
-                fullProjectsQuery.managedByMe && !fullProjectsQuery.status
-                  ? activeButtonClass
-                  : inactiveButtonClass
-              } ${linkCombo}`}
+              to={`./?status=PUBLISHED&managedByMe=1`}
+              className={`di mh1 ${isActiveButton('PUBLISHED', fullProjectsQuery)} ${linkCombo}`}
             >
               <FormattedMessage {...messages.active} />
             </Link>

--- a/frontend/src/hooks/tests/UseMetaTags.test.js
+++ b/frontend/src/hooks/tests/UseMetaTags.test.js
@@ -1,7 +1,7 @@
 import { formatProjectTag, formatTitleTag } from '../UseMetaTags';
 import { ORG_CODE } from '../../config';
-
 describe('test formatProjectTag and formatTitleTag', () => {
+  const instanceName = ORG_CODE ? `${ORG_CODE} Tasking Manager` : 'Tasking Manager';
   it('return project information and instance name', () => {
     const project = {
       projectId: 1,
@@ -11,14 +11,14 @@ describe('test formatProjectTag and formatTitleTag', () => {
     };
     expect(formatProjectTag(project)).toBe(`#1: Test Project`);
     expect(formatTitleTag(formatProjectTag(project))).toBe(
-      `#1: Test Project - ${ORG_CODE} Tasking Manager`,
+      `#1: Test Project - ${instanceName}`,
     );
   });
   it('return only instance name', () => {
     expect(formatProjectTag({})).toBe('');
-    expect(formatTitleTag(formatProjectTag({}))).toBe(`${ORG_CODE} Tasking Manager`);
+    expect(formatTitleTag(formatProjectTag({}))).toBe(instanceName);
   });
   it('return a page name', () => {
-    expect(formatTitleTag('username')).toBe(`username - ${ORG_CODE} Tasking Manager`);
+    expect(formatTitleTag('username')).toBe(`username - ${instanceName}`);
   });
 });


### PR DESCRIPTION
Closes #2663 

Here is the description of changes made:
1. The `manageByMe` filter should also include the **projects created by a person**. They were missing, I appended them.
2. The `Active` tab should list 'PUBLISHED' projects as per the instructions by @xamanu in #2663, I added the status filter to query param.

Also if no status is mentioned then all projects should be listed irrespective of statuses rather than just the 'PUBLISHED' ones that is **no status param means no status filter**.
@xamanu Please correct me if I am wrong !