### PR TITLE
Fixes in project creation view

### DIFF
--- a/frontend/src/components/projectCreate/navButtons.js
+++ b/frontend/src/components/projectCreate/navButtons.js
@@ -51,7 +51,7 @@ const clearParamsStep = props => {
       props.updateMetadata({ ...props.metadata, tasksNo: 0, taskGrid: null, tempTaskGrid: null });
       break;
     case 3:
-      props.updateMetadata({ ...props.metadata, tempTaskGrid: null });
+      props.updateMetadata({ ...props.metadata, taskGrid: props.metadata.tempTaskGrid });
       break;
     default:
       break;

--- a/frontend/src/components/projectCreate/projectCreationMap.js
+++ b/frontend/src/components/projectCreate/projectCreationMap.js
@@ -92,7 +92,7 @@ const ProjectCreationMap = ({ mapObj, setMapObj, metadata, updateMetadata, step 
           addLayer('aoi', metadata.geom, mapObj.map);
         }
 
-        if (metadata.taskGrid && step === 2) {
+        if (metadata.taskGrid && step !== 1) {
           addLayer('grid', metadata.taskGrid, mapObj.map);
         } else {
           mapObj.map.removeLayer('grid');


### PR DESCRIPTION
- Fixes bug that does not render taskgrid on a  basemap change in trim project and set project name steps for project creation.
- Fixes the taskgrid not reset after being clipped or trimmed and **previous** button is clicked.