### PR TITLE
Search projects without tables union for correct sorting

### DIFF
--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -35,7 +35,6 @@ from backend.models.postgis.utils import (
 )
 from backend.models.postgis.interests import project_interests
 from backend.services.users.user_service import UserService
-from backend.services.organisation_service import OrganisationService
 
 
 search_cache = TTLCache(maxsize=128, ttl=300)
@@ -91,9 +90,15 @@ class ProjectSearchService:
         if user is None:
             query = query.filter(Project.private.is_(False))
 
-        # Get also private projects of teams that the user is member.
         if user is not None and user.role != UserRole.ADMIN.value:
+            # Get also private projects of teams that the user is member.
             project_ids = [[p.project_id for p in t.team.projects] for t in user.teams]
+
+            # Get projects that belong to user organizations.
+            orgs_projects_ids = [[p.id for p in u.projects] for u in user.organisations]
+
+            project_ids.extend(orgs_projects_ids)
+
             project_ids = tuple(
                 set([item for sublist in project_ids for item in sublist])
             )
@@ -296,16 +301,27 @@ class ProjectSearchService:
         query = query.order_by(order_by).group_by(Project.id)
 
         if search_dto.managed_by and user.role != UserRole.ADMIN.value:
-            team_projects = query.join(ProjectTeams).filter(
-                ProjectTeams.role == TeamRoles.PROJECT_MANAGER.value,
-                ProjectTeams.project_id == Project.id,
-            )
-            user_orgs_list = OrganisationService.get_organisations_managed_by_user(
-                search_dto.managed_by
-            )
-            orgs_managed = [org.id for org in user_orgs_list]
-            org_projects = query.filter(Project.organisation_id.in_(orgs_managed))
-            query = org_projects.union(team_projects)
+            # Get all the projects associated with the user and team.
+            orgs_projects_ids = [[p.id for p in u.projects] for u in user.organisations]
+            orgs_projects_ids = [
+                item for sublist in orgs_projects_ids for item in sublist
+            ]
+
+            team_project_ids = [
+                [
+                    p.project_id
+                    for p in u.team.projects
+                    if p.role == TeamRoles.PROJECT_MANAGER.value
+                ]
+                for u in user.teams
+            ]
+            team_project_ids = [
+                item for sublist in team_project_ids for item in sublist
+            ]
+
+            orgs_projects_ids.extend(team_project_ids)
+            ids = tuple(set(orgs_projects_ids))
+            query = query.filter(Project.id.in_(ids))
 
         all_results = []
         if not search_dto.omit_map_results:


### PR DESCRIPTION
closes #2869 .

Search for projects based on user organization moved to global search and removed union query. This fixes the bug related to sorting.