### PR TITLE
Fix indentation in circleci YAML config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -424,10 +424,10 @@ workflows:
   build-deploy:
     jobs:
     - build:
-      filters:
-        branches:
-          ignore:
-          - /^deployment\/.*/
+        filters:
+          branches:
+            ignore:
+            - /^deployment\/.*/
     - backend_deploy:
         name: staging
         filters:


### PR DESCRIPTION
fix indentation in YAML config for circleci to get filters working
 properly.