### PR TITLE
Update task count on undo

### DIFF
--- a/backend/services/stats_service.py
+++ b/backend/services/stats_service.py
@@ -43,7 +43,6 @@ class StatsService:
         """ Update stats when a task has had a state change """
 
         if new_state in [
-            TaskStatus.READY,
             TaskStatus.LOCKED_FOR_VALIDATION,
             TaskStatus.LOCKED_FOR_MAPPING,
         ]:

--- a/frontend/src/components/projectDetail/index.js
+++ b/frontend/src/components/projectDetail/index.js
@@ -158,6 +158,7 @@ export const ProjectDetailLeft = (props) => {
             className="pb2 bg-white"
             percentMapped={props.project.percentMapped}
             percentValidated={props.project.percentValidated}
+            percentBadImagery={props.project.percentBadImagery}
           />
           <div className="cf pb1 bg-white">
             <MappingLevelMessage

--- a/frontend/src/components/projectcard/messages.js
+++ b/frontend/src/components/projectcard/messages.js
@@ -20,6 +20,10 @@ export default defineMessages({
     id: 'project.card.percentValidated',
     defaultMessage: 'Validated',
   },
+  percentBadImagery: {
+    id: 'project.card.percentBadImagery',
+    defaultMessage: 'Bad imagery',
+  },
   projectPriorityURGENT: {
     id: 'project.card.projectPriorityUrgent',
     defaultMessage: 'Urgent',

--- a/frontend/src/components/projectcard/projectProgressBar.js
+++ b/frontend/src/components/projectcard/projectProgressBar.js
@@ -4,7 +4,12 @@ import { FormattedMessage } from 'react-intl';
 import messages from './messages';
 import { useHover } from '../../hooks/UseHover';
 
-export default function ProjectProgressBar({ percentMapped, percentValidated, className }: Object) {
+export default function ProjectProgressBar({
+  percentMapped,
+  percentValidated,
+  percentBadImagery,
+  className,
+}: Object) {
   const [hoverRef, isHovered, position] = useHover();
 
   /* tooltip component credit: https://codepen.io/syndicatefx/pen/QVPbJg */
@@ -34,6 +39,12 @@ export default function ProjectProgressBar({ percentMapped, percentValidated, cl
                 <span className="fw8">{percentValidated}%</span>&nbsp;
                 <FormattedMessage {...messages['percentValidated']} />
               </p>
+              {![null, undefined].includes(percentBadImagery) && (
+                <p className="f6 lh-copy ma0 white f7 fw4">
+                  <span className="fw8">{percentBadImagery}%</span>&nbsp;
+                  <FormattedMessage {...messages['percentBadImagery']} />
+                </p>
+              )}
               <span className="absolute top-0 left-2 nt2 w1 h1 bg-blue-dark bl bt b--blue-dark rotate-45"></span>
             </span>
           )}

--- a/frontend/src/components/taskSelection/contributions.js
+++ b/frontend/src/components/taskSelection/contributions.js
@@ -10,7 +10,7 @@ import ProjectProgressBar from '../projectcard/projectProgressBar';
 import { computeCompleteness } from '../../utils/projectCompletenessCalc';
 import { OSMChaButton } from '../projectDetail/osmchaButton';
 
-const Contributions = props => {
+const Contributions = (props) => {
   const mappingLevels = [
     { value: 'ALL', label: props.intl.formatMessage(messages.mappingLevelALL) },
     { value: 'ADVANCED', label: props.intl.formatMessage(messages.mappingLevelADVANCED) },
@@ -19,14 +19,14 @@ const Contributions = props => {
   ];
 
   const [level, setLevel] = useState(mappingLevels[0]);
-  const { percentMapped, percentValidated } = computeCompleteness(props.tasks);
+  const { percentMapped, percentValidated, percentBadImagery } = computeCompleteness(props.tasks);
 
   const MappingLevelSelect = () => {
     return (
       <Select
         isClearable={false}
         options={mappingLevels}
-        onChange={value => setLevel(value)}
+        onChange={(value) => setLevel(value)}
         className="w-30 fr mb3 pointer"
         value={level}
       />
@@ -45,24 +45,24 @@ const Contributions = props => {
       let filteredTasksByStatus = props.tasks.features;
       if (status === 'MAPPED') {
         filteredTasksByStatus = filteredTasksByStatus.filter(
-          task => task.properties.taskStatus === 'MAPPED',
+          (task) => task.properties.taskStatus === 'MAPPED',
         );
       }
       if (status === 'VALIDATED') {
         filteredTasksByStatus = filteredTasksByStatus.filter(
-          task => task.properties.taskStatus === 'VALIDATED',
+          (task) => task.properties.taskStatus === 'VALIDATED',
         );
       }
       const ids = filteredTasksByStatus
-        .filter(t => taskIds.includes(t.properties.taskId))
-        .map(f => f.properties.taskId);
+        .filter((t) => taskIds.includes(t.properties.taskId))
+        .map((f) => f.properties.taskId);
       props.selectTask(ids, status, user);
     }
   };
 
   let contributionsArray = props.contribsData.userContributions || [];
   if (level.value !== 'ALL') {
-    contributionsArray = contributionsArray.filter(u => u.mappingLevel === level.value);
+    contributionsArray = contributionsArray.filter((u) => u.mappingLevel === level.value);
   }
 
   return (
@@ -71,6 +71,7 @@ const Contributions = props => {
         <ProjectProgressBar
           percentMapped={percentMapped}
           percentValidated={percentValidated}
+          percentBadImagery={percentBadImagery}
           className="pt1 pb3"
         />
         <OSMChaButton project={props.project} className="bg-white blue-light bn mv2" />
@@ -83,7 +84,7 @@ const Contributions = props => {
           delay={50}
           ready={contributionsArray !== undefined}
         >
-          {contributionsArray.map(user => {
+          {contributionsArray.map((user) => {
             return (
               <div
                 className={`w-100 cf pv3 ph3-ns ph1 ba bw1 mb2 ${

--- a/frontend/src/utils/projectCompletenessCalc.js
+++ b/frontend/src/utils/projectCompletenessCalc.js
@@ -1,12 +1,14 @@
 export function computeCompleteness(tasks) {
   const totalTasks = tasks.features.length;
-  const mapped = tasks.features.filter(task => task.properties.taskStatus === 'MAPPED').length;
-  const validated = tasks.features.filter(task => task.properties.taskStatus === 'VALIDATED')
+  const mapped = tasks.features.filter((task) => task.properties.taskStatus === 'MAPPED').length;
+  const validated = tasks.features.filter((task) => task.properties.taskStatus === 'VALIDATED')
     .length;
-  const badImagery = tasks.features.filter(task => task.properties.taskStatus === 'BADIMAGERY')
+  const badImagery = tasks.features.filter((task) => task.properties.taskStatus === 'BADIMAGERY')
     .length;
+
   return {
     percentMapped: parseInt(((mapped + validated) / (totalTasks - badImagery)) * 100),
     percentValidated: parseInt((validated / (totalTasks - badImagery)) * 100),
+    percentBadImagery: parseInt((badImagery / totalTasks) * 100),
   };
 }

--- a/frontend/src/utils/projectPermissions.js
+++ b/frontend/src/utils/projectPermissions.js
@@ -2,10 +2,10 @@ export function userCanMap(user, project, userTeams = []) {
   if (user.role === 'READ_ONLY') return false;
   if (user.role === 'ADMIN') return true;
   const projectTeamsIds = project.teams
-    .filter(team => ['MAPPER', 'VALIDATOR', 'PROJECT_MANAGER'].includes(team.role))
-    .map(team => team.teamId);
+    .filter((team) => ['MAPPER', 'VALIDATOR', 'PROJECT_MANAGER'].includes(team.role))
+    .map((team) => team.teamId);
   const isUserMemberOfATeam =
-    userTeams.filter(team => projectTeamsIds.includes(team.teamId)).length > 0;
+    userTeams.filter((team) => projectTeamsIds.includes(team.teamId)).length > 0;
   const isUserExperienced = ['INTERMEDIATE', 'ADVANCED'].includes(user.mappingLevel);
 
   // check for private projects
@@ -40,10 +40,10 @@ export function userCanValidate(user, project, userTeams = []) {
   if (user.role === 'READ_ONLY') return false;
   if (user.role === 'ADMIN') return true;
   const projectTeamsIds = project.teams
-    .filter(team => ['VALIDATOR', 'PROJECT_MANAGER'].includes(team.role))
-    .map(team => team.teamId);
+    .filter((team) => ['VALIDATOR', 'PROJECT_MANAGER'].includes(team.role))
+    .map((team) => team.teamId);
   const isUserMemberOfATeam =
-    userTeams.filter(team => projectTeamsIds.includes(team.teamId)).length > 0;
+    userTeams.filter((team) => projectTeamsIds.includes(team.teamId)).length > 0;
   const isUserExperienced = ['INTERMEDIATE', 'ADVANCED'].includes(user.mappingLevel);
 
   // check for private projects
@@ -100,7 +100,7 @@ export function getMessageOnValidationContext(mappingIsPossible, taskStatus) {
 
 export function getTaskAction(user, project, taskStatus, userTeams = []) {
   // nothing more to do if all tasks are validated or set as BADIMAGERY
-  if (project.percentValidated + project.percentBadImagery === 100) {
+  if (project.percentValidated + project.percentBadImagery >= 100) {
     return 'projectIsComplete';
   }
   const validationIsPossible = userCanValidate(user, project, userTeams);
@@ -113,7 +113,7 @@ export function getTaskAction(user, project, taskStatus, userTeams = []) {
   if (mappingIsPossible) {
     return getMessageOnMappingContext(taskStatus);
   }
-  if (project.percentMapped + project.percentBadImagery === 100) {
+  if (project.percentMapped + project.percentBadImagery >= 100) {
     return 'mappingIsComplete';
   }
   return 'selectAnotherProject';

--- a/frontend/src/utils/tests/projectCompletenessCalc.test.js
+++ b/frontend/src/utils/tests/projectCompletenessCalc.test.js
@@ -5,4 +5,5 @@ it('computeCompleteness', () => {
   const project = computeCompleteness(tasksGeojson);
   expect(project.percentMapped).toBe(28);
   expect(project.percentValidated).toBe(14);
+  expect(project.percentBadImagery).toBe(12);
 });

--- a/scripts/database/update-task-stats.sql
+++ b/scripts/database/update-task-stats.sql
@@ -1,0 +1,31 @@
+-- Fetch all project IDs in a temporary table
+SELECT
+    projects.id
+INTO TEMPORARY TABLE
+    temp_projects_id
+FROM
+     projects;
+
+ -- Function to iterate over project IDs and update table entries
+ -- Affected tables:
+ --    projects
+ --    task_status = 2(MAPPED), 4(VALIDATED), 6(BADIMAGERY)
+CREATE OR REPLACE FUNCTION update_task_stats()
+  RETURNS SETOF text AS
+$func$
+DECLARE
+   proj int;
+BEGIN
+   FOR proj IN
+      SELECT * FROM temp_projects_id
+   LOOP
+      update projects set tasks_mapped = (select count(*) from tasks where project_id = proj and task_status = 2) where id = proj;
+      update projects set tasks_validated = (select count(*) from tasks where project_id = proj and task_status = 4) where id = proj;
+      update projects set tasks_bad_imagery = (select count(*) from tasks where project_id = proj and task_status = 6) where id = proj;
+      RETURN NEXT proj;
+      RAISE NOTICE 'Project: %', proj;
+   END LOOP;
+END
+$func$  LANGUAGE plpgsql;
+
+SELECT * from update_task_stats();


### PR DESCRIPTION
Per chat w/ @willemarcel, there is a discrepancy in numbers for a project on TM4 instance.

* Project 31 has a total of 83 tasks - 
     * 76 validated
     * 2 bad imagery
    * 3 mapped
That gets the percentages to - 95% mapped, 91% validated and 2% bad imagery

However the project ID endpoint retruns:

```
"percentMapped": 87,
"percentValidated": 96,
"percentBadImagery": 4,

```

Because  validated  + bad imagery = 100%, contribute button is not enabled on the frontend.

On closer investigation, `update_stats_after_task_state_change` method invokes the `_update_tasks_stats` only if TaskStatus is not in READY, LOCKED_FOR_MAPPING and LOCKED_FOR_VALIDATION. For undo eg: when a BADIMAGERY is set to READY, per current logic this function is not invoked and hence the bad imagery count on projects table never gets decremented resulting in inflated percentage values.

For existing projects, I have a script integrated to updated tasks count on projects table, using tasks current status. I have already run this against our TM4 Database. Queuing this to our TM3 deployment list. cc @dakotabenjamin @xamanu 

Also updated the  denominator for percentage computation in project/id GET endpoint.

State|Current % logic for project 31 | Percentage after changes in this PR
------|-----------------------------|-------------------------------------
Mapped |97|95
Validated|94|91

@willemarcel and I will discuss this in the working group meet today to arrive at an agreement on excluding bad imagery tasks from validated count.
