### PR TITLE
add perTaskInstructions + handle better multiple tasks validation

### DIFF
--- a/frontend/src/components/projectDetail/index.js
+++ b/frontend/src/components/projectDetail/index.js
@@ -115,7 +115,7 @@ export const ProjectDetailLeft = (props) => {
         >
           <ProjectHeader project={props.project} showEditLink={true} />
           <section className="lh-title h-100 overflow-x-scroll">
-            <div className="pr2" dangerouslySetInnerHTML={htmlShortDescription} />
+            <div className="pr2 markdown-content" dangerouslySetInnerHTML={htmlShortDescription} />
             <div>
               <a href="#description" className="link base-font bg-white f6 bn pn red pointer">
                 <span className="pr2 ttu f6 fw6">
@@ -228,7 +228,7 @@ export const ProjectDetail = (props) => {
         <FormattedMessage {...messages.description} />
       </h3>
       <div
-        className="pv2 ph4 w-60-l w-80-m w-100 lh-title"
+        className="pv2 ph4 w-60-l w-80-m w-100 lh-title markdown-content"
         dangerouslySetInnerHTML={htmlDescription}
       />
 

--- a/frontend/src/components/projectDetail/questionsAndComments.js
+++ b/frontend/src/components/projectDetail/questionsAndComments.js
@@ -195,7 +195,7 @@ function CommentList({ comments }: Object) {
           <div className="cf db">
             <div
               style={{ wordWrap: 'break-word' }}
-              className="blue-grey f5 lh-title"
+              className="blue-grey f5 lh-title markdown-content"
               dangerouslySetInnerHTML={htmlFromMarkdown(formatUserNamesToLink(comment.message))}
             />
           </div>

--- a/frontend/src/components/projectEdit/inputLocale.js
+++ b/frontend/src/components/projectEdit/inputLocale.js
@@ -5,7 +5,7 @@ import messages from './messages';
 import { htmlFromMarkdown } from '../../utils/htmlFromMarkdown';
 import { StateContext, styleClasses } from '../../views/projectEdit';
 
-export const InputLocale = props => {
+export const InputLocale = (props) => {
   const { projectInfo, setProjectInfo, success, setSuccess, error, setError } = useContext(
     StateContext,
   );
@@ -15,8 +15,8 @@ export const InputLocale = props => {
 
   const locales = projectInfo.projectInfoLocales;
 
-  const updateState = e => {
-    let selected = locales.filter(f => f.locale === language);
+  const updateState = (e) => {
+    let selected = locales.filter((f) => f.locale === language);
     let data = null;
     if (selected.length === 0) {
       data = { locale: language, [e.target.name]: e.target.value };
@@ -25,12 +25,12 @@ export const InputLocale = props => {
       data[e.target.name] = e.target.value;
     }
     // create element with new locale.
-    let newLocales = locales.filter(f => f.locale !== language);
+    let newLocales = locales.filter((f) => f.locale !== language);
     newLocales.push(data);
     setProjectInfo({ ...projectInfo, projectInfoLocales: newLocales });
   };
 
-  const handleChange = e => {
+  const handleChange = (e) => {
     setValue(e.target.value);
     if (props.preview !== false) {
       const html = htmlFromMarkdown(e.target.value);
@@ -52,7 +52,7 @@ export const InputLocale = props => {
   }, [language, setSuccess, setError]);
 
   const getValue = useCallback(() => {
-    const data = locales.filter(l => l.locale === language);
+    const data = locales.filter((l) => l.locale === language);
     if (data.length > 0) {
       return data[0][props.name];
     } else {
@@ -129,7 +129,10 @@ export const InputLocale = props => {
           <h3 className="ttu f6 fw6 blue-grey mb1">
             <FormattedMessage {...messages.preview} />
           </h3>
-          <div dangerouslySetInnerHTML={preview} className="pv1 ph3 bg-grey-light blue-dark" />
+          <div
+            dangerouslySetInnerHTML={preview}
+            className="pv1 ph3 bg-grey-light blue-dark markdown-content"
+          />
         </div>
       )}
     </div>

--- a/frontend/src/components/taskSelection/action.js
+++ b/frontend/src/components/taskSelection/action.js
@@ -35,7 +35,6 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
   const tasksIds = activeTasks ? activeTasks.map((task) => task.taskId) : [];
   const [editorRef, setEditorRef] = useState(null);
   const [disabled, setDisable] = useState(false);
-
   const activeTask = activeTasks && activeTasks[0];
   const timer = new Date(activeTask.lastUpdated);
 
@@ -155,14 +154,16 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
                 >
                   <FormattedMessage {...messages.instructions} />
                 </span>
-                <span
-                  className={`mr4-l mr3 pb2 pointer ${
-                    activeSection === 'history' && 'bb b--blue-dark'
-                  }`}
-                  onClick={() => setActiveSection('history')}
-                >
-                  <FormattedMessage {...messages.history} />
-                </span>
+                {activeTasks && activeTasks.length === 1 && (
+                  <span
+                    className={`mr4-l mr3 pb2 pointer ${
+                      activeSection === 'history' && 'bb b--blue-dark'
+                    }`}
+                    onClick={() => setActiveSection('history')}
+                  >
+                    <FormattedMessage {...messages.history} />
+                  </span>
+                )}
               </div>
             </div>
             <div className="pt3">
@@ -172,6 +173,11 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
                     <CompletionTabForMapping
                       project={project}
                       tasksIds={tasksIds}
+                      taskInstructions={
+                        activeTasks && activeTasks.length === 1
+                          ? activeTasks[0].perTaskInstructions
+                          : null
+                      }
                       disabled={disabled}
                       taskComment={taskComment}
                       setTaskComment={setTaskComment}
@@ -183,6 +189,11 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
                     <CompletionTabForValidation
                       project={project}
                       tasksIds={tasksIds}
+                      taskInstructions={
+                        activeTasks && activeTasks.length === 1
+                          ? activeTasks[0].perTaskInstructions
+                          : null
+                      }
                       disabled={disabled}
                       taskComment={taskComment}
                       setTaskComment={setTaskComment}

--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -8,8 +8,16 @@ import messages from './messages';
 import { Button } from '../button';
 import { Dropdown } from '../dropdown';
 import { CheckCircle } from '../checkCircle';
-import { CloseIcon, SidebarIcon, AlertIcon, QuestionCircleIcon } from '../svgIcons';
+import {
+  CloseIcon,
+  SidebarIcon,
+  AlertIcon,
+  QuestionCircleIcon,
+  ChevronRightIcon,
+  ChevronDownIcon,
+} from '../svgIcons';
 import { getEditors } from '../../utils/editorsList';
+import { htmlFromMarkdown } from '../../utils/htmlFromMarkdown';
 import { pushToLocalJSONAPI, fetchLocalJSONAPI } from '../../network/genericJSONRequest';
 import { UserFetchTextarea } from '../projectDetail/questionsAndComments';
 import { useFetchLockedTasks } from '../../hooks/UseLockedTasks';
@@ -17,6 +25,7 @@ import { useFetchLockedTasks } from '../../hooks/UseLockedTasks';
 export function CompletionTabForMapping({
   project,
   tasksIds,
+  taskInstructions,
   disabled,
   taskComment,
   setTaskComment,
@@ -89,6 +98,7 @@ export function CompletionTabForMapping({
         </Popup>
       )}
       <div className="cf">
+        {taskInstructions && <TaskSpecificInstructions instructions={taskInstructions} />}
         <h4 className="ttu blue-grey f5">
           <FormattedMessage {...messages.editStatus} />
           <QuestionCircleIcon
@@ -179,6 +189,7 @@ export function CompletionTabForMapping({
 export function CompletionTabForValidation({
   project,
   tasksIds,
+  taskInstructions,
   disabled,
   taskComment,
   setTaskComment,
@@ -238,6 +249,9 @@ export function CompletionTabForValidation({
       )}
       <div className="bb b--grey-light w-100"></div>
       <div className="cf">
+        {taskInstructions && (
+          <TaskSpecificInstructions instructions={taskInstructions} open={false} />
+        )}
         <h4 className="ttu blue-grey f5">
           <FormattedMessage {...messages.editStatus} />
         </h4>
@@ -391,6 +405,28 @@ function UnsavedMapChangesModalContent({ close, action }: Object) {
       <Button className="bg-red white" onClick={() => close()}>
         <FormattedMessage {...messages.closeModal} />
       </Button>
+    </div>
+  );
+}
+
+function TaskSpecificInstructions({ instructions, open = true }: Object) {
+  const [isOpen, setIsOpen] = useState(open);
+  return (
+    <div className="">
+      <h4 className="ttu blue-grey mb0 pointer" onClick={() => setIsOpen(!isOpen)}>
+        {isOpen ? (
+          <ChevronDownIcon style={{ height: '14px' }} className="pr1 pb1 v-mid" />
+        ) : (
+          <ChevronRightIcon style={{ height: '14px' }} className="pr1 pb1 v-mid" />
+        )}
+        <FormattedMessage {...messages.taskExtraInfo} />
+      </h4>
+      {isOpen && (
+        <div
+          className="markdown-content"
+          dangerouslySetInnerHTML={htmlFromMarkdown(instructions)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -457,6 +457,10 @@ export default defineMessages({
     id: 'project.tasks.locked_by_user',
     defaultMessage: '{lockStatus} by {user}',
   },
+  taskExtraInfo: {
+    id: 'project.tasks.extra_information.title',
+    defaultMessage: 'Specific task information',
+  },
   mappingLevelALL: {
     id: 'project.level.all',
     defaultMessage: 'All levels',

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -560,6 +560,7 @@
   "project.tasks.action.validated": "Validated",
   "project.tasks.number.total": "Total",
   "project.tasks.locked_by_user": "{lockStatus} by {user}",
+  "project.tasks.extra_information.title": "Specific task information",
   "project.level.all": "All levels",
   "project.level.advanced": "Advanced",
   "project.level.intermediate": "Intermediate",


### PR DESCRIPTION
- add perTaskInstruction info on mapping/validation page
- hide history tab when validating multiple tasks
- format markdown content correctly across all system