### PR TITLE
correct spelling of preferred

### DIFF
--- a/frontend/src/components/user/messages.js
+++ b/frontend/src/components/user/messages.js
@@ -97,7 +97,7 @@ export default defineMessages({
   languageDescription: {
     id: 'user.settings.language.description',
     defaultMessage:
-      'Define your prefered language. It will also affect the language of the maps you see on Tasking Manager.',
+      'Define your preferred language. It will also affect the language of the maps you see on Tasking Manager.',
   },
   becomeValidator: {
     id: 'user.settings.become_validator',


### PR DESCRIPTION
not very good at spelling, but spell check found this:
prefered should be preferred

@willemarcel  didn't see a commit, so added one.  didn't want it to fall through cracks.