### PR TITLE
Run auto unlock operation as background thread

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -9,6 +9,7 @@ from flask_oauthlib.client import OAuth
 from flask_restful import Api
 from flask_sqlalchemy import SQLAlchemy
 
+
 from backend.config import EnvironmentConfig
 
 
@@ -47,7 +48,7 @@ def create_app(env=None):
     app.logger.info(f"Starting up a new Tasking Manager application")
 
     # Connect to database
-    app.logger.debug(f"Connecting to the databse")
+    app.logger.debug(f"Connecting to the database")
     db.init_app(app)
     migrate.init_app(app, db)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 alembic==1.4.2
 aniso8601==8.0.0
 appdirs==1.4.3
+apscheduler==2.1.2
 attrs==19.3.0
 black==19.10b0
 bleach==3.1.4


### PR DESCRIPTION
This PR addresses #2108 by setting up a cron job which runs in background once every 2 hours while the server is up.