### PR TITLE
Include private project filter correctly

### DIFF
--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -83,7 +83,7 @@ class ProjectSearchService:
                 Organisation.name.label("organisation_name"),
                 Organisation.logo.label("organisation_logo"),
             )
-            .filter(Project.private is not True)
+            .filter(Project.private.is_(False))
             .outerjoin(Organisation, Organisation.id == Project.organisation_id)
             .group_by(Organisation.id, Project.id)
         )


### PR DESCRIPTION
Closes #2861. To test this PR, you would need to disable server cache.

**how to test:**
- Using the example db dump.
- Go to explore page.
- Set projects as private. ie
```update projects set private=true where id in (1, 2);```
- You will not see projects 1 and 2.
```update projects set private=false where id in (1, 2);```
- You will see projects 1 and 2.