### PR TITLE
remove organization link from card + filter active members on team card

### DIFF
--- a/frontend/src/components/teamsAndOrgs/organisations.js
+++ b/frontend/src/components/teamsAndOrgs/organisations.js
@@ -51,23 +51,11 @@ export function OrganisationCard({ details }: Object) {
     <Link to={`${details.organisationId}/`} className="w-50-l w-100 fl pr3">
       <div className="bg-white blue-dark mv2 pb4 dib w-100 ba br1 b--grey-light shadow-hover">
         <div className="w-25 h4 fl pa3">
-          {details.logo && <img src={details.logo} alt={`${details.name} logo`} className="w-80" />}
+          {details.logo && <img src={details.logo} alt={`${details.name} logo`} className="w-70" />}
         </div>
         <div className="w-75 fl pl3">
           <div className="w-100 dib">
             <h3 className="barlow-condensed ttu f3 mb2 mt2 truncate">{details.name}</h3>
-            <span>
-              {details.url && (
-                <a
-                  className="blue-grey link pointer"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href={details.url}
-                >
-                  {details.url}
-                </a>
-              )}
-            </span>
           </div>
           <div className="w-100 dib pt2 fl">
             <h4 className="ttu blue-grey f6">

--- a/frontend/src/components/teamsAndOrgs/teams.js
+++ b/frontend/src/components/teamsAndOrgs/teams.js
@@ -108,7 +108,7 @@ export function TeamCard({ team, managementView }: Object) {
             <UserAvatarList
               size="small"
               textColor="white"
-              users={team.members.filter((user) => user.function === 'MANAGER')}
+              users={team.members.filter((user) => user.function === 'MANAGER' && user.active)}
               maxLength={8}
             />
           </div>
@@ -119,7 +119,7 @@ export function TeamCard({ team, managementView }: Object) {
             <UserAvatarList
               size="small"
               textColor="white"
-              users={team.members.filter((user) => user.function !== 'MANAGER')}
+              users={team.members.filter((user) => user.function !== 'MANAGER' && user.active)}
               maxLength={8}
             />
           </div>


### PR DESCRIPTION
- remove organization link from card, as it's not possible to click on the organisation link inside the card and it was breaking the page style when an org doesn't have the url set
- reduce org logo size on card
- show only active managers/members on team cards (related to https://github.com/hotosm/tasking-manager/issues/2832)
