### PR TITLE
Add Name tag to EC2 instances

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -139,7 +139,12 @@ const Resources = {
       LaunchConfigurationName: cf.ref('TaskingManagerLaunchConfiguration'),
       TargetGroupARNs: [ cf.ref('TaskingManagerTargetGroup') ],
       HealthCheckType: 'EC2',
-      AvailabilityZones: ['us-east-1a', 'us-east-1b', 'us-east-1c', 'us-east-1d', 'us-east-1f']
+      AvailabilityZones: ['us-east-1a', 'us-east-1b', 'us-east-1c', 'us-east-1d', 'us-east-1f'],
+      Tags: [{
+        Key: 'Name',
+        PropagateAtLaunch: true,
+        Value: cf.stackName
+      }]
     },
     UpdatePolicy: {
       AutoScalingRollingUpdate: {


### PR DESCRIPTION
Closes #1454 

Adds a tag to the autoscaling group to propagate the stack name to the EC2 instance name. 