### PR TITLE
update iD editor and fix problems with comments and imagery

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "@formatjs/intl-relativetimeformat": "^4.5.14",
     "@formatjs/intl-utils": "^2.2.4",
     "@formatjs/macro": "^0.2.6",
-    "@hotosm/id": "^2.17.3-beta-5",
+    "@hotosm/id": "2.18.0-beta-1",
     "@hotosm/iso-countries-languages": "^0.3.1",
     "@lokibai/react-use-copy-clipboard": "^1.0.4",
     "@mapbox/geo-viewport": "^0.4.0",

--- a/frontend/src/components/editor.js
+++ b/frontend/src/components/editor.js
@@ -5,7 +5,7 @@ import '@hotosm/id/dist/iD.css';
 
 import { OSM_CONSUMER_KEY, OSM_CONSUMER_SECRET } from '../config';
 
-export default function Editor({ editorRef, setEditorRef, setDisable }) {
+export default function Editor({ editorRef, setEditorRef, setDisable, comment }) {
   const session = useSelector((state) => state.auth.get('session'));
   const windowInit = typeof window !== undefined;
 
@@ -18,6 +18,12 @@ export default function Editor({ editorRef, setEditorRef, setDisable }) {
       setEditorRef(window.iD.coreContext());
     }
   }, [windowInit, setEditorRef, editorRef]);
+
+  useEffect(() => {
+    if (editorRef && comment) {
+      editorRef.defaultChangesetComment(comment);
+    }
+  }, [comment, editorRef]);
 
   useEffect(() => {
     if (session && iD && editorRef) {

--- a/frontend/src/utils/openEditor.js
+++ b/frontend/src/utils/openEditor.js
@@ -81,7 +81,7 @@ export function getIdUrl(project, centroid, zoomLevel, selectedTasks, locale = '
   if (project.changesetComment) {
     url += '&comment=' + encodeURIComponent(project.changesetComment);
   }
-  if (project.imagery) {
+  if (project.imagery && project.imagery.includes('http')) {
     // url is supposed to look like tms[22]:http://hiu...
     let urlForImagery = project.imagery.substring(project.imagery.indexOf('http'));
     urlForImagery = urlForImagery.replace('zoom', 'z');
@@ -126,7 +126,7 @@ function loadTasksBoundaries(project, selectedTasks) {
 }
 
 function loadImageryonJosm(project) {
-  if (project.imagery) {
+  if (project.imagery && project.imagery.includes('http')) {
     const imageryParams = {
       title: project.imagery,
       type: project.imagery.toLowerCase().substring(0, 3),

--- a/frontend/src/utils/tests/openEditor.test.js
+++ b/frontend/src/utils/tests/openEditor.test.js
@@ -59,6 +59,21 @@ describe('test if getIdUrl', () => {
         '&locale=en',
     );
   });
+
+  it('with a imagery that is not a URL and with multiple tasks returns the correct url', () => {
+    const testProject = {
+      changesetComment: '#hotosm-project-5522',
+      projectId: 1234,
+      imagery: 'Bing',
+    };
+    expect(getIdUrl(testProject, [120.25684, -9.663953], 18, [1, 2])).toBe(
+      'https://www.openstreetmap.org/edit?editor=id&' +
+        '#map=18/-9.663953/120.25684' +
+        '&comment=%23hotosm-project-5522' +
+        '&gpx=http%3A%2F%2F127.0.0.1%3A5000%2Fapi%2Fv2%2Fprojects%2F1234%2Ftasks%2Fqueries%2Fgpx%2F%3Ftasks%3D1%2C2' +
+        '&locale=en',
+    );
+  });
 });
 
 it('test if formatCustomUrl returns the url with question mark', () => {


### PR DESCRIPTION
- Update iD editor to 2.18.0-beta-1
- Fix problem with changesetComment (Resolves #2650 )
- Only load imagery on iD and JOSM if `project.imagery` contains 'http'
