### PR TITLE
disable backend tests on circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,21 +52,21 @@ jobs:
           cd ${CIRCLE_WORKING_DIRECTORY}/frontend
           CI=true yarn test -w 1 --env=jsdom
           CI=true GENERATE_SOURCEMAP=false yarn build
-    - run:
-        name: Run backend tests
-        command: |
-          # Run Python tests
-          cd ${CIRCLE_WORKING_DIRECTORY}
-          mkdir ${CIRCLE_WORKING_DIRECTORY}/tests/backend/results
-          find ./tests/backend -name "test*.py" -exec chmod -x {} \;
-          env/bin/nosetests ./tests/backend --with-xunit \
-            --xunit-file ${CIRCLE_WORKING_DIRECTORY}/tests/backend/results/unitresults.xml \
-            --with-coverage --cover-erase --cover-package=./backend
-          env/bin/coverage xml -o ${CIRCLE_WORKING_DIRECTORY}/tests/backend/results/coverage.xml
-    - store_test_results:
-        path: tests/backend/results
-    - store_artifacts:
-        path: tests/backend/results
+    # - run:
+    #     name: Run backend tests
+    #     command: |
+    #       # Run Python tests
+    #       cd ${CIRCLE_WORKING_DIRECTORY}
+    #       mkdir ${CIRCLE_WORKING_DIRECTORY}/tests/backend/results
+    #       find ./tests/backend -name "test*.py" -exec chmod -x {} \;
+    #       env/bin/nosetests ./tests/backend --with-xunit \
+    #         --xunit-file ${CIRCLE_WORKING_DIRECTORY}/tests/backend/results/unitresults.xml \
+    #         --with-coverage --cover-erase --cover-package=./backend
+    #       env/bin/coverage xml -o ${CIRCLE_WORKING_DIRECTORY}/tests/backend/results/coverage.xml
+    # - store_test_results:
+    #     path: tests/backend/results
+    # - store_artifacts:
+    #     path: tests/backend/results
     - save_cache:
         key: node-v1-{{ .Branch }}-{{ checksum "frontend/yarn.lock" }}
         paths:


### PR DESCRIPTION
All backend tests are skipped because we don't have a test db configured (https://github.com/hotosm/tasking-manager/issues/3230). Also, it seems the tests are outdated and are not reliable anymore.

I'm disabling it because someone could think that the code is being tested.