### PR TITLE
Remove authorization header from being forwarded to react app

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -657,7 +657,7 @@ const Resources = {
             Cookies: {
               Forward: 'all'
             },
-            Headers: ['Accept', 'Authorization', 'Referer']
+            Headers: ['Accept', 'Referer']
           },
           TargetOriginId: cf.join('-', [cf.stackName, 'react-app']),
           ViewerProtocolPolicy: "redirect-to-https"


### PR DESCRIPTION
I created a maintenance page that can give access to users with authentication, but the app was configured to forward the `Authentication` header to the s3 bucket hosting the frontend. S3 doesn't allow this header for Basic Authentication (only AWS type auths), so I have to remove this from the Cloudfront Forwarded Values. 