### PR TITLE
Include abbreviated response for teams and orgs endpoints

### DIFF
--- a/backend/api/organisations/resources.py
+++ b/backend/api/organisations/resources.py
@@ -165,9 +165,9 @@ class OrganisationsRestAPI(Resource):
               type: integer
               default: 1
             - in: query
-              name: abbreviated
+              name: omitManagerList
               type: boolean
-              description: Set to true if members are not needed.
+              description: Set it to true if you don't want the managers list on the response.
               default: False
         responses:
             200:
@@ -186,9 +186,9 @@ class OrganisationsRestAPI(Resource):
             else:
                 user_id = authenticated_user_id
             # Validate abbreviated.
-            abbreviated = strtobool(request.args.get("abbreviated", "false"))
+            omit_managers = strtobool(request.args.get("omitManagerList", "false"))
             organisation_dto = OrganisationService.get_organisation_by_id_as_dto(
-                organisation_id, user_id, abbreviated
+                organisation_id, user_id, omit_managers
             )
             return organisation_dto.to_primitive(), 200
         except NotFound:
@@ -304,7 +304,7 @@ class OrganisationsAllAPI(Resource):
             - in: query
               name: omitManagerList
               type: boolean
-              description: Set to true if members are not needed.
+              description: Set it to true if you don't want the managers list on the response.
               default: False
         responses:
             200:

--- a/backend/api/teams/resources.py
+++ b/backend/api/teams/resources.py
@@ -206,9 +206,9 @@ class TeamsRestAPI(Resource):
               type: integer
               default: 1
             - in: query
-              name: abbreviated
+              name: omitMemberList
               type: boolean
-              description: Set to true if only state information is desired
+              description: Set it to true if you don't want the members list on the response.
               default: False
         responses:
             200:
@@ -222,12 +222,12 @@ class TeamsRestAPI(Resource):
         """
         try:
             authenticated_user_id = token_auth.current_user()
-            abbreviated = strtobool(request.args.get("abbreviated", "false"))
+            omit_members = strtobool(request.args.get("omitMemberList", "false"))
             if authenticated_user_id is None:
                 user_id = 0
             else:
                 user_id = authenticated_user_id
-            team_dto = TeamService.get_team_as_dto(team_id, user_id, abbreviated)
+            team_dto = TeamService.get_team_as_dto(team_id, user_id, omit_members)
             return team_dto.to_primitive(), 200
         except NotFound:
             return {"Error": "Team Not Found"}, 404
@@ -335,7 +335,7 @@ class TeamsAllAPI(Resource):
             - in: query
               name: omitMemberList
               type: boolean
-              description: Set to true if only state information is desired
+              description: Set it to true if you don't want the members list on the response.
               default: False
         responses:
             201:

--- a/backend/models/dtos/organisation_dto.py
+++ b/backend/models/dtos/organisation_dto.py
@@ -36,7 +36,7 @@ class OrganisationDTO(Model):
     logo = StringType()
     url = StringType()
     is_manager = BooleanType(serialized_name="isManager")
-    projects = ListType(StringType)
+    projects = ListType(StringType, serialize_when_none=False)
     teams = ListType(ModelType(OrganisationTeamsDTO))
     campaigns = ListType(ListType(StringType))
 

--- a/backend/models/postgis/organisation.py
+++ b/backend/models/postgis/organisation.py
@@ -154,7 +154,7 @@ class Organisation(db.Model):
         )
         return query_results
 
-    def as_dto(self):
+    def as_dto(self, omit_managers):
         """ Returns a dto for an organisation """
         organisation_dto = OrganisationDTO()
         organisation_dto.organisation_id = self.id
@@ -162,6 +162,10 @@ class Organisation(db.Model):
         organisation_dto.logo = self.logo
         organisation_dto.url = self.url
         organisation_dto.managers = []
+
+        if omit_managers:
+            return organisation_dto
+
         for manager in self.managers:
             org_manager_dto = OrganisationManagerDTO()
             org_manager_dto.username = manager.username

--- a/backend/services/team_service.py
+++ b/backend/services/team_service.py
@@ -184,6 +184,7 @@ class TeamService:
         member_request_filter: int = None,
         manager_filter: int = None,
         organisation_filter: int = None,
+        omit_members: bool = False,
     ) -> TeamsListDTO:
 
         query = db.session.query(Team).outerjoin(TeamMembers).outerjoin(ProjectTeams)
@@ -251,6 +252,9 @@ class TeamService:
             is_team_manager = False
             is_team_member = False
             for member in team_members:
+                # Skip if members are not included.
+                if omit_members:
+                    continue
                 user = UserService.get_user_by_id(member.user_id)
                 member_dto = TeamMembersDTO()
                 member_dto.username = user.username
@@ -272,7 +276,7 @@ class TeamService:
         return teams_list_dto
 
     @staticmethod
-    def get_team_as_dto(team_id: int, user_id: int) -> TeamDTO:
+    def get_team_as_dto(team_id: int, user_id: int, abbreviated: bool) -> TeamDTO:
         team = TeamService.get_team_by_id(team_id)
 
         if team is None:
@@ -299,6 +303,9 @@ class TeamService:
         else:
             team_dto.is_general_admin = False
             team_dto.is_org_admin = False
+
+        if abbreviated:
+            return team_dto
 
         team_members = TeamService._get_team_members(team_id)
         for member in team_members:

--- a/frontend/src/components/formInputs.js
+++ b/frontend/src/components/formInputs.js
@@ -45,8 +45,8 @@ export function OrganisationSelect({ className }: Object) {
 
   useEffect(() => {
     if (token && userDetails && userDetails.id) {
-      const query = userDetails.role === 'ADMIN' ? '' : `?manager_user_id=${userDetails.id}`;
-      fetchLocalJSONAPI(`organisations/${query}`, token)
+      const query = userDetails.role === 'ADMIN' ? '' : `&manager_user_id=${userDetails.id}`;
+      fetchLocalJSONAPI(`organisations/?omitManagerList=true${query}`, token)
         .then((result) => setOrganisations(result.organisations))
         .catch((e) => console.log(e));
     }

--- a/frontend/src/components/projectEdit/metadataForm.js
+++ b/frontend/src/components/projectEdit/metadataForm.js
@@ -18,8 +18,8 @@ export const MetadataForm = () => {
 
   useEffect(() => {
     if (userDetails && userDetails.id) {
-      const query = userDetails.role === 'ADMIN' ? '' : `?manager_user_id=${userDetails.id}`;
-      fetchLocalJSONAPI(`organisations/${query}`, token)
+      const query = userDetails.role === 'ADMIN' ? '' : `&manager_user_id=${userDetails.id}`;
+      fetchLocalJSONAPI(`organisations/?omitManagerList=true${query}`, token)
         .then((result) => setOrganisations(result.organisations))
         .catch((e) => console.log(e));
     }

--- a/frontend/src/components/projectEdit/teamSelect.js
+++ b/frontend/src/components/projectEdit/teamSelect.js
@@ -24,8 +24,10 @@ export const TeamSelect = () => {
   const [org, setOrg] = useState(null);
 
   useEffect(() => {
-    fetchLocalJSONAPI('organisations/', token).then((r) => setOrgs(r.organisations));
-    fetchLocalJSONAPI('teams/', token).then((t) => setTeams(t.teams));
+    fetchLocalJSONAPI('organisations/?omitManagerList=true', token).then((r) =>
+      setOrgs(r.organisations),
+    );
+    fetchLocalJSONAPI('teams/?omitMemberList=true', token).then((t) => setTeams(t.teams));
   }, [token]);
 
   const teamRoles = [

--- a/frontend/src/components/projects/myProjectNav.js
+++ b/frontend/src/components/projects/myProjectNav.js
@@ -166,7 +166,9 @@ function ManagerFilters({ query, setQuery }: Object) {
   const userDetails = useSelector((state) => state.auth.get('userDetails'));
   const [campaignsError, campaignsLoading, campaigns] = useFetch('campaigns/');
   const [orgsError, orgsLoading, organisations] = useFetch(
-    `organisations/${userDetails.role === 'ADMIN' ? '' : `?manager_user_id=${userDetails.id}`}`,
+    `organisations/?omitManagerList=true${
+      userDetails.role === 'ADMIN' ? '' : `&manager_user_id=${userDetails.id}`
+    }`,
     userDetails && userDetails.id,
   );
   const { campaign: campaignInQuery, organisation: orgInQuery } = query;

--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -65,7 +65,7 @@ export function TaskSelection({ project, type, loading }: Object) {
 
   // get teams the user is part of
   const [userTeamsError, userTeamsLoading, userTeams] = useFetch(
-    `teams/?member=${user.id}`,
+    `teams/?omitMemberList=true&member=${user.id}`,
     user.id !== undefined,
   );
 

--- a/frontend/src/hooks/UseTagAPI.js
+++ b/frontend/src/hooks/UseTagAPI.js
@@ -46,12 +46,15 @@ export const useTagAPI = (initialData, tagType, processDataFn) => {
        make sure to consider how to monitor if form is unloaded */
 
     const fetchData = async () => {
+      const queryParams = {
+        organisations: '?omitManagerList=true',
+      };
       dispatch({ type: 'FETCH_INIT' });
       try {
         let result;
         if (token) {
           result = await axios({
-            url: `${API_URL}${tagType}/`,
+            url: `${API_URL}${tagType}/${queryParams[tagType] ? queryParams[tagType] : ''}`,
             method: 'GET',
             headers: { Authorization: `Token ${token}` },
           });

--- a/frontend/src/store/actions/auth.js
+++ b/frontend/src/store/actions/auth.js
@@ -121,12 +121,18 @@ export const setUserDetails = (username, encodedToken, update = false) => (dispa
     .then((userDetails) => {
       dispatch(updateUserDetails(userDetails));
       // GET USER ORGS INFO
-      fetchLocalJSONAPI(`organisations/?manager_user_id=${userDetails.id}`, encodedToken)
+      fetchLocalJSONAPI(
+        `organisations/?omitManagerList=true&manager_user_id=${userDetails.id}`,
+        encodedToken,
+      )
         .then((orgs) =>
           dispatch(updateOrgsInfo(orgs.organisations.map((org) => org.organisationId))),
         )
         .catch((error) => dispatch(updateOrgsInfo([])));
-      fetchLocalJSONAPI(`teams/?team_role=PROJECT_MANAGER&member=${userDetails.id}`, encodedToken)
+      fetchLocalJSONAPI(
+        `teams/?omitMemberList=true&team_role=PROJECT_MANAGER&member=${userDetails.id}`,
+        encodedToken,
+      )
         .then((teams) => dispatch(updatePMsTeams(teams.teams.map((team) => team.teamId))))
         .catch((error) => dispatch(updatePMsTeams([])));
       dispatch(setLoader(false));

--- a/frontend/src/views/organisations.js
+++ b/frontend/src/views/organisations.js
@@ -33,7 +33,9 @@ export function ListOrganisations() {
   const [userOrgsOnly, setUserOrgsOnly] = useState(true);
   useEffect(() => {
     if (token && userDetails && userDetails.id) {
-      const queryParam = userOrgsOnly ? `?manager_user_id=${userDetails.id}` : '';
+      const queryParam = `?omitManagerList=true${
+        userOrgsOnly ? `&manager_user_id=${userDetails.id}` : ''
+      }`;
       fetchLocalJSONAPI(`organisations/${queryParam}`, token).then((orgs) =>
         setOrganisations(orgs.organisations),
       );

--- a/frontend/src/views/project.js
+++ b/frontend/src/views/project.js
@@ -44,14 +44,13 @@ export const ProjectsPage = (props) => {
   const [fullProjectsQuery, setProjectQuery] = useExploreProjectsQueryParams();
   const [forceUpdated, forceUpdate] = useForceUpdate();
   const [state] = useProjectsQueryAPI(initialData, fullProjectsQuery, forceUpdated);
-  const [orgAPIState] = useTagAPI([], 'organisations');
 
   const isMapShown = useSelector((state) => state.preferences['mapShown']);
   const searchResultWidth = isMapShown ? 'w-60-l w-100' : 'w-100';
 
   return (
     <div className="pull-center">
-      <ProjectNav location={props.location} orgAPIState={orgAPIState}>
+      <ProjectNav location={props.location}>
         {
           props.children
           /* This is where the MoreFilters component is rendered


### PR DESCRIPTION
Closes #3177 . Included a request parameter **abbreviated**. When set to True, hides information according to the given endpoint.

**/v2/organisations/:** Hides managers for each organization.
**/v2/organisations/<id>:** Hides managers, teams and projects associated to the organization.
**/v2/teams/:** Hides team members.
**/v2/teams/<id>:** Hides team members, team projects and organization projects.