### PR TITLE
move frontend build to the end of frontend tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,6 @@ jobs:
           cd ${CIRCLE_WORKING_DIRECTORY}/frontend
           yarn
           npm rebuild node-sass
-          yarn build
           cd ${CIRCLE_WORKING_DIRECTORY}
           # Install Python dependencies
           pip install virtualenv
@@ -52,6 +51,7 @@ jobs:
           # JS Unit Tests
           cd ${CIRCLE_WORKING_DIRECTORY}/frontend
           CI=true yarn test -w 1 --env=jsdom
+          yarn build
     - run:
         name: Run backend tests
         command: |


### PR DESCRIPTION
As the build is the step that takes more time, I moved it to after the frontend tests, so we can have a failing test result faster.