### PR TITLE
Fix managedBy, createdBy and status project filters

### DIFF
--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -193,7 +193,10 @@ class ProjectSearchService:
             for project_status in search_dto.project_statuses:
                 project_status_array.append(ProjectStatus[project_status].value)
             query = query.filter(Project.status.in_(project_status_array))
-
+        else:
+            if not search_dto.created_by:
+                project_status_array = [ProjectStatus.PUBLISHED.value]
+                query = query.filter(Project.status.in_(project_status_array))
         if search_dto.interests:
             query = query.join(
                 project_interests, project_interests.c.project_id == Project.id

--- a/frontend/src/components/projectDetail/header.js
+++ b/frontend/src/components/projectDetail/header.js
@@ -6,6 +6,7 @@ import { FormattedMessage } from 'react-intl';
 import messages from './messages';
 import { PriorityBox } from '../projectcard/projectCard';
 import { translateCountry } from '../../utils/countries';
+import { ProjectStatusBox } from './statusBox';
 
 export function HeaderLine({ author, projectId, priority }: Object) {
   const userLink = (
@@ -36,14 +37,6 @@ export function HeaderLine({ author, projectId, priority }: Object) {
     </div>
   );
 }
-
-export const ProjectStatusBox = ({ status, className }: Object) => {
-  return (
-    <div className={`tc br1 f7 ttu ba b--red red ${className}`}>
-      <FormattedMessage {...messages[`status_${status}`]} />
-    </div>
-  );
-};
 
 export const ProjectHeader = ({ project }: Object) => {
   const locale = useSelector((state) => state.preferences.locale);

--- a/frontend/src/components/projectDetail/statusBox.js
+++ b/frontend/src/components/projectDetail/statusBox.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import messages from './messages';
+
+export const ProjectStatusBox = ({ status, className }: Object) => {
+  const colour = status === 'DRAFT' ? 'orange' : 'blue-grey';
+  return (
+    <div className={`tc br1 f7 ttu ba b--${colour} ${colour} ${className}`}>
+      <FormattedMessage {...messages[`status_${status}`]} />
+    </div>
+  );
+};

--- a/frontend/src/components/projectcard/projectCard.js
+++ b/frontend/src/components/projectcard/projectCard.js
@@ -7,6 +7,7 @@ import { RelativeTimeWithUnit } from '../../utils/formattedRelativeTime';
 import DueDateBox from './dueDateBox';
 import ProjectProgressBar from './projectProgressBar';
 import { MappingLevelMessage } from '../mappingLevel';
+import { ProjectStatusBox } from '../projectDetail/statusBox';
 import { PROJECTCARD_CONTRIBUTION_SHOWN_THRESHOLD } from '../../config/index';
 
 export function PriorityBox({ priority, extraClasses }: Object) {
@@ -65,6 +66,7 @@ export function ProjectCard({
   lastUpdated,
   dueDate,
   priority,
+  status,
   mapperLevel,
   campaignTag,
   percentMapped,
@@ -106,7 +108,11 @@ export function ProjectCard({
         <article className={``}>
           <div className={`${bottomButtonSpacer} ph3 ba br1 b--grey-light bg-white shadow-hover`}>
             <div className="mt3 fr">
-              <PriorityBox priority={priority} extraClasses={'pv1 ph2 dib'} />
+              {['DRAFT', 'ARCHIVED'].includes(status) ? (
+                <ProjectStatusBox status={status} className={'pv1 ph1 dib'} />
+              ) : (
+                <PriorityBox priority={priority} extraClasses={'pv1 ph2 dib'} />
+              )}
             </div>
             <div className="w-50 cf red dib">
               <img

--- a/frontend/src/components/projects/myProjectNav.js
+++ b/frontend/src/components/projects/myProjectNav.js
@@ -102,7 +102,11 @@ export const MyProjectNav = (props) => {
           <>
             <Link
               to={`./?status=PUBLISHED&managedByMe=1`}
-              className={`di mh1 ${isActiveButton('PUBLISHED', fullProjectsQuery)} ${linkCombo}`}
+              className={`di mh1 ${
+                fullProjectsQuery.managedByMe && fullProjectsQuery.status === 'PUBLISHED'
+                  ? activeButtonClass
+                  : inactiveButtonClass
+              } ${linkCombo}`}
             >
               <FormattedMessage {...messages.active} />
             </Link>

--- a/frontend/src/components/projects/myProjectNav.js
+++ b/frontend/src/components/projects/myProjectNav.js
@@ -101,12 +101,8 @@ export const MyProjectNav = (props) => {
         {props.management && (userDetails.role === 'ADMIN' || isOrgManager) && (
           <>
             <Link
-              to={`./?managedByMe=1`}
-              className={`di mh1 ${
-                fullProjectsQuery.managedByMe && !fullProjectsQuery.status
-                  ? activeButtonClass
-                  : inactiveButtonClass
-              } ${linkCombo}`}
+              to={`./?status=PUBLISHED&managedByMe=1`}
+              className={`di mh1 ${isActiveButton('PUBLISHED', fullProjectsQuery)} ${linkCombo}`}
             >
               <FormattedMessage {...messages.active} />
             </Link>

--- a/frontend/src/components/teamsAndOrgs/menu.js
+++ b/frontend/src/components/teamsAndOrgs/menu.js
@@ -11,7 +11,7 @@ export function ManagementMenu({ isAdmin }: Object) {
     links = links.slice(0, 3);
   }
   const items = links.map((item) => ({
-    url: `/manage/${item}/${item === 'projects' ? '?managedByMe=1' : ''}`,
+    url: `/manage/${item}/${item === 'projects' ? '?status=PUBLISHED&managedByMe=1' : ''}`,
     label: <FormattedMessage {...messages[item]} />,
   }));
 

--- a/frontend/src/hooks/tests/UseMetaTags.test.js
+++ b/frontend/src/hooks/tests/UseMetaTags.test.js
@@ -1,7 +1,7 @@
 import { formatProjectTag, formatTitleTag } from '../UseMetaTags';
 import { ORG_CODE } from '../../config';
-
 describe('test formatProjectTag and formatTitleTag', () => {
+  const instanceName = ORG_CODE ? `${ORG_CODE} Tasking Manager` : 'Tasking Manager';
   it('return project information and instance name', () => {
     const project = {
       projectId: 1,
@@ -11,14 +11,14 @@ describe('test formatProjectTag and formatTitleTag', () => {
     };
     expect(formatProjectTag(project)).toBe(`#1: Test Project`);
     expect(formatTitleTag(formatProjectTag(project))).toBe(
-      `#1: Test Project - ${ORG_CODE} Tasking Manager`,
+      `#1: Test Project - ${instanceName}`,
     );
   });
   it('return only instance name', () => {
     expect(formatProjectTag({})).toBe('');
-    expect(formatTitleTag(formatProjectTag({}))).toBe(`${ORG_CODE} Tasking Manager`);
+    expect(formatTitleTag(formatProjectTag({}))).toBe(instanceName);
   });
   it('return a page name', () => {
-    expect(formatTitleTag('username')).toBe(`username - ${ORG_CODE} Tasking Manager`);
+    expect(formatTitleTag('username')).toBe(`username - ${instanceName}`);
   });
 });

--- a/frontend/src/views/project.js
+++ b/frontend/src/views/project.js
@@ -167,7 +167,7 @@ export const MoreFilters = (props) => {
       </div>
       <div
         onClick={() => props.navigate(currentUrl)}
-        className="absolute right-0 z-5 br w-60-l w-0 h-100 bg-blue-dark o-70 h6"
+        className="absolute right-0 z-4 br w-60-l w-0 h-100 bg-blue-dark o-70 h6"
       ></div>
     </>
   );


### PR DESCRIPTION
- Resolves #2663
- status filter is not applied if `createdBy` query param is true
- show status on projectCard if it is draft or archived
- improve status box style