### PR TITLE
Validate mapbox token on basemap change in project creation

### DIFF
--- a/frontend/src/components/projectCreate/projectCreationMap.js
+++ b/frontend/src/components/projectCreate/projectCreationMap.js
@@ -87,6 +87,9 @@ const ProjectCreationMap = ({ mapObj, setMapObj, metadata, updateMetadata, step 
       });
 
       mapObj.map.on('style.load', event => {
+        if (!MAPBOX_TOKEN) {
+          return;
+        }
         const features = mapObj.draw.getAll();
         if (features.features.length === 0) {
           addLayer('aoi', metadata.geom, mapObj.map);


### PR DESCRIPTION
This avoid frontend crash when a mapbox token is not provided.