### PR TITLE
Fix some floating point comparisons to be less brittle

### DIFF
--- a/tests/backend/integration/services/test_project_search_service.py
+++ b/tests/backend/integration/services/test_project_search_service.py
@@ -122,7 +122,8 @@ class TestProjectSearchService(unittest.TestCase):
         )
 
         # assert
-        self.assertEqual(expected, polygon.bounds)
+        for expected_val, actual_val in zip(expected, polygon.bounds):
+            self.assertAlmostEqual(expected_val, actual_val, places=10)
 
     def test_get_area_from_3857_bbox(self):
 
@@ -147,4 +148,4 @@ class TestProjectSearchService(unittest.TestCase):
         expected = ProjectSearchService._get_area_sqm(polygon)
 
         # assert
-        self.assertEqual(expected, 28276407740.2797)
+        self.assertAlmostEqual(expected, 28276407740.2797, places=3)


### PR DESCRIPTION
Trying to make the test less brittle across Linux platforms by using `assertAlmostEqual` for floating point comparisons to prevent failures like this:

```
======================================================================
FAIL: test_get_area_from_3857_bbox (tests.backend.integration.services.test_project_search_service.TestProjectSearchService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/src/tasking-manager/tests/backend/integration/services/test_project_search_service.py", line 150, in test_get_area_from_3857_bbox
    self.assertEqual(expected, 28276407740.2797)
AssertionError: 28276407740.2798 != 28276407740.2797

======================================================================
FAIL: test_make_polygon_from_3857_bbox (tests.backend.integration.services.test_project_search_service.TestProjectSearchService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/src/tasking-manager/tests/backend/integration/services/test_project_search_service.py", line 125, in test_make_polygon_from_3857_bbox
    self.assertEqual(expected, polygon.bounds)
AssertionError: Tuples differ: (32.50198296132938, -12.59912449955007, 34.68826225820438, -11.578583176891955) != (32.50198296132938, -12.599124499550062, 34.68826225820438, -11.57858317689196)

First differing element 1:
-12.59912449955007
-12.599124499550062

- (32.50198296132938, -12.59912449955007, 34.68826225820438, -11.578583176891955)
?                                      ^                                      ^^

+ (32.50198296132938, -12.599124499550062, 34.68826225820438, -11.57858317689196)
?                                      ^^                                      ^
```