### PR TITLE
Disable validation task lock across projects

### DIFF
--- a/backend/services/project_service.py
+++ b/backend/services/project_service.py
@@ -340,9 +340,6 @@ class ProjectService:
         if UserService.is_user_blocked(user_id):
             return False, ValidatingNotAllowed.USER_NOT_ON_ALLOWED_LIST
 
-        if ProjectAdminService.is_user_action_permitted_on_project(user_id, project_id):
-            return True, "User allowed to validate"
-
         project = ProjectService.get_project_by_id(project_id)
         validation_permission = project.validation_permission
 

--- a/backend/services/validator_service.py
+++ b/backend/services/validator_service.py
@@ -61,9 +61,7 @@ class ValidatorService:
             user_can_validate = ValidatorService._user_can_validate_task(
                 validation_dto.user_id, task.mapped_by
             )
-            if not ValidatorService._user_can_validate_task(
-                validation_dto.user_id, task.mapped_by
-            ):
+            if not user_can_validate:
                 raise ValidatorServiceError(
                     f"Tasks cannot be validated by the same user who marked task as mapped or badimagery"
                 )
@@ -102,10 +100,14 @@ class ValidatorService:
         :param mapped_by: id of user who mapped the task
         :return: Boolean
         """
-        mapped_by_me = mapped_by == user_id
-        if not mapped_by_me:
+        is_admin = UserService.is_user_an_admin(user_id)
+        if is_admin:
             return True
-        return False
+        else:
+            mapped_by_me = mapped_by == user_id
+            if not mapped_by_me:
+                return True
+            return False
 
     @staticmethod
     def unlock_tasks_after_validation(


### PR DESCRIPTION
From https://github.com/hotosm/tasking-manager/issues/2559 - fixed validation task lock on multiple projects. User can lock multiple tasks on one project in a single selection.