### PR TITLE
Limit upload size of project geometry files to 1MB

### DIFF
--- a/example.env
+++ b/example.env
@@ -121,4 +121,4 @@ TM_DEFAULT_LOCALE=en
 # TM_FRONTEND_BASE_URL=http://127.0.0.1:3000
 
 # This sets a file size limit to project geometry import. Define it in bytes.
-# TM_IMPORT_MAX_FILESIZE=5000000
+# TM_IMPORT_MAX_FILESIZE=1000000

--- a/frontend/src/config/index.js
+++ b/frontend/src/config/index.js
@@ -35,7 +35,7 @@ export const ORG_GITHUB = process.env.REACT_APP_ORG_GITHUB || 'https://github.co
 export const MATOMO_ID = process.env.REACT_APP_MATOMO_ID || '';
 export const IMAGE_UPLOAD_SERVICE = process.env.REACT_APP_IMAGE_UPLOAD_API_URL !== undefined;
 
-export const MAX_FILESIZE = parseInt(process.env.REACT_APP_MAX_FILESIZE) || 5000000; // bytes
+export const MAX_FILESIZE = parseInt(process.env.REACT_APP_MAX_FILESIZE) || 1000000; // bytes
 
 export const TASK_COLOURS = {
   READY: '#fff',


### PR DESCRIPTION
Closes #2808 

Disallow to upload files that are larger than 1MB in the project creation.