### PR TITLE
Handle projects with no mapped task

### DIFF
--- a/backend/api/tasks/resources.py
+++ b/backend/api/tasks/resources.py
@@ -372,16 +372,12 @@ class TasksQueriesMappedAPI(Resource):
         responses:
             200:
                 description: Mapped tasks returned
-            404:
-                description: No mapped tasks
             500:
                 description: Internal Server Error
         """
         try:
             mapped_tasks = ValidatorService.get_mapped_tasks_by_user(project_id)
             return mapped_tasks.to_primitive(), 200
-        except NotFound:
-            return {"Error": "No mapped tasks"}, 404
         except Exception as e:
             error_msg = f"Task Lock API - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)

--- a/backend/models/postgis/task.py
+++ b/backend/models/postgis/task.py
@@ -955,8 +955,6 @@ class Task(db.Model):
                      group by u.username, u.mapping_level, u.date_registered, u.last_validation_date"""
 
         results = db.engine.execute(text(sql), project_id=project_id)
-        if results.rowcount == 0:
-            raise NotFound()
 
         mapped_tasks_dto = MappedTasks()
         for row in results:


### PR DESCRIPTION
From #2320 - instead of returning 404 when there is no activity on a project, let it return 200 with an empty array