### PR TITLE
Add exception for projects mission geom record

### DIFF
--- a/migrations/versions/0eee8c1abd3a_.py
+++ b/migrations/versions/0eee8c1abd3a_.py
@@ -45,9 +45,10 @@ def upgrade():
         count = count + 1
         project_id = project[0]
         try:
-            project_centroid = shapely.wkt.loads(str(project[1]))
+            project_centroid = shapely.wkt.loads(project[1])
         except Exception as e:
-            print(e)
+            sys.stdout.write("\033[K")
+            print("Geometry Exception: Project " + str(project_id) + " " + str(e))
             continue
 
         if not project_centroid.is_valid:

--- a/migrations/versions/0eee8c1abd3a_.py
+++ b/migrations/versions/0eee8c1abd3a_.py
@@ -44,7 +44,11 @@ def upgrade():
     for project in projects:
         count = count + 1
         project_id = project[0]
-        project_centroid = shapely.wkt.loads(project[1])
+        try:
+            project_centroid = shapely.wkt.loads(str(project[1]))
+        except Exception as e:
+            print(e)
+            continue
 
         if not project_centroid.is_valid:
             project_centroid = project_centroid.buffer(0)


### PR DESCRIPTION
during trial migration we came across a project with missing geometry, which caused a migration script to fail. The project is 8475. This fix makes sure the migration doesn't fail in that instance. 