### PR TITLE
Modify query to remove timestamps from simultaneously locked validation tasks

### DIFF
--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -590,9 +590,24 @@ class Project(db.Model):
                 stats_dto.time_spent_mapping = total_mapping_time.total_seconds()
                 stats_dto.total_time_spent += stats_dto.time_spent_mapping
 
-        query = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-                   WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION')
-                   and user_id = :user_id and project_id = :project_id;"""
+        query = """with query as (select
+                                   id,
+                                   user_id,
+                                   action,
+                                   action_text,
+                                   (TO_TIMESTAMP(action_text, 'HH24:MI:SS')::time) -
+                                    lag(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::time)
+                                    over (order by id) as time_difference,
+                                    user_id - lag(user_id)
+                                    over (order by id) as user_id_difference,
+                                    id - lag (id)
+                                    over (order by id) as incidence_difference
+                                    from task_history
+                                    WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION')
+                                    and user_id = :user_id and project_id = :project_id)
+                   select SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) from query
+                   where not (time_difference = '00:00:00' and user_id_difference = 0 and incidence_difference = 1);
+                   """
         total_validation_time = db.engine.execute(
             text(query), user_id=user_id, project_id=self.id
         )
@@ -680,9 +695,6 @@ class Project(db.Model):
                     average_mapping_time = total_mapping_seconds / unique_mappers
                     project_stats.average_mapping_time = average_mapping_time
 
-        # query = """SELECT SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) FROM task_history
-        #            WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION')
-        #            and project_id = :project_id;"""
         query = """with query as (select
                                    id,
                                    user_id,

--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -8,7 +8,7 @@ from flask import current_app
 from geoalchemy2 import Geometry
 import sqlalchemy
 from sqlalchemy.sql.expression import cast
-from sqlalchemy import text, desc, func
+from sqlalchemy import text, desc, func, Time
 from shapely.geometry import shape
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm.session import make_transient
@@ -590,27 +590,21 @@ class Project(db.Model):
                 stats_dto.time_spent_mapping = total_mapping_time.total_seconds()
                 stats_dto.total_time_spent += stats_dto.time_spent_mapping
 
-        query = """with query as (select
-                                   id,
-                                   user_id,
-                                   action,
-                                   action_text,
-                                   (TO_TIMESTAMP(action_text, 'HH24:MI:SS')::time) -
-                                    lag(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::time)
-                                    over (order by id) as time_difference,
-                                    user_id - lag(user_id)
-                                    over (order by id) as user_id_difference,
-                                    id - lag (id)
-                                    over (order by id) as incidence_difference
-                                    from task_history
-                                    WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION')
-                                    and user_id = :user_id and project_id = :project_id)
-                   select SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) from query
-                   where not (time_difference = '00:00:00' and user_id_difference = 0 and incidence_difference = 1);
-                   """
-        total_validation_time = db.engine.execute(
-            text(query), user_id=user_id, project_id=self.id
+        query = (
+            TaskHistory.query.with_entities(
+                func.date_trunc("minute", TaskHistory.action_date).label("trn"),
+                func.max(TaskHistory.action_text).label("tm"),
+            )
+            .filter(TaskHistory.user_id == user_id)
+            .filter(TaskHistory.project_id == self.id)
+            .filter(TaskHistory.action == "LOCKED_FOR_VALIDATION")
+            .group_by("trn")
+            .subquery()
         )
+        total_validation_time = db.session.query(
+            func.sum(cast(func.to_timestamp(query.c.tm, "HH24:MI:SS"), Time))
+        ).all()
+
         for time in total_validation_time:
             total_validation_time = time[0]
             if total_validation_time:
@@ -695,25 +689,20 @@ class Project(db.Model):
                     average_mapping_time = total_mapping_seconds / unique_mappers
                     project_stats.average_mapping_time = average_mapping_time
 
-        query = """with query as (select
-                                   id,
-                                   user_id,
-                                   action,
-                                   action_text,
-                                   (TO_TIMESTAMP(action_text, 'HH24:MI:SS')::time) -
-                                    lag(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::time)
-                                    over (order by id) as time_difference,
-                                    user_id - lag(user_id)
-                                    over (order by id) as user_id_difference,
-                                    id - lag (id)
-                                    over (order by id) as incidence_difference
-                                    from task_history
-                                    WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION')
-                                    and project_id = :project_id)
-                   select SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) from query
-                   where not (time_difference = '00:00:00' and user_id_difference = 0 and incidence_difference = 1);"""
+        query = (
+            TaskHistory.query.with_entities(
+                func.date_trunc("minute", TaskHistory.action_date).label("trn"),
+                func.max(TaskHistory.action_text).label("tm"),
+            )
+            .filter(TaskHistory.project_id == self.id)
+            .filter(TaskHistory.action == "LOCKED_FOR_VALIDATION")
+            .group_by("trn")
+            .subquery()
+        )
+        total_validation_time = db.session.query(
+            func.sum(cast(func.to_timestamp(query.c.tm, "HH24:MI:SS"), Time))
+        ).all()
 
-        total_validation_time = db.engine.execute(text(query), project_id=self.id)
         for row in total_validation_time:
             total_validation_time = row[0]
             if total_validation_time:

--- a/backend/services/users/user_service.py
+++ b/backend/services/users/user_service.py
@@ -1,7 +1,7 @@
 from cachetools import TTLCache, cached
 from flask import current_app
 import datetime
-from sqlalchemy import text, func, or_, desc, and_, distinct
+from sqlalchemy import text, func, or_, desc, and_, distinct, cast, Time
 from backend import db
 from backend.models.dtos.project_dto import ProjectFavoritesDTO, ProjectSearchResultsDTO
 from backend.models.dtos.user_dto import (
@@ -315,25 +315,20 @@ class UserService:
         stats_dto.time_spent_mapping = 0
         stats_dto.time_spent_validating = 0
 
-        sql = """with query as (select
-                                   id,
-                                   user_id,
-                                   action,
-                                   action_text,
-                                   (TO_TIMESTAMP(action_text, 'HH24:MI:SS')::time) -
-                                    lag(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::time)
-                                    over (order by id) as time_difference,
-                                    user_id - lag(user_id)
-                                    over (order by id) as user_id_difference,
-                                    id - lag (id)
-                                    over (order by id) as incidence_difference
-                                    from task_history
-                                    WHERE (action='LOCKED_FOR_VALIDATION' or action='AUTO_UNLOCKED_FOR_VALIDATION')
-                                    and user_id = :user_id)
-                   select SUM(TO_TIMESTAMP(action_text, 'HH24:MI:SS')::TIME) from query
-                   where not (time_difference = '00:00:00' and user_id_difference = 0 and incidence_difference = 1);
-                   """
-        total_validation_time = db.engine.execute(text(sql), user_id=user.id)
+        query = (
+            TaskHistory.query.with_entities(
+                func.date_trunc("minute", TaskHistory.action_date).label("trn"),
+                func.max(TaskHistory.action_text).label("tm"),
+            )
+            .filter(TaskHistory.user_id == user.id)
+            .filter(TaskHistory.action == "LOCKED_FOR_VALIDATION")
+            .group_by("trn")
+            .subquery()
+        )
+        total_validation_time = db.session.query(
+            func.sum(cast(func.to_timestamp(query.c.tm, "HH24:MI:SS"), Time))
+        ).all()
+
         for time in total_validation_time:
             total_validation_time = time[0]
             if total_validation_time:


### PR DESCRIPTION
From #2824 - 

updated the query for 
* project stats section
* user stats
* user stats for each project

Sample from project stats endpoint:

With timestamps from simultaneously locked tasks | after the query update to remove timestamps from tasks locked together
----------------------------------------------------|--------------------------------------------------------------------------
totalValidationTime: 463873 </br> totalTimeSpent:965400 </br> averageMappingTime: 524 </br> averageValidationTime: 2712 </br>| totalValidationTime: 425268 </br>totalTimeSpent: 926795 </br>averageMappingTime: 524 </br> averageValidationTime: 2486
  