### PR TITLE
Updates to project edit permissions check

### DIFF
--- a/backend/api/campaigns/resources.py
+++ b/backend/api/campaigns/resources.py
@@ -44,9 +44,10 @@ class CampaignsRestAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            if tm.authenticated_user_id:
+            authenticated_user_id = tm.authenticated_user_id
+            if authenticated_user_id:
                 campaign = CampaignService.get_campaign_as_dto(
-                    campaign_id, tm.authenticated_user_id
+                    campaign_id, authenticated_user_id
                 )
             else:
                 campaign = CampaignService.get_campaign_as_dto(campaign_id, 0)

--- a/backend/api/campaigns/resources.py
+++ b/backend/api/campaigns/resources.py
@@ -5,7 +5,7 @@ from backend.models.dtos.campaign_dto import CampaignDTO, NewCampaignDTO
 from backend.services.campaign_service import CampaignService
 from backend.services.organisation_service import OrganisationService
 from backend.models.postgis.utils import NotFound
-from backend.services.users.authentication_service import token_auth, tm
+from backend.services.users.authentication_service import token_auth
 
 
 class CampaignsRestAPI(Resource):
@@ -44,7 +44,7 @@ class CampaignsRestAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             if authenticated_user_id:
                 campaign = CampaignService.get_campaign_as_dto(
                     campaign_id, authenticated_user_id
@@ -121,7 +121,7 @@ class CampaignsRestAPI(Resource):
         """
         try:
             orgs_dto = OrganisationService.get_organisations_managed_by_user_as_dto(
-                tm.authenticated_user_id
+                token_auth.current_user()
             )
             if len(orgs_dto.organisations) < 1:
                 raise ValueError("User not a Org Manager")
@@ -186,7 +186,7 @@ class CampaignsRestAPI(Resource):
         """
         try:
             orgs_dto = OrganisationService.get_organisations_managed_by_user_as_dto(
-                tm.authenticated_user_id
+                token_auth.current_user()
             )
             if len(orgs_dto.organisations) < 1:
                 raise ValueError("User not a Org Manager")
@@ -285,7 +285,7 @@ class CampaignsAllAPI(Resource):
         """
         try:
             orgs_dto = OrganisationService.get_organisations_managed_by_user_as_dto(
-                tm.authenticated_user_id
+                token_auth.current_user()
             )
             if len(orgs_dto.organisations) < 1:
                 raise ValueError("User not a Org Manager")

--- a/backend/api/comments/resources.py
+++ b/backend/api/comments/resources.py
@@ -52,13 +52,13 @@ class CommentsProjectsRestAPI(Resource):
             500:
                 description: Internal Server Error
         """
-
-        if UserService.is_user_blocked(tm.authenticated_user_id):
+        authenticated_user_id = tm.authenticated_user_id
+        if UserService.is_user_blocked(authenticated_user_id):
             return "User is on read only mode", 403
 
         try:
             chat_dto = ChatMessageDTO(request.get_json())
-            chat_dto.user_id = tm.authenticated_user_id
+            chat_dto.user_id = authenticated_user_id
             chat_dto.project_id = project_id
             chat_dto.validate()
         except DataError as e:
@@ -67,7 +67,7 @@ class CommentsProjectsRestAPI(Resource):
 
         try:
             project_messages = ChatService.post_message(
-                chat_dto, project_id, tm.authenticated_user_id
+                chat_dto, project_id, authenticated_user_id
             )
             return project_messages.to_primitive(), 201
         except ValueError as e:

--- a/backend/api/comments/resources.py
+++ b/backend/api/comments/resources.py
@@ -52,7 +52,7 @@ class CommentsProjectsRestAPI(Resource):
             500:
                 description: Internal Server Error
         """
-        authenticated_user_id = tm.authenticated_user_id
+        authenticated_user_id = token_auth.current_user()
         if UserService.is_user_blocked(authenticated_user_id):
             return "User is on read only mode", 403
 
@@ -188,7 +188,7 @@ class CommentsTasksRestAPI(Resource):
         """
         try:
             task_comment = TaskCommentDTO(request.get_json())
-            task_comment.user_id = tm.authenticated_user_id
+            task_comment.user_id = token_auth.current_user()
             task_comment.task_id = task_id
             task_comment.project_id = project_id
             task_comment.validate()
@@ -263,7 +263,7 @@ class CommentsTasksRestAPI(Resource):
         """
         try:
             task_comment = TaskCommentDTO(request.get_json())
-            task_comment.user_id = tm.authenticated_user_id
+            task_comment.user_id = token_auth.current_user()
             task_comment.task_id = task_id
             task_comment.project_id = project_id
             task_comment.validate()

--- a/backend/api/interests/resources.py
+++ b/backend/api/interests/resources.py
@@ -5,7 +5,7 @@ from backend.models.dtos.interests_dto import InterestDTO
 from backend.models.postgis.utils import NotFound
 from backend.services.interests_service import InterestService
 from backend.services.organisation_service import OrganisationService
-from backend.services.users.authentication_service import token_auth, tm
+from backend.services.users.authentication_service import token_auth
 
 from sqlalchemy.exc import IntegrityError
 
@@ -50,7 +50,7 @@ class InterestsAllAPI(Resource):
         """
         try:
             orgs_dto = OrganisationService.get_organisations_managed_by_user_as_dto(
-                tm.authenticated_user_id
+                token_auth.current_user()
             )
             if len(orgs_dto.organisations) < 1:
                 raise ValueError("User not a Org Manager")
@@ -145,7 +145,7 @@ class InterestsRestAPI(Resource):
         """
         try:
             orgs_dto = OrganisationService.get_organisations_managed_by_user_as_dto(
-                tm.authenticated_user_id
+                token_auth.current_user()
             )
             if len(orgs_dto.organisations) < 1:
                 raise ValueError("User not a Org Manager")
@@ -206,7 +206,7 @@ class InterestsRestAPI(Resource):
         """
         try:
             orgs_dto = OrganisationService.get_organisations_managed_by_user_as_dto(
-                tm.authenticated_user_id
+                token_auth.current_user()
             )
             if len(orgs_dto.organisations) < 1:
                 raise ValueError("User not a Org Manager")
@@ -265,7 +265,7 @@ class InterestsRestAPI(Resource):
         """
         try:
             orgs_dto = OrganisationService.get_organisations_managed_by_user_as_dto(
-                tm.authenticated_user_id
+                token_auth.current_user()
             )
             if len(orgs_dto.organisations) < 1:
                 raise ValueError("User not a Org Manager")

--- a/backend/api/licenses/actions.py
+++ b/backend/api/licenses/actions.py
@@ -1,6 +1,6 @@
 from flask_restful import Resource, current_app
 
-from backend.services.users.authentication_service import token_auth, tm
+from backend.services.users.authentication_service import token_auth
 from backend.services.users.user_service import UserService, NotFound
 
 
@@ -38,7 +38,7 @@ class LicensesActionsAcceptAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            UserService.accept_license_terms(tm.authenticated_user_id, license_id)
+            UserService.accept_license_terms(token_auth.current_user(), license_id)
             return {"Success": "Terms Accepted"}, 200
         except NotFound:
             return {"Error": "User or mapping not found"}, 404

--- a/backend/api/notifications/actions.py
+++ b/backend/api/notifications/actions.py
@@ -42,7 +42,7 @@ class NotificationsActionsDeleteMultipleAPI(Resource):
             message_ids = request.get_json()["messageIds"]
             if message_ids:
                 MessageService.delete_multiple_messages(
-                    message_ids, tm.authenticated_user_id
+                    message_ids, token_auth.current_user()
                 )
 
             return {"Success": "Messages deleted"}, 200

--- a/backend/api/notifications/resources.py
+++ b/backend/api/notifications/resources.py
@@ -43,7 +43,7 @@ class NotificationsRestAPI(Resource):
         """
         try:
             user_message = MessageService.get_message_as_dto(
-                message_id, tm.authenticated_user_id
+                message_id, token_auth.current_user()
             )
             return user_message.to_primitive(), 200
         except MessageServiceError:
@@ -89,7 +89,7 @@ class NotificationsRestAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            MessageService.delete_message(message_id, tm.authenticated_user_id)
+            MessageService.delete_message(message_id, token_auth.current_user())
             return {"Success": "Message deleted"}, 200
         except MessageServiceError:
             return {"Error": "Unable to delete message"}, 403
@@ -171,7 +171,7 @@ class NotificationsAllAPI(Resource):
             project = request.args.get("project", None, int)
             task_id = request.args.get("taskId", None, int)
             user_messages = MessageService.get_all_messages(
-                tm.authenticated_user_id,
+                token_auth.current_user(),
                 preferred_locale,
                 page,
                 page_size,
@@ -215,7 +215,7 @@ class NotificationsQueriesCountUnreadAPI(Resource):
         """
         try:
             unread_count = MessageService.has_user_new_messages(
-                tm.authenticated_user_id
+                token_auth.current_user()
             )
             return unread_count, 200
         except Exception as e:

--- a/backend/api/organisations/campaigns.py
+++ b/backend/api/organisations/campaigns.py
@@ -4,7 +4,7 @@ from backend.services.campaign_service import CampaignService
 from backend.services.organisation_service import OrganisationService
 from backend.models.postgis.utils import NotFound
 from backend.models.postgis.campaign import Campaign
-from backend.services.users.authentication_service import token_auth, tm
+from backend.services.users.authentication_service import token_auth
 
 
 class OrganisationsCampaignsAPI(Resource):
@@ -50,7 +50,7 @@ class OrganisationsCampaignsAPI(Resource):
         """
         try:
             if OrganisationService.can_user_manage_organisation(
-                organisation_id, tm.authenticated_user_id
+                organisation_id, token_auth.current_user()
             ):
                 if Campaign.campaign_organisation_exists(campaign_id, organisation_id):
                     message = "Campaign {} is already assigned to organisation {}.".format(
@@ -155,7 +155,7 @@ class OrganisationsCampaignsAPI(Resource):
         """
         try:
             if OrganisationService.can_user_manage_organisation(
-                organisation_id, tm.authenticated_user_id
+                organisation_id, token_auth.current_user()
             ):
                 CampaignService.delete_organisation_campaign(
                     organisation_id, campaign_id

--- a/backend/api/organisations/resources.py
+++ b/backend/api/organisations/resources.py
@@ -13,7 +13,7 @@ from backend.services.organisation_service import (
 )
 
 from backend.services.users.user_service import UserService
-from backend.services.users.authentication_service import token_auth, tm, verify_token
+from backend.services.users.authentication_service import token_auth
 
 
 class OrganisationsRestAPI(Resource):
@@ -70,7 +70,7 @@ class OrganisationsRestAPI(Resource):
             500:
                 description: Internal Server Error
         """
-        request_user = User.get_by_id(tm.authenticated_user_id)
+        request_user = User.get_by_id(token_auth.current_user())
         if request_user.role != 1:
             return {"Error": "Only admin users can create organisations."}, 403
 
@@ -128,7 +128,7 @@ class OrganisationsRestAPI(Resource):
                 description: Internal Server Error
         """
         if not OrganisationService.can_user_manage_organisation(
-            organisation_id, tm.authenticated_user_id
+            organisation_id, token_auth.current_user()
         ):
             return {"Error": "User is not an admin for the org"}, 403
         try:
@@ -174,7 +174,7 @@ class OrganisationsRestAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             if authenticated_user_id is None:
                 user_id = 0
             else:
@@ -248,7 +248,7 @@ class OrganisationsRestAPI(Resource):
                 description: Internal Server Error
         """
         if not OrganisationService.can_user_manage_organisation(
-            organisation_id, tm.authenticated_user_id
+            organisation_id, token_auth.current_user()
         ):
             return {"Error": "User is not an admin for the org"}, 403
         try:
@@ -273,6 +273,7 @@ class OrganisationsRestAPI(Resource):
 
 
 class OrganisationsAllAPI(Resource):
+    @token_auth.login_required(optional=True)
     def get(self):
         """
         List all organisations
@@ -308,7 +309,7 @@ class OrganisationsAllAPI(Resource):
         """
 
         # Restrict some of the parameters to some permissions
-        authenticated_user_id = tm.authenticated_user_id
+        authenticated_user_id = token_auth.current_user()
         try:
             manager_user_id = int(request.args.get("manager_user_id"))
         except Exception:
@@ -316,11 +317,6 @@ class OrganisationsAllAPI(Resource):
 
         if manager_user_id is not None:
             try:
-                # Verify login
-                verify_token(
-                    request.environ.get("HTTP_AUTHORIZATION").split(None, 1)[1]
-                )
-
                 # Check whether user is admin (can do any query) or user is checking for own projects
                 if (
                     not UserService.is_user_an_admin(authenticated_user_id)

--- a/backend/api/organisations/resources.py
+++ b/backend/api/organisations/resources.py
@@ -174,10 +174,11 @@ class OrganisationsRestAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            if tm.authenticated_user_id is None:
+            authenticated_user_id = tm.authenticated_user_id
+            if authenticated_user_id is None:
                 user_id = 0
             else:
-                user_id = tm.authenticated_user_id
+                user_id = authenticated_user_id
             organisation_dto = OrganisationService.get_organisation_by_id_as_dto(
                 organisation_id, user_id
             )
@@ -307,6 +308,7 @@ class OrganisationsAllAPI(Resource):
         """
 
         # Restrict some of the parameters to some permissions
+        authenticated_user_id = tm.authenticated_user_id
         try:
             manager_user_id = int(request.args.get("manager_user_id"))
         except Exception:
@@ -321,8 +323,8 @@ class OrganisationsAllAPI(Resource):
 
                 # Check whether user is admin (can do any query) or user is checking for own projects
                 if (
-                    not UserService.is_user_an_admin(tm.authenticated_user_id)
-                    and tm.authenticated_user_id != manager_user_id
+                    not UserService.is_user_an_admin(authenticated_user_id)
+                    and authenticated_user_id != manager_user_id
                 ):
                     raise ValueError
 
@@ -332,7 +334,7 @@ class OrganisationsAllAPI(Resource):
         # Obtain organisations
         try:
             results_dto = OrganisationService.get_organisations_as_dto(
-                manager_user_id, tm.authenticated_user_id
+                manager_user_id, authenticated_user_id
             )
             return results_dto.to_primitive(), 200
         except NotFound:

--- a/backend/api/projects/actions.py
+++ b/backend/api/projects/actions.py
@@ -54,8 +54,9 @@ class ProjectsActionsTransferAPI(Resource):
         """
         try:
             username = request.get_json()["username"]
+            authenticated_user_id = tm.authenticated_user_id
             ProjectAdminService.transfer_project_to(
-                project_id, tm.authenticated_user_id, username
+                project_id, authenticated_user_id, username
             )
             return {"Success": "Project Transfered"}, 200
         except ValueError as e:
@@ -114,8 +115,9 @@ class ProjectsActionsMessageContributorsAPI(Resource):
                 description: Internal Server Error
         """
         try:
+            authenticated_user_id = tm.authenticated_user_id
             message_dto = MessageDTO(request.get_json())
-            message_dto.from_user_id = tm.authenticated_user_id
+            message_dto.from_user_id = authenticated_user_id
             message_dto.validate()
         except DataError as e:
             current_app.logger.error(f"Error validating request: {str(e)}")
@@ -123,7 +125,7 @@ class ProjectsActionsMessageContributorsAPI(Resource):
 
         try:
             ProjectAdminService.is_user_action_permitted_on_project(
-                tm.authenticated_user_id, project_id
+                authenticated_user_id, project_id
             )
             threading.Thread(
                 target=MessageService.send_message_to_all_contributors,
@@ -175,15 +177,16 @@ class ProjectsActionsFeatureAPI(Resource):
                 description: Internal Server Error
         """
         try:
+            authenticated_user_id = tm.authenticated_user_id
             ProjectAdminService.is_user_action_permitted_on_project(
-                tm.authenticated_user_id, project_id
+                authenticated_user_id, project_id
             )
         except ValueError as e:
             error_msg = f"FeaturedProjects POST: {str(e)}"
             return {"Error": error_msg}, 403
 
         try:
-            ProjectService.set_project_as_featured(project_id, tm.authenticated_user_id)
+            ProjectService.set_project_as_featured(project_id, authenticated_user_id)
             return {"Success": True}, 200
         except NotFound:
             return {"Error": "Project Not Found"}, 404

--- a/backend/api/projects/actions.py
+++ b/backend/api/projects/actions.py
@@ -7,7 +7,7 @@ from backend.models.dtos.message_dto import MessageDTO
 from backend.services.project_service import ProjectService, NotFound
 from backend.services.project_admin_service import ProjectAdminService
 from backend.services.messaging.message_service import MessageService
-from backend.services.users.authentication_service import token_auth, tm
+from backend.services.users.authentication_service import token_auth
 from backend.services.interests_service import InterestService
 
 
@@ -54,7 +54,7 @@ class ProjectsActionsTransferAPI(Resource):
         """
         try:
             username = request.get_json()["username"]
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             ProjectAdminService.transfer_project_to(
                 project_id, authenticated_user_id, username
             )
@@ -115,7 +115,7 @@ class ProjectsActionsMessageContributorsAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             message_dto = MessageDTO(request.get_json())
             message_dto.from_user_id = authenticated_user_id
             message_dto.validate()
@@ -177,7 +177,7 @@ class ProjectsActionsFeatureAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             ProjectAdminService.is_user_action_permitted_on_project(
                 authenticated_user_id, project_id
             )
@@ -236,7 +236,7 @@ class ProjectsActionsUnFeatureAPI(Resource):
         """
         try:
             ProjectAdminService.is_user_action_permitted_on_project(
-                tm.authenticated_user_id, project_id
+                token_auth.current_user(), project_id
             )
         except ValueError as e:
             error_msg = f"FeaturedProjects POST: {str(e)}"
@@ -303,7 +303,7 @@ class ProjectsActionsSetInterestsAPI(Resource):
         """
         try:
             ProjectAdminService.is_user_action_permitted_on_project(
-                tm.authenticated_user_id, project_id
+                token_auth.current_user(), project_id
             )
         except ValueError as e:
             error_msg = f"ProjectsActionsSetInterestsAPI POST: {str(e)}"

--- a/backend/api/projects/campaigns.py
+++ b/backend/api/projects/campaigns.py
@@ -5,7 +5,7 @@ from backend.models.dtos.campaign_dto import CampaignProjectDTO
 from backend.services.campaign_service import CampaignService
 from backend.services.project_admin_service import ProjectAdminService
 from backend.models.postgis.utils import NotFound
-from backend.services.users.authentication_service import token_auth, tm
+from backend.services.users.authentication_service import token_auth
 
 
 class ProjectsCampaignsAPI(Resource):
@@ -51,7 +51,7 @@ class ProjectsCampaignsAPI(Resource):
         """
         try:
             ProjectAdminService.is_user_action_permitted_on_project(
-                tm.authenticated_user_id, project_id
+                token_auth.current_user(), project_id
             )
         except ValueError as e:
             error_msg = f"ProjectsCampaignsAPI POST: {str(e)}"
@@ -154,7 +154,7 @@ class ProjectsCampaignsAPI(Resource):
         """
         try:
             ProjectAdminService.is_user_action_permitted_on_project(
-                tm.authenticated_user_id, project_id
+                token_auth.current_user(), project_id
             )
         except ValueError as e:
             error_msg = f"ProjectsCampaignsAPI DELETE: {str(e)}"

--- a/backend/api/projects/favorites.py
+++ b/backend/api/projects/favorites.py
@@ -85,15 +85,16 @@ class ProjectsFavoritesAPI(Resource):
                 description: Internal Server Error
         """
         try:
+            authenticated_user_id = tm.authenticated_user_id
             favorite_dto = ProjectFavoriteDTO()
             favorite_dto.project_id = project_id
-            favorite_dto.user_id = tm.authenticated_user_id
+            favorite_dto.user_id = authenticated_user_id
             favorite_dto.validate()
         except DataError as e:
             current_app.logger.error(f"Error validating request: {str(e)}")
             return str(e), 400
         try:
-            ProjectService.favorite(project_id, tm.authenticated_user_id)
+            ProjectService.favorite(project_id, authenticated_user_id)
         except NotFound:
             return {"Error": "Project Not Found"}, 404
         except ValueError as e:

--- a/backend/api/projects/favorites.py
+++ b/backend/api/projects/favorites.py
@@ -4,7 +4,7 @@ from schematics.exceptions import DataError
 from backend.models.postgis.utils import NotFound
 from backend.models.dtos.project_dto import ProjectFavoriteDTO
 from backend.services.project_service import ProjectService
-from backend.services.users.authentication_service import token_auth, tm
+from backend.services.users.authentication_service import token_auth
 
 
 class ProjectsFavoritesAPI(Resource):
@@ -40,7 +40,7 @@ class ProjectsFavoritesAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            user_id = tm.authenticated_user_id
+            user_id = token_auth.current_user()
             favorited = ProjectService.is_favorited(project_id, user_id)
             if favorited is True:
                 return {"favorited": True}, 200
@@ -85,7 +85,7 @@ class ProjectsFavoritesAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             favorite_dto = ProjectFavoriteDTO()
             favorite_dto.project_id = project_id
             favorite_dto.user_id = authenticated_user_id
@@ -138,7 +138,7 @@ class ProjectsFavoritesAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            ProjectService.unfavorite(project_id, tm.authenticated_user_id)
+            ProjectService.unfavorite(project_id, token_auth.current_user())
         except NotFound:
             return {"Error": "Project Not Found"}, 404
         except ValueError as e:

--- a/backend/api/projects/resources.py
+++ b/backend/api/projects/resources.py
@@ -387,9 +387,10 @@ class ProjectsRestAPI(Resource):
             500:
                 description: Internal Server Error
         """
+        authenticated_user_id = tm.authenticated_user_id
         try:
             ProjectAdminService.is_user_action_permitted_on_project(
-                tm.authenticated_user_id, project_id
+                authenticated_user_id, project_id
             )
         except ValueError as e:
             error_msg = f"ProjectsRestAPI PATCH: {str(e)}"
@@ -404,7 +405,7 @@ class ProjectsRestAPI(Resource):
             return {"Error": "Unable to update project"}, 400
 
         try:
-            ProjectAdminService.update_project(project_dto, tm.authenticated_user_id)
+            ProjectAdminService.update_project(project_dto, authenticated_user_id)
             return {"Status": "Updated"}, 200
         except InvalidGeoJson as e:
             return {"Invalid GeoJson": str(e)}, 400

--- a/backend/api/projects/teams.py
+++ b/backend/api/projects/teams.py
@@ -2,7 +2,7 @@ from flask_restful import Resource, request, current_app
 from schematics.exceptions import DataError
 
 from backend.services.team_service import TeamService, TeamServiceError, NotFound
-from backend.services.users.authentication_service import token_auth, tm
+from backend.services.users.authentication_service import token_auth
 
 
 class ProjectsTeamsAPI(Resource):
@@ -92,7 +92,7 @@ class ProjectsTeamsAPI(Resource):
             500:
                 description: Internal Server Error
         """
-        if not TeamService.user_is_manager(team_id, tm.authenticated_user_id):
+        if not TeamService.user_is_manager(team_id, token_auth.current_user()):
             return {"Error": "User is not an admin or a manager for the team"}, 401
 
         try:
@@ -163,7 +163,7 @@ class ProjectsTeamsAPI(Resource):
             500:
                 description: Internal Server Error
         """
-        if not TeamService.user_is_manager(team_id, tm.authenticated_user_id):
+        if not TeamService.user_is_manager(team_id, token_auth.current_user()):
             return {"Error": "User is not an admin or a manager for the team"}, 401
         try:
             role = request.get_json(force=True)["role"]
@@ -217,7 +217,7 @@ class ProjectsTeamsAPI(Resource):
             500:
                 description: Internal Server Error
         """
-        if not TeamService.user_is_manager(team_id, tm.authenticated_user_id):
+        if not TeamService.user_is_manager(team_id, token_auth.current_user()):
             return {"Error": "User is not an admin or a manager for the team"}, 401
         try:
             TeamService.delete_team_project(team_id, project_id)

--- a/backend/api/system/applications.py
+++ b/backend/api/system/applications.py
@@ -1,7 +1,7 @@
 from flask_restful import Resource, current_app
 
 from backend.services.application_service import ApplicationService, NotFound
-from backend.services.users.authentication_service import token_auth, tm
+from backend.services.users.authentication_service import token_auth
 
 
 class SystemApplicationsRestAPI(Resource):
@@ -31,7 +31,7 @@ class SystemApplicationsRestAPI(Resource):
         """
         try:
             tokens = ApplicationService.get_all_tokens_for_logged_in_user(
-                tm.authenticated_user_id
+                token_auth.current_user()
             )
             if len(tokens) == 0:
                 return 400
@@ -66,7 +66,7 @@ class SystemApplicationsRestAPI(Resource):
             description: A problem occurred
         """
         try:
-            token = ApplicationService.create_token(tm.authenticated_user_id)
+            token = ApplicationService.create_token(token_auth.current_user())
             return token.to_primitive(), 200
         except Exception as e:
             error_msg = f"Application POST API - unhandled error: {str(e)}"
@@ -141,7 +141,7 @@ class SystemApplicationsRestAPI(Resource):
         """
         try:
             token = ApplicationService.get_token(application_key)
-            if token.user == tm.authenticated_user_id:
+            if token.user == token_auth.current_user():
                 token.delete()
                 return 200
             else:

--- a/backend/api/system/image_upload.py
+++ b/backend/api/system/image_upload.py
@@ -4,7 +4,7 @@ import json
 from flask_restful import Resource, request, current_app
 
 from backend.services.organisation_service import OrganisationService
-from backend.services.users.authentication_service import token_auth, tm
+from backend.services.users.authentication_service import token_auth
 
 
 class SystemImageUploadRestAPI(Resource):
@@ -59,7 +59,7 @@ class SystemImageUploadRestAPI(Resource):
             is_org_manager = (
                 len(
                     OrganisationService.get_organisations_managed_by_user(
-                        tm.authenticated_user_id
+                        token_auth.current_user()
                     )
                 )
                 > 0

--- a/backend/api/tasks/actions.py
+++ b/backend/api/tasks/actions.py
@@ -247,8 +247,9 @@ class TasksActionsMappingUnlockAPI(Resource):
                 description: Internal Server Error
         """
         try:
+            authenticated_user_id = tm.authenticated_user_id
             mapped_task = MappedTaskDTO(request.get_json())
-            mapped_task.user_id = tm.authenticated_user_id
+            mapped_task.user_id = authenticated_user_id
             mapped_task.task_id = task_id
             mapped_task.project_id = project_id
             mapped_task.validate()
@@ -269,7 +270,7 @@ class TasksActionsMappingUnlockAPI(Resource):
             return {"Error": "Task unlock failed"}, 500
         finally:
             # Refresh mapper level after mapping
-            UserService.check_and_update_mapper_level(tm.authenticated_user_id)
+            UserService.check_and_update_mapper_level(authenticated_user_id)
 
 
 class TasksActionsMappingUndoAPI(Resource):
@@ -605,15 +606,16 @@ class TasksActionsMapAllAPI(Resource):
                 description: Internal Server Error
         """
         try:
+            authenticated_user_id = tm.authenticated_user_id
             ProjectAdminService.is_user_action_permitted_on_project(
-                tm.authenticated_user_id, project_id
+                authenticated_user_id, project_id
             )
         except ValueError as e:
             error_msg = f"TasksActionsMapAllAPI POST: {str(e)}"
             return {"Error": error_msg}, 403
 
         try:
-            MappingService.map_all_tasks(project_id, tm.authenticated_user_id)
+            MappingService.map_all_tasks(project_id, authenticated_user_id)
             return {"Success": "All tasks mapped"}, 200
         except Exception as e:
             error_msg = f"TasksActionsMapAllAPI POST - unhandled error: {str(e)}"
@@ -655,15 +657,16 @@ class TasksActionsValidateAllAPI(Resource):
                 description: Internal Server Error
         """
         try:
+            authenticated_user_id = tm.authenticated_user_id
             ProjectAdminService.is_user_action_permitted_on_project(
-                tm.authenticated_user_id, project_id
+                authenticated_user_id, project_id
             )
         except ValueError as e:
             error_msg = f"TasksActionsValidateAllAPI POST: {str(e)}"
             return {"Error": error_msg}, 403
 
         try:
-            ValidatorService.validate_all_tasks(project_id, tm.authenticated_user_id)
+            ValidatorService.validate_all_tasks(project_id, authenticated_user_id)
             return {"Success": "All tasks validated"}, 200
         except Exception as e:
             error_msg = f"TasksActionsValidateAllAPI POST - unhandled error: {str(e)}"
@@ -705,15 +708,16 @@ class TasksActionsInvalidateAllAPI(Resource):
                 description: Internal Server Error
         """
         try:
+            authenticated_user_id = tm.authenticated_user_id
             ProjectAdminService.is_user_action_permitted_on_project(
-                tm.authenticated_user_id, project_id
+                authenticated_user_id, project_id
             )
         except ValueError as e:
             error_msg = f"TasksActionsInvalidateAllAPI POST: {str(e)}"
             return {"Error": error_msg}, 403
 
         try:
-            ValidatorService.invalidate_all_tasks(project_id, tm.authenticated_user_id)
+            ValidatorService.invalidate_all_tasks(project_id, authenticated_user_id)
             return {"Success": "All tasks invalidated"}, 200
         except Exception as e:
             error_msg = f"TasksActionsInvalidateAllAPI POST - unhandled error: {str(e)}"
@@ -755,15 +759,16 @@ class TasksActionsResetBadImageryAllAPI(Resource):
                 description: Internal Server Error
         """
         try:
+            authenticated_user_id = tm.authenticated_user_id
             ProjectAdminService.is_user_action_permitted_on_project(
-                tm.authenticated_user_id, project_id
+                authenticated_user_id, project_id
             )
         except ValueError as e:
             error_msg = f"TasksActionsResetBadImageryAllAPI POST: {str(e)}"
             return {"Error": error_msg}, 403
 
         try:
-            MappingService.reset_all_badimagery(project_id, tm.authenticated_user_id)
+            MappingService.reset_all_badimagery(project_id, authenticated_user_id)
             return {"Success": "All bad imagery tasks marked ready for mapping"}, 200
         except Exception as e:
             error_msg = (
@@ -807,15 +812,16 @@ class TasksActionsResetAllAPI(Resource):
                 description: Internal Server Error
         """
         try:
+            authenticated_user_id = tm.authenticated_user_id
             ProjectAdminService.is_user_action_permitted_on_project(
-                tm.authenticated_user_id, project_id
+                authenticated_user_id, project_id
             )
         except ValueError as e:
             error_msg = f"TasksActionsResetAllAPI POST: {str(e)}"
             return {"Error": error_msg}, 403
 
         try:
-            ProjectAdminService.reset_all_tasks(project_id, tm.authenticated_user_id)
+            ProjectAdminService.reset_all_tasks(project_id, authenticated_user_id)
             return {"Success": "All tasks reset"}, 200
         except Exception as e:
             error_msg = f"TasksActionsResetAllAPI POST - unhandled error: {str(e)}"

--- a/backend/api/tasks/actions.py
+++ b/backend/api/tasks/actions.py
@@ -78,7 +78,7 @@ class TasksActionsMappingLockAPI(Resource):
         """
         try:
             lock_task_dto = LockTaskDTO()
-            lock_task_dto.user_id = tm.authenticated_user_id
+            lock_task_dto.user_id = token_auth.current_user()
             lock_task_dto.project_id = project_id
             lock_task_dto.task_id = task_id
             lock_task_dto.preferred_locale = request.environ.get("HTTP_ACCEPT_LANGUAGE")
@@ -164,7 +164,7 @@ class TasksActionsMappingStopAPI(Resource):
         """
         try:
             stop_task = StopMappingTaskDTO(request.get_json())
-            stop_task.user_id = tm.authenticated_user_id
+            stop_task.user_id = token_auth.current_user()
             stop_task.task_id = task_id
             stop_task.project_id = project_id
             stop_task.preferred_locale = request.environ.get("HTTP_ACCEPT_LANGUAGE")
@@ -247,7 +247,7 @@ class TasksActionsMappingUnlockAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             mapped_task = MappedTaskDTO(request.get_json())
             mapped_task.user_id = authenticated_user_id
             mapped_task.task_id = task_id
@@ -321,7 +321,7 @@ class TasksActionsMappingUndoAPI(Resource):
         try:
             preferred_locale = request.environ.get("HTTP_ACCEPT_LANGUAGE")
             task = MappingService.undo_mapping(
-                project_id, task_id, tm.authenticated_user_id, preferred_locale
+                project_id, task_id, token_auth.current_user(), preferred_locale
             )
             return task.to_primitive(), 200
         except NotFound:
@@ -394,7 +394,7 @@ class TasksActionsValidationLockAPI(Resource):
         try:
             validator_dto = LockForValidationDTO(request.get_json())
             validator_dto.project_id = project_id
-            validator_dto.user_id = tm.authenticated_user_id
+            validator_dto.user_id = token_auth.current_user()
             validator_dto.preferred_locale = request.environ.get("HTTP_ACCEPT_LANGUAGE")
             validator_dto.validate()
         except DataError as e:
@@ -475,7 +475,7 @@ class TasksActionsValidationStopAPI(Resource):
         try:
             validated_dto = StopValidationDTO(request.get_json())
             validated_dto.project_id = project_id
-            validated_dto.user_id = tm.authenticated_user_id
+            validated_dto.user_id = token_auth.current_user()
             validated_dto.preferred_locale = request.environ.get("HTTP_ACCEPT_LANGUAGE")
             validated_dto.validate()
         except DataError as e:
@@ -552,7 +552,7 @@ class TasksActionsValidationUnlockAPI(Resource):
         try:
             validated_dto = UnlockAfterValidationDTO(request.get_json())
             validated_dto.project_id = project_id
-            validated_dto.user_id = tm.authenticated_user_id
+            validated_dto.user_id = token_auth.current_user()
             validated_dto.preferred_locale = request.environ.get("HTTP_ACCEPT_LANGUAGE")
             validated_dto.validate()
         except DataError as e:
@@ -606,7 +606,7 @@ class TasksActionsMapAllAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             ProjectAdminService.is_user_action_permitted_on_project(
                 authenticated_user_id, project_id
             )
@@ -657,7 +657,7 @@ class TasksActionsValidateAllAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             ProjectAdminService.is_user_action_permitted_on_project(
                 authenticated_user_id, project_id
             )
@@ -708,7 +708,7 @@ class TasksActionsInvalidateAllAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             ProjectAdminService.is_user_action_permitted_on_project(
                 authenticated_user_id, project_id
             )
@@ -759,7 +759,7 @@ class TasksActionsResetBadImageryAllAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             ProjectAdminService.is_user_action_permitted_on_project(
                 authenticated_user_id, project_id
             )
@@ -812,7 +812,7 @@ class TasksActionsResetAllAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             ProjectAdminService.is_user_action_permitted_on_project(
                 authenticated_user_id, project_id
             )
@@ -880,7 +880,7 @@ class TasksActionsSplitAPI(Resource):
         """
         try:
             split_task_dto = SplitTaskDTO()
-            split_task_dto.user_id = tm.authenticated_user_id
+            split_task_dto.user_id = token_auth.current_user()
             split_task_dto.project_id = project_id
             split_task_dto.task_id = task_id
             split_task_dto.preferred_locale = request.environ.get(

--- a/backend/api/tasks/resources.py
+++ b/backend/api/tasks/resources.py
@@ -8,7 +8,7 @@ from schematics.exceptions import DataError
 from backend.services.mapping_service import MappingService, NotFound
 from backend.models.dtos.grid_dto import GridDTO
 
-from backend.services.users.authentication_service import token_auth, tm, verify_token
+from backend.services.users.authentication_service import token_auth, tm
 from backend.services.validator_service import ValidatorService
 
 from backend.services.project_service import ProjectService, ProjectServiceError
@@ -17,6 +17,7 @@ from backend.models.postgis.utils import InvalidGeoJson
 
 
 class TasksRestAPI(Resource):
+    @token_auth.login_required(optional=True)
     def get(self, project_id, task_id):
         """
         Get a task's metadata
@@ -60,13 +61,7 @@ class TasksRestAPI(Resource):
         """
         try:
             preferred_locale = request.environ.get("HTTP_ACCEPT_LANGUAGE")
-            token = request.environ.get("HTTP_AUTHORIZATION")
-
-            # Login isn't required here, but if we have a token we can find out if the user can undo the task
-            if token:
-                verify_token(token[6:])
-
-            user_id = tm.authenticated_user_id
+            user_id = token_auth.current_user()
 
             task = MappingService.get_task_as_dto(
                 task_id, project_id, preferred_locale, user_id

--- a/backend/api/teams/actions.py
+++ b/backend/api/teams/actions.py
@@ -61,8 +61,9 @@ class TeamsActionsJoinAPI(Resource):
             return str(e), 400
 
         try:
-            TeamService.join_team(team_id, tm.authenticated_user_id, username, role)
-            if TeamService.user_is_manager(team_id, tm.authenticated_user_id):
+            authenticated_user_id = tm.authenticated_user_id
+            TeamService.join_team(team_id, authenticated_user_id, username, role)
+            if TeamService.user_is_manager(team_id, authenticated_user_id):
                 return {"Success": "User added to the team"}, 200
             else:
                 return {"Success": "Request to join the team sent successfully."}, 200
@@ -138,10 +139,11 @@ class TeamsActionsJoinAPI(Resource):
             return str(e), 400
 
         try:
+            authenticated_user_id = tm.authenticated_user_id
             if request_type == "join-response":
-                if TeamService.user_is_manager(team_id, tm.authenticated_user_id):
+                if TeamService.user_is_manager(team_id, authenticated_user_id):
                     TeamService.accept_reject_join_request(
-                        team_id, tm.authenticated_user_id, username, role, action
+                        team_id, authenticated_user_id, username, role, action
                     )
                     return {"Success": "True"}, 200
                 else:
@@ -153,7 +155,7 @@ class TeamsActionsJoinAPI(Resource):
                     )
             elif request_type == "invite-response":
                 TeamService.accept_reject_invitation_request(
-                    team_id, tm.authenticated_user_id, username, role, action
+                    team_id, authenticated_user_id, username, role, action
                 )
                 return {"Success": "True"}, 200
         except Exception as e:
@@ -208,10 +210,11 @@ class TeamsActionsLeaveAPI(Resource):
                 description: Internal Server Error
         """
         try:
+            authenticated_user_id = tm.authenticated_user_id
             username = request.get_json(force=True)["username"]
-            request_user = User.get_by_id(tm.authenticated_user_id)
+            request_user = User.get_by_id(authenticated_user_id)
             if (
-                TeamService.user_is_manager(team_id, tm.authenticated_user_id)
+                TeamService.user_is_manager(team_id, authenticated_user_id)
                 or request_user.username == username
             ):
                 TeamService.leave_team(team_id, username)

--- a/backend/api/teams/actions.py
+++ b/backend/api/teams/actions.py
@@ -61,7 +61,7 @@ class TeamsActionsJoinAPI(Resource):
             return str(e), 400
 
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             TeamService.join_team(team_id, authenticated_user_id, username, role)
             if TeamService.user_is_manager(team_id, authenticated_user_id):
                 return {"Success": "User added to the team"}, 200
@@ -139,7 +139,7 @@ class TeamsActionsJoinAPI(Resource):
             return str(e), 400
 
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             if request_type == "join-response":
                 if TeamService.user_is_manager(team_id, authenticated_user_id):
                     TeamService.accept_reject_join_request(
@@ -210,7 +210,7 @@ class TeamsActionsLeaveAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             username = request.get_json(force=True)["username"]
             request_user = User.get_by_id(authenticated_user_id)
             if (

--- a/backend/api/teams/resources.py
+++ b/backend/api/teams/resources.py
@@ -3,7 +3,7 @@ from schematics.exceptions import DataError
 
 from backend.models.dtos.team_dto import TeamDTO, NewTeamDTO, UpdateTeamDTO
 from backend.services.team_service import TeamService, TeamServiceError, NotFound
-from backend.services.users.authentication_service import token_auth, tm
+from backend.services.users.authentication_service import token_auth
 from backend.services.organisation_service import OrganisationService
 from backend.services.users.user_service import UserService
 
@@ -72,7 +72,7 @@ class TeamsRestAPI(Resource):
             team_dto.team_id = team_id
             team_dto.validate()
 
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             team_details_dto = TeamService.get_team_as_dto(
                 team_id, authenticated_user_id
             )
@@ -166,7 +166,7 @@ class TeamsRestAPI(Resource):
             team_dto.team_id = team_id
             team_dto.validate()
 
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             if not TeamService.user_is_manager(
                 team_id, authenticated_user_id
             ) and not OrganisationService.can_user_manage_organisation(
@@ -215,7 +215,7 @@ class TeamsRestAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             if authenticated_user_id is None:
                 user_id = 0
             else:
@@ -265,7 +265,7 @@ class TeamsRestAPI(Resource):
             500:
                 description: Internal Server Error
         """
-        if not TeamService.user_is_manager(team_id, tm.authenticated_user_id):
+        if not TeamService.user_is_manager(team_id, token_auth.current_user()):
             return {"Error": "User is not a manager for the team"}, 401
         try:
             TeamService.delete_team(team_id)
@@ -336,7 +336,7 @@ class TeamsAllAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            user_id = tm.authenticated_user_id
+            user_id = token_auth.current_user()
         except Exception as e:
             error_msg = f"Teams GET - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)
@@ -421,7 +421,7 @@ class TeamsAllAPI(Resource):
             500:
                 description: Internal Server Error
         """
-        user_id = tm.authenticated_user_id
+        user_id = token_auth.current_user()
 
         try:
             team_dto = NewTeamDTO(request.get_json())

--- a/backend/api/teams/resources.py
+++ b/backend/api/teams/resources.py
@@ -72,17 +72,18 @@ class TeamsRestAPI(Resource):
             team_dto.team_id = team_id
             team_dto.validate()
 
+            authenticated_user_id = tm.authenticated_user_id
             team_details_dto = TeamService.get_team_as_dto(
-                team_id, tm.authenticated_user_id
+                team_id, authenticated_user_id
             )
 
             org = TeamService.assert_validate_organisation(team_dto.organisation_id)
             TeamService.assert_validate_members(team_details_dto)
 
             if not TeamService.user_is_manager(
-                team_id, tm.authenticated_user_id
+                team_id, authenticated_user_id
             ) and not OrganisationService.can_user_manage_organisation(
-                org.id, tm.authenticated_user_id
+                org.id, authenticated_user_id
             ):
                 return {"Error": "User is not a admin or a manager for the team"}, 401
         except DataError as e:
@@ -165,10 +166,11 @@ class TeamsRestAPI(Resource):
             team_dto.team_id = team_id
             team_dto.validate()
 
+            authenticated_user_id = tm.authenticated_user_id
             if not TeamService.user_is_manager(
-                team_id, tm.authenticated_user_id
+                team_id, authenticated_user_id
             ) and not OrganisationService.can_user_manage_organisation(
-                team.organisation_id, tm.authenticated_user_id
+                team.organisation_id, authenticated_user_id
             ):
                 return {"Error": "User is not a admin or a manager for the team"}, 401
         except DataError as e:
@@ -213,10 +215,11 @@ class TeamsRestAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            if tm.authenticated_user_id is None:
+            authenticated_user_id = tm.authenticated_user_id
+            if authenticated_user_id is None:
                 user_id = 0
             else:
-                user_id = tm.authenticated_user_id
+                user_id = authenticated_user_id
             team_dto = TeamService.get_team_as_dto(team_id, user_id)
             return team_dto.to_primitive(), 200
         except NotFound:

--- a/backend/api/users/actions.py
+++ b/backend/api/users/actions.py
@@ -77,7 +77,7 @@ class UsersActionsSetUsersAPI(Resource):
                 )
 
             user_dto.validate()
-            authenticated_user_id = tm.authenticated_user_id
+            authenticated_user_id = token_auth.current_user()
             if authenticated_user_id != user_dto.id:
                 return {"Error": "Unable to authenticate"}, 401
         except ValueError as e:
@@ -197,7 +197,7 @@ class UsersActionsSetRoleAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            UserService.add_role_to_user(tm.authenticated_user_id, username, role)
+            UserService.add_role_to_user(token_auth.current_user(), username, role)
             return {"Success": "Role Added"}, 200
         except UserServiceError:
             return {"Error": "Not allowed"}, 403
@@ -246,7 +246,7 @@ class UsersActionsSetExpertModeAPI(Resource):
         """
         try:
             UserService.set_user_is_expert(
-                tm.authenticated_user_id, is_expert == "true"
+                token_auth.current_user(), is_expert == "true"
             )
             return {"Success": "Expert mode updated"}, 200
         except UserServiceError:
@@ -284,7 +284,7 @@ class UsersActionsVerifyEmailAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            MessageService.resend_email_validation(tm.authenticated_user_id)
+            MessageService.resend_email_validation(token_auth.current_user())
             return {"Success": "Verification email resent"}, 200
         except Exception as e:
             error_msg = f"User GET - unhandled error: {str(e)}"
@@ -389,7 +389,7 @@ class UsersActionsSetInterestsAPI(Resource):
         try:
             data = request.get_json()
             user_interests = InterestService.create_or_update_user_interests(
-                tm.authenticated_user_id, data["interests"]
+                token_auth.current_user(), data["interests"]
             )
             return user_interests.to_primitive(), 200
         except ValueError as e:

--- a/backend/api/users/actions.py
+++ b/backend/api/users/actions.py
@@ -77,8 +77,8 @@ class UsersActionsSetUsersAPI(Resource):
                 )
 
             user_dto.validate()
-
-            if tm.authenticated_user_id != user_dto.id:
+            authenticated_user_id = tm.authenticated_user_id
+            if authenticated_user_id != user_dto.id:
                 return {"Error": "Unable to authenticate"}, 401
         except ValueError as e:
             return {"Error": str(e)}, 400
@@ -88,7 +88,7 @@ class UsersActionsSetUsersAPI(Resource):
 
         try:
             verification_sent = UserService.update_user_details(
-                tm.authenticated_user_id, user_dto
+                authenticated_user_id, user_dto
             )
             return verification_sent, 200
         except NotFound:

--- a/backend/api/users/resources.py
+++ b/backend/api/users/resources.py
@@ -2,7 +2,7 @@ from flask_restful import Resource, current_app, request
 from schematics.exceptions import DataError
 
 from backend.models.dtos.user_dto import UserSearchQuery
-from backend.services.users.authentication_service import token_auth, tm
+from backend.services.users.authentication_service import token_auth
 from backend.services.users.user_service import UserService, NotFound
 from backend.services.project_service import ProjectService
 
@@ -149,7 +149,7 @@ class UsersQueriesUsernameAPI(Resource):
         """
         try:
             user_dto = UserService.get_user_dto_by_username(
-                username, tm.authenticated_user_id
+                username, token_auth.current_user()
             )
             return user_dto.to_primitive(), 200
         except NotFound:
@@ -242,7 +242,7 @@ class UsersQueriesOwnLockedAPI(Resource):
         """
         try:
             locked_tasks = ProjectService.get_task_for_logged_in_user(
-                tm.authenticated_user_id
+                token_auth.current_user()
             )
             return locked_tasks.to_primitive(), 200
         except Exception as e:
@@ -287,7 +287,7 @@ class UsersQueriesOwnLockedDetailsAPI(Resource):
         try:
             preferred_locale = request.environ.get("HTTP_ACCEPT_LANGUAGE")
             locked_tasks = ProjectService.get_task_details_for_logged_in_user(
-                tm.authenticated_user_id, preferred_locale
+                token_auth.current_user(), preferred_locale
             )
             return locked_tasks.to_primitive(), 200
         except NotFound:
@@ -324,7 +324,7 @@ class UsersQueriesFavoritesAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            favs_dto = UserService.get_projects_favorited(tm.authenticated_user_id)
+            favs_dto = UserService.get_projects_favorited(token_auth.current_user())
             return favs_dto.to_primitive(), 200
         except NotFound:
             return {"Error": "User not found"}, 404

--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -1023,6 +1023,7 @@ class Project(db.Model):
             is_allowed_user = False
             if authenticated_user_id:
                 user = User.get_by_id(authenticated_user_id)
+
                 if (
                     UserRole(user.role) == UserRole.ADMIN
                     or authenticated_user_id == self.author_id

--- a/backend/services/users/authentication_service.py
+++ b/backend/services/users/authentication_service.py
@@ -37,9 +37,7 @@ def verify_token(token):
     tm.authenticated_user_id = (
         user_id  # Set the user ID on the decorator as a convenience
     )
-    return UserService.get_user_by_id(
-        user_id
-    ).id  # All tests passed token is good for the requested resource
+    return user_id  # All tests passed token is good for the requested resource
 
 
 class AuthServiceError(Exception):

--- a/backend/services/users/authentication_service.py
+++ b/backend/services/users/authentication_service.py
@@ -37,7 +37,9 @@ def verify_token(token):
     tm.authenticated_user_id = (
         user_id  # Set the user ID on the decorator as a convenience
     )
-    return True  # All tests passed token is good for the requested resource
+    return UserService.get_user_by_id(
+        user_id
+    ).id  # All tests passed token is good for the requested resource
 
 
 class AuthServiceError(Exception):


### PR DESCRIPTION
In line with #2894,

* updated the project api resources file to fetch authenticated_user_id into a var, rather than calling the TMDecorator Object everytime we need user id
* Within the permissions check method, change the checking order. Now we check for all the four types of permissions - is_admin, is_author, is_team_manager, is_org_manager. Instead get on team and org manager check only if the user is not an admin or author. Here we save some repeated querying and make the process faster