### PR TITLE
Improvements to imagery handle

### DIFF
--- a/frontend/src/components/taskSelection/imagery.js
+++ b/frontend/src/components/taskSelection/imagery.js
@@ -10,17 +10,17 @@ export function Imagery({ value = '' }: Object) {
   const [isCopied, setCopied] = useCopyClipboard();
 
   const handleClick = () => setCopied(value);
-  let content = <span>{value}</span>;
+  let content = <span title={value}>{value}</span>;
   let copyButton;
   let messageId;
   if (value) {
-    if (value.startsWith('tms[')) {
+    if (value.startsWith('tms')) {
       messageId = 'customTMSLayer';
     }
-    if (value.startsWith('wms[')) {
+    if (value.startsWith('wms')) {
       messageId = 'customWMSLayer';
     }
-    if (value.startsWith('wmts[')) {
+    if (value.startsWith('wmts')) {
       messageId = 'customWMTSLayer';
     }
     if (value.startsWith('http') || value.startsWith('https')) {
@@ -42,7 +42,7 @@ export function Imagery({ value = '' }: Object) {
     content = <FormattedMessage {...messages.noImageryDefined} />;
   }
   return (
-    <p className={`f5 fw6 pt1 ma0 ${value ? 'blue-dark' : 'blue-light'}`}>
+    <p className={`f5 fw6 pt1 pr3 ma0 truncate ${value ? 'blue-dark' : 'blue-light'}`}>
       {content}
       {copyButton}
     </p>

--- a/frontend/src/components/taskSelection/tests/imagery.test.js
+++ b/frontend/src/components/taskSelection/tests/imagery.test.js
@@ -16,6 +16,16 @@ it('test if Imagery returns the correct FormattedMessage to TMS', () => {
   expect(testInstance.findByType(FormattedMessage).props.id).toBe('project.imagery.tms');
 });
 
+it('test if Imagery returns the correct FormattedMessage to TMS, even without the zoom level information', () => {
+  const element = createComponentWithIntl(
+    <Imagery
+      value={'tms:https://service.com/earthservice/tms/Layer@EPSG:3857@jpg/{zoom}/{x}/{-y}.jpg'}
+    />,
+  );
+  const testInstance = element.root;
+  expect(testInstance.findByType(FormattedMessage).props.id).toBe('project.imagery.tms');
+});
+
 it('test if Imagery returns the correct FormattedMessage to WMS', () => {
   const element = createComponentWithIntl(
     <Imagery

--- a/frontend/src/utils/openEditor.js
+++ b/frontend/src/utils/openEditor.js
@@ -128,7 +128,7 @@ function loadTasksBoundaries(project, selectedTasks) {
 function loadImageryonJosm(project) {
   if (project.imagery) {
     const imageryParams = {
-      title: `TM imagery for project #${project.projectId}`,
+      title: project.imagery,
       type: project.imagery.toLowerCase().substring(0, 3),
       url: project.imagery,
     };


### PR DESCRIPTION
- Accept TMS urls starting with `tms:https://` (the same to WMS and WMTS) as valid urls
- Avoid imagery info area to have more than one line
- Launch JOSM with the imagery URL as title of the layer