### PR TITLE
add 'Managed by Me' filter on My Projects page

### DIFF
--- a/frontend/src/components/projects/myProjectNav.js
+++ b/frontend/src/components/projects/myProjectNav.js
@@ -106,6 +106,19 @@ export const MyProjectNav = (props) => {
             >
               <FormattedMessage {...messages.favorited} />
             </FilterButton>
+            <FilterButton
+              query={fullProjectsQuery}
+              newQueryParams={{
+                favoritedByMe: undefined,
+                mappedByMe: undefined,
+                managedByMe: 1,
+                status: 'PUBLISHED',
+              }}
+              setQuery={setQuery}
+              isActive={isActiveButton('managedByMe', fullProjectsQuery)}
+            >
+              <FormattedMessage {...messages.managed} />
+            </FilterButton>
           </>
         )}
         {props.management && (userDetails.role === 'ADMIN' || isOrgManager) && (


### PR DESCRIPTION
Resolves #2923, but depends on an improvement on `managedByMe` filters to be merged. That filter should include the projects a user created, even if it's not assigned to their organizations and PM teams.