### PR TITLE
avoid editorRef redefinition

### DIFF
--- a/frontend/src/components/editor.js
+++ b/frontend/src/components/editor.js
@@ -10,10 +10,10 @@ export default function Editor({ editorRef, setEditorRef, setDisable }) {
   const windowInit = typeof window !== undefined;
 
   useEffect(() => {
-    if (windowInit) {
+    if (windowInit && !editorRef) {
       setEditorRef(window.iD.coreContext());
     }
-  }, [windowInit, setEditorRef]);
+  }, [windowInit, setEditorRef, editorRef]);
 
   useEffect(() => {
     if (session && iD && editorRef) {


### PR DESCRIPTION
iD was not behaving well after loaded for the 2nd, 3rd or 4th time, this PR tries to solve it.