### PR TITLE
Let users with manage permissions to map/validate

### DIFF
--- a/backend/models/dtos/project_dto.py
+++ b/backend/models/dtos/project_dto.py
@@ -457,6 +457,7 @@ class ProjectSummary(Model):
     last_updated = UTCDateTimeType(serialized_name="lastUpdated")
     priority = StringType(serialized_name="projectPriority")
     campaigns = ListType(ModelType(CampaignDTO), default=[])
+    organisation = IntType()
     organisation_name = StringType(serialized_name="organisationName")
     organisation_logo = StringType(serialized_name="organisationLogo")
     country_tag = ListType(StringType, serialized_name="countryTag")

--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -732,6 +732,7 @@ class Project(db.Model):
         summary.entities_to_map = self.entities_to_map
         summary.imagery = self.imagery
         if self.organisation_id:
+            summary.organisation = self.organisation_id
             summary.organisation_name = self.organisation.name
             summary.organisation_logo = self.organisation.logo
 

--- a/backend/services/project_admin_service.py
+++ b/backend/services/project_admin_service.py
@@ -330,7 +330,7 @@ class ProjectAdminService:
             if org.is_manager:
                 is_org_manager = True
 
-        is_team_member = None
+        is_manager_team = None
         if hasattr(project, "project_teams") and project.project_teams:
             teams_dto = TeamService.get_project_teams_as_dto(project_id)
             if teams_dto.teams:
@@ -347,6 +347,6 @@ class ProjectAdminService:
                     )
                 ]
                 if user_membership:
-                    is_team_member = True
+                    is_manager_team = True
 
-        return is_admin or is_author or is_org_manager or is_team_member
+        return is_admin or is_author or is_org_manager or is_manager_team

--- a/backend/services/team_service.py
+++ b/backend/services/team_service.py
@@ -240,19 +240,22 @@ class TeamService:
             team_dto.members = []
             team_members = TeamService._get_team_members(team.id)
             is_team_manager = False
+            is_team_member = False
             for member in team_members:
                 user = UserService.get_user_by_id(member.user_id)
                 member_dto = TeamMembersDTO()
                 member_dto.username = user.username
                 member_dto.function = TeamMemberFunctions(member.function).name
-                if member.user_id == user_id and member_dto.function == "MANAGER":
-                    is_team_manager = True
+                if member.user_id == user_id:
+                    is_team_member = True
+                    if member_dto.function == "MANAGER":
+                        is_team_manager = True
                 member_dto.picture_url = user.picture_url
                 member_dto.active = member.active
 
                 team_dto.members.append(member_dto)
             if team_dto.visibility == "PRIVATE" and not is_admin:
-                if is_team_manager:
+                if is_team_manager or is_team_member:
                     teams_list_dto.teams.append(team_dto)
             else:
                 teams_list_dto.teams.append(team_dto)

--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -43,6 +43,7 @@ const getRandomTaskByAction = (activities, taskAction) => {
 
 export function TaskSelection({ project, type, loading }: Object) {
   const user = useSelector((state) => state.auth.get('userDetails'));
+  const userOrgs = useSelector((state) => state.auth.get('organisations'));
   const lockedTasks = useSelector((state) => state.lockedTasks);
   const dispatch = useDispatch();
   const [tasks, setTasks] = useState();
@@ -157,11 +158,21 @@ export function TaskSelection({ project, type, loading }: Object) {
         dispatch({ type: 'SET_TASKS_STATUS', status: lockedByCurrentUser[0].taskStatus });
       } else {
         // otherwise we check if the user can map or validate the project
-        setTaskAction(getTaskAction(user, project, null, userTeams.teams));
+        setTaskAction(getTaskAction(user, project, null, userTeams.teams, userOrgs));
       }
       setMapInit(true);
     }
-  }, [lockedTasks, dispatch, activities, user.username, mapInit, project, user, userTeams.teams]);
+  }, [
+    lockedTasks,
+    dispatch,
+    activities,
+    user.username,
+    mapInit,
+    project,
+    user,
+    userTeams.teams,
+    userOrgs,
+  ]);
 
   // chooses a random task to the user
   useEffect(() => {
@@ -174,12 +185,12 @@ export function TaskSelection({ project, type, loading }: Object) {
     // if selection is an array, just update the state
     if (typeof selection === 'object') {
       setSelectedTasks(selection);
-      setTaskAction(getTaskAction(user, project, status));
+      setTaskAction(getTaskAction(user, project, status, userTeams.teams, userOrgs));
     } else {
       // unselecting tasks
       if (selected.includes(selection)) {
         setSelectedTasks([]);
-        setTaskAction(getTaskAction(user, project, null, userTeams.teams));
+        setTaskAction(getTaskAction(user, project, null, userTeams.teams, userOrgs));
       } else {
         setSelectedTasks([selection]);
         if (lockedTasks.get('tasks').includes(selection)) {
@@ -189,7 +200,7 @@ export function TaskSelection({ project, type, loading }: Object) {
               : 'resumeValidation',
           );
         } else {
-          setTaskAction(getTaskAction(user, project, status, userTeams.teams));
+          setTaskAction(getTaskAction(user, project, status, userTeams.teams, userOrgs));
         }
       }
     }

--- a/frontend/src/utils/projectPermissions.js
+++ b/frontend/src/utils/projectPermissions.js
@@ -1,11 +1,12 @@
-export function userCanMap(user, project, userTeams = []) {
+export function userCanMap(user, project, userTeams = [], userOrgs = []) {
   if (user.role === 'READ_ONLY') return false;
   if (user.role === 'ADMIN') return true;
+  if (project.organisation && userOrgs.includes(project.organisation)) return true;
   const projectTeamsIds = project.teams
-    .filter(team => ['MAPPER', 'VALIDATOR', 'PROJECT_MANAGER'].includes(team.role))
-    .map(team => team.teamId);
+    .filter((team) => ['MAPPER', 'VALIDATOR', 'PROJECT_MANAGER'].includes(team.role))
+    .map((team) => team.teamId);
   const isUserMemberOfATeam =
-    userTeams.filter(team => projectTeamsIds.includes(team.teamId)).length > 0;
+    userTeams.filter((team) => projectTeamsIds.includes(team.teamId)).length > 0;
   const isUserExperienced = ['INTERMEDIATE', 'ADVANCED'].includes(user.mappingLevel);
 
   // check for private projects
@@ -36,14 +37,15 @@ export function userCanMap(user, project, userTeams = []) {
   }
 }
 
-export function userCanValidate(user, project, userTeams = []) {
+export function userCanValidate(user, project, userTeams = [], userOrgs = []) {
   if (user.role === 'READ_ONLY') return false;
   if (user.role === 'ADMIN') return true;
+  if (project.organisation && userOrgs.includes(project.organisation)) return true;
   const projectTeamsIds = project.teams
-    .filter(team => ['VALIDATOR', 'PROJECT_MANAGER'].includes(team.role))
-    .map(team => team.teamId);
+    .filter((team) => ['VALIDATOR', 'PROJECT_MANAGER'].includes(team.role))
+    .map((team) => team.teamId);
   const isUserMemberOfATeam =
-    userTeams.filter(team => projectTeamsIds.includes(team.teamId)).length > 0;
+    userTeams.filter((team) => projectTeamsIds.includes(team.teamId)).length > 0;
   const isUserExperienced = ['INTERMEDIATE', 'ADVANCED'].includes(user.mappingLevel);
 
   // check for private projects
@@ -98,14 +100,15 @@ export function getMessageOnValidationContext(mappingIsPossible, taskStatus) {
   return 'validateATask';
 }
 
-export function getTaskAction(user, project, taskStatus, userTeams = []) {
+export function getTaskAction(user, project, taskStatus, userTeams = [], userOrgs = []) {
   // nothing more to do if all tasks are validated or set as BADIMAGERY
   if (project.percentValidated + project.percentBadImagery === 100) {
     return 'projectIsComplete';
   }
-  const validationIsPossible = userCanValidate(user, project, userTeams);
+  const validationIsPossible = userCanValidate(user, project, userTeams, userOrgs);
   const mappingIsPossible =
-    userCanMap(user, project, userTeams) && project.percentMapped + project.percentBadImagery < 100;
+    userCanMap(user, project, userTeams, userOrgs) &&
+    project.percentMapped + project.percentBadImagery < 100;
 
   if (validationIsPossible) {
     return getMessageOnValidationContext(mappingIsPossible, taskStatus);

--- a/frontend/src/utils/tests/permissionsToMap.test.js
+++ b/frontend/src/utils/tests/permissionsToMap.test.js
@@ -311,3 +311,33 @@ describe('PRIVATE projects', () => {
     expect(userCanMap(user, project, userTeams)).toBe(true);
   });
 });
+
+it('CAN be mapped by Organisation manager', () => {
+  const userTeams = [];
+  const userOrgs = [108];
+  const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
+  const project1 = {
+    mappingPermission: 'ANY',
+    teams: [{ teamId: 7, role: 'MAPPER' }],
+    organisation: 108,
+  };
+  const project2 = {
+    mappingPermission: 'TEAMS',
+    teams: [{ teamId: 7, role: 'MAPPER' }],
+    organisation: 108,
+  };
+  const project3 = {
+    mappingPermission: 'LEVEL',
+    teams: [{ teamId: 7, role: 'MAPPER' }],
+    organisation: 108,
+  };
+  const project4 = {
+    mappingPermission: 'TEAMS_LEVEL',
+    teams: [{ teamId: 7, role: 'MAPPER' }],
+    organisation: 108,
+  };
+  expect(userCanMap(user, project1, userTeams, userOrgs)).toBe(true);
+  expect(userCanMap(user, project2, userTeams, userOrgs)).toBe(true);
+  expect(userCanMap(user, project3, userTeams, userOrgs)).toBe(true);
+  expect(userCanMap(user, project4, userTeams, userOrgs)).toBe(true);
+});

--- a/frontend/src/utils/tests/permissionsToValidate.test.js
+++ b/frontend/src/utils/tests/permissionsToValidate.test.js
@@ -301,3 +301,33 @@ describe('PRIVATE projects', () => {
     expect(userCanValidate(user, project, userTeams)).toBe(true);
   });
 });
+
+it('CAN be validated by Organisation manager', () => {
+  const userTeams = [];
+  const userOrgs = [108];
+  const user = { mappingLevel: 'BEGINNER', role: 'MAPPER' };
+  const project1 = {
+    mappingPermission: 'ANY',
+    teams: [{ teamId: 7, role: 'VALIDATOR' }],
+    organisation: 108,
+  };
+  const project2 = {
+    mappingPermission: 'TEAMS',
+    teams: [{ teamId: 7, role: 'VALIDATOR' }],
+    organisation: 108,
+  };
+  const project3 = {
+    mappingPermission: 'LEVEL',
+    teams: [{ teamId: 7, role: 'VALIDATOR' }],
+    organisation: 108,
+  };
+  const project4 = {
+    mappingPermission: 'TEAMS_LEVEL',
+    teams: [{ teamId: 7, role: 'VALIDATOR' }],
+    organisation: 108,
+  };
+  expect(userCanValidate(user, project1, userTeams, userOrgs)).toBe(true);
+  expect(userCanValidate(user, project2, userTeams, userOrgs)).toBe(true);
+  expect(userCanValidate(user, project3, userTeams, userOrgs)).toBe(true);
+  expect(userCanValidate(user, project4, userTeams, userOrgs)).toBe(true);
+});

--- a/tests/backend/unit/services/test_project_service.py
+++ b/tests/backend/unit/services/test_project_service.py
@@ -9,6 +9,7 @@ from backend.services.project_service import (
     UserService,
     MappingNotAllowed,
 )
+from backend.services.project_service import ProjectAdminService
 from backend.models.dtos.project_dto import LockedTasksForUser
 from backend.models.postgis.task import Task
 
@@ -53,19 +54,19 @@ class TestProjectService(unittest.TestCase):
         # Assert
         self.assertFalse(allowed)
 
-    @patch.object(UserService, "is_user_an_admin")
     @patch.object(UserService, "is_user_blocked")
+    @patch.object(ProjectAdminService, "is_user_action_permitted_on_project")
     @patch.object(Project, "get")
     def test_user_cant_map_if_project_not_published(
-        self, mock_project, mock_user_blocked, mock_user_pm_status
+        self, mock_project, mock_user_action_permitted, mock_user_blocked
     ):
         # Arrange
         stub_project = Project()
         stub_project.status = ProjectStatus.DRAFT.value
         mock_project.return_value = stub_project
 
-        mock_user_pm_status.return_value = False
         mock_user_blocked.return_value = False
+        mock_user_action_permitted.return_value = False
 
         # Act
         allowed, reason = ProjectService.is_user_permitted_to_map(1, 1)


### PR DESCRIPTION
As reported by Ralph, for projects with team permissions on mapping/validation  - admin users were not permitted to lock tasks for validation.
 
Expected behaviour: users with managerial permissions for a project - admins, org managers, PM team members, author can choose to map/validate tasks irrespective of whether they're part of mapper and validation team.

Permission matrix  for mapping a project between users at various access levels and mapping_permissions set in the backend:

User Access | LEVEL - Only users with intermediate or advanced level | TEAMS - Only team members | TEAMS_LEVEL - Only intermediate and advanced team members
-------------|---------------------------------------------------------|-------------------------------|-------------------------------------------------------------------
ADMIN| ✅ |✅|✅
PROJECT AUTHOR|✅|✅|✅
PROJECT ORG MANAGER|✅|✅|✅
MAPPER TEAM|N/A|✅|Only if user level matches
VALIDATOR TEAM|N/A|✅|Only if user level matches
PM TEAM|✅|✅|✅
TM Mappers outside the team|Only if user level matches| ❌ | ❌ 

Permission matrix  for validating a project between users at various access levels and validation_permissions set in the backend:

User Access | LEVEL - Only users with intermediate or advanced level | TEAMS - Only team members | TEAMS_LEVEL - Only intermediate and advanced team members
-------------|---------------------------------------------------------|-------------------------------|-------------------------------------------------------------------
ADMIN| ✅ |✅|✅
PROJECT AUTHOR|✅|✅|✅
PROJECT ORG MANAGER|✅|✅|✅
MAPPER TEAM|N/A| ❌ | ❌ 
VALIDATOR TEAM|Only if user level matches|✅|Only if user level matches
PM TEAM|✅|✅|✅
General TM Mappers|Only if user level matches| ❌ | ❌ 

