### PR TITLE
Enable file compression in Cloudfront Behavior

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -669,6 +669,7 @@ const Resources = {
             },
             Headers: ['Accept', 'Referer']
           },
+          Compress: true,
           TargetOriginId: cf.join('-', [cf.stackName, 'react-app']),
           ViewerProtocolPolicy: "redirect-to-https"
         },


### PR DESCRIPTION
According to https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html this will compress javascript files so long as the viewer request header contains `Accept-Encoding: gzip` and the following factors are true:
- The file must be of a type that CloudFront compresses.
- The file size must be between 1,000 and 10,000,000 bytes.
- The response must include a `Content-Length` header so CloudFront can determine whether the size of the file is in the range that CloudFront compresses. If the `Content-Length` header is missing, CloudFront won't compress the file.
- The response must not include a `Content-Encoding` header.

