### PR TITLE
Limit upload size of project geometry files to 1MB

### DIFF
--- a/example.env
+++ b/example.env
@@ -121,4 +121,4 @@ TM_DEFAULT_LOCALE=en
 # TM_FRONTEND_BASE_URL=http://127.0.0.1:3000
 
 # This sets a file size limit to project geometry import. Define it in bytes.
-# TM_IMPORT_MAX_FILESIZE=5000000
+# TM_IMPORT_MAX_FILESIZE=1000000

--- a/frontend/src/components/projectCreate/messages.js
+++ b/frontend/src/components/projectCreate/messages.js
@@ -107,7 +107,7 @@ export default defineMessages({
   },
   fileSize: {
     id: 'management.projects.create.errors.fileSize',
-    defaultMessage: 'File size is higher than {fileSize} bytes',
+    defaultMessage: 'We only accept files up to {fileSize} MB. Please reduce the size of your file and try again.',
   },
   splitTaskDescription: {
     id: 'management.projects.create.split_task.description',

--- a/frontend/src/components/projectCreate/setAOI.js
+++ b/frontend/src/components/projectCreate/setAOI.js
@@ -91,7 +91,7 @@ export default function SetAOI({ mapObj, metadata, updateMetadata, setErr }) {
     if (file.size >= MAX_FILESIZE) {
       setErr({
         error: true,
-        message: <FormattedMessage {...messages.fileSize} values={{ fileSize: MAX_FILESIZE }} />,
+        message: <FormattedMessage {...messages.fileSize} values={{ fileSize: MAX_FILESIZE/1000000 }} />,
       });
       return null;
     }

--- a/frontend/src/config/index.js
+++ b/frontend/src/config/index.js
@@ -35,7 +35,7 @@ export const ORG_GITHUB = process.env.REACT_APP_ORG_GITHUB || 'https://github.co
 export const MATOMO_ID = process.env.REACT_APP_MATOMO_ID || '';
 export const IMAGE_UPLOAD_SERVICE = process.env.REACT_APP_IMAGE_UPLOAD_API_URL !== undefined;
 
-export const MAX_FILESIZE = parseInt(process.env.REACT_APP_MAX_FILESIZE) || 5000000; // bytes
+export const MAX_FILESIZE = parseInt(process.env.REACT_APP_MAX_FILESIZE) || 1000000; // bytes
 
 export const TASK_COLOURS = {
   READY: '#fff',

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -203,7 +203,7 @@
   "management.projects.create.errors.unsupported_geom": "Unsupported geometry type {geometry}",
   "management.projects.create.errors.no_featurecollection": "type field is not FeatureCollection",
   "management.projects.create.errors.closed_linestring": "Points do not form a closed linestring",
-  "management.projects.create.errors.fileSize": "File size is higher than {fileSize} bytes",
+  "management.projects.create.errors.fileSize": "We only accept files up to {fileSize} MB. Please reduce the size of your file and try again.",
   "management.projects.create.split_task.description": "Make tasks smaller by clicking on specific tasks or drawing an area on the map.",
   "management.projects.create.reset.button": "Reset",
   "management.projects.create.split.tasks.number": "A new project will be created with {n} tasks.",


### PR DESCRIPTION
Superseeds #2810 and closes #2808

* Disallow to upload files that are larger than 1MB in the project creation.
* Adjust wording of error message when hitting the file limit