### PR TITLE
Update production stack name for new tm4 stack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,7 @@ workflows:
               - deployment/hot-tasking-manager
         requires:
           - build
-        stack_name: "production"
+        stack_name: "tm4-production"
         environment_name: "production"
         autoscaling_policy: "production"
         postgres_db: POSTGRES_DB_PRODUCTION


### PR DESCRIPTION
We can marge this to `master` via release but do not merge to `deployment/hot-tasking-manager` until the correct time during the deployment window. 

We will need to make sure the following envvars in CircleCI are correct before pushing:
```
POSTGRES_DB_PRODUCTION: tm
POSTGRES_PASSWORD_PRODUCTION: *MUST BE ROTATED*
POSTGRES_USER_PRODUCTION: *redacted*
TM_APP_BASE_URL_PRODUCTION: https://tasks.hotosm.org/
TM_APP_URL_PRODUCTION: tasks.hotosm.org
TM_APP_API_VERSION_PRODUCTION: "v2"
TM_CONSUMER_KEY_PRODUCTION: from OSM
TM_CONSUMER_SECRET_PRODUCTION: from OSM
TM_SECRET_PRODUCTION: *MUST BE ROTATED*
TM_EMAIL_FROM_ADDRESS_PRODUCTION: noreply@hotosmmail.org
TM_EMAIL_CONTACT_ADDRESS_PRODUCTION: sysadmin@hotosm.org
TM_SMTP_HOST_PRODUCTION: no change
TM_SMTP_PASSWORD_PRODUCTION: no change
TM_SMTP_USER_PRODUCTION: no change
TM_SMTP_PORT_PRODUCTION: no change
TM_LOG_DIR_PRODUCTION: : no change
DATABASE_SIZE_PRODUCTION: 1000
ELB_SUBNETS_PRODUCTION: no change
SSL_CERTIFICATE_ID_PRODUCTION: no change
TM_DEFAULT_CHANGESET_COMMENT_PRODUCTION: no change
MATOMO_SITE_ID_PRODUCTION: no change
MATOMO_ENDPOINT_PRODUCTION: https://matomo.hotosm.org/
```