### PR TITLE
change order of task action evaluation

### DIFF
--- a/frontend/src/components/taskSelection/footer.js
+++ b/frontend/src/components/taskSelection/footer.js
@@ -52,7 +52,15 @@ const TaskSelectionFooter = (props) => {
     dispatch({ type: 'SET_PROJECT', project: project });
     dispatch({ type: 'SET_TASKS_STATUS', status: status });
   };
+
   const lockTasks = async () => {
+    // if user can not map or validate the project, lead him to the explore projects page
+    if (
+      ['selectAnotherProject', 'mappingIsComplete', 'projectIsComplete'].includes(props.taskAction)
+    ) {
+      navigate(`/explore/`);
+    }
+    // then pass to the JOSM check and validate/map checks
     if (editor === 'JOSM' && !window.safari) {
       try {
         await fetch(formatJosmUrl('version', { jsonp: 'checkJOSM' }));
@@ -104,12 +112,6 @@ const TaskSelectionFooter = (props) => {
       );
       const endpoint = props.taskAction === 'resumeMapping' ? 'map' : 'validate';
       navigate(`/projects/${props.project.projectId}/${endpoint}/${urlParams}`);
-    }
-    // if user can not map or validate the project, lead him to the explore projects page
-    if (
-      ['selectAnotherProject', 'mappingIsComplete', 'projectIsComplete'].includes(props.taskAction)
-    ) {
-      navigate(`/explore/`);
     }
   };
 


### PR DESCRIPTION
In https://tasks-stage.hotosm.org/projects/6489/ the "Select another project" button isn't redirecting. It happens because JOSM is the only editor possible and it's checking if JOSM is open instead of redirecting. This PR fixes it.