### PR TITLE
Handle member omission for private teams

### DIFF
--- a/backend/services/team_service.py
+++ b/backend/services/team_service.py
@@ -239,6 +239,8 @@ class TeamService:
 
         for team in query.all():
             team_dto = TeamDTO()
+        for team in query.all():
+            team_dto = TeamDTO()
             team_dto.team_id = team.id
             team_dto.name = team.name
             team_dto.invite_only = team.invite_only
@@ -252,27 +254,25 @@ class TeamService:
             is_team_manager = False
             is_team_member = False
             for member in team_members:
-                # Skip if members are not included.
+                user = UserService.get_user_by_id(member.user_id)
+                member_function = TeamMemberFunctions(member.function).name
+                is_team_member = True if member.user_id == user_id else False
+                is_team_manager = True if member_function == "MANAGER" else False
+                # Skip if members are not included
                 if omit_members:
                     continue
-                user = UserService.get_user_by_id(member.user_id)
                 member_dto = TeamMembersDTO()
                 member_dto.username = user.username
-                member_dto.function = TeamMemberFunctions(member.function).name
-                if member.user_id == user_id:
-                    is_team_member = True
-                    if member_dto.function == "MANAGER":
-                        is_team_manager = True
+                member_dto.function = member_function
                 member_dto.picture_url = user.picture_url
                 member_dto.active = member.active
-
                 team_dto.members.append(member_dto)
+
             if team_dto.visibility == "PRIVATE" and not is_admin:
                 if is_team_manager or is_team_member:
                     teams_list_dto.teams.append(team_dto)
             else:
                 teams_list_dto.teams.append(team_dto)
-
         return teams_list_dto
 
     @staticmethod

--- a/backend/services/team_service.py
+++ b/backend/services/team_service.py
@@ -239,8 +239,6 @@ class TeamService:
 
         for team in query.all():
             team_dto = TeamDTO()
-        for team in query.all():
-            team_dto = TeamDTO()
             team_dto.team_id = team.id
             team_dto.name = team.name
             team_dto.invite_only = team.invite_only

--- a/frontend/src/components/projectEdit/teamSelect.js
+++ b/frontend/src/components/projectEdit/teamSelect.js
@@ -27,7 +27,7 @@ export const TeamSelect = () => {
     fetchLocalJSONAPI('organisations/?omitManagerList=true', token).then((r) =>
       setOrgs(r.organisations),
     );
-    fetchLocalJSONAPI('teams/', token).then((t) => setTeams(t.teams));
+    fetchLocalJSONAPI('teams/?omitMemberList=true', token).then((t) => setTeams(t.teams));
   }, [token]);
 
   const teamRoles = [

--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -65,7 +65,7 @@ export function TaskSelection({ project, type, loading }: Object) {
 
   // get teams the user is part of
   const [userTeamsError, userTeamsLoading, userTeams] = useFetch(
-    `teams/?member=${user.id}`,
+    `teams/?omitMemberList=true&member=${user.id}`,
     user.id !== undefined,
   );
   //eslint-disable-next-line

--- a/frontend/src/store/actions/auth.js
+++ b/frontend/src/store/actions/auth.js
@@ -129,7 +129,10 @@ export const setUserDetails = (username, encodedToken, update = false) => (dispa
           dispatch(updateOrgsInfo(orgs.organisations.map((org) => org.organisationId))),
         )
         .catch((error) => dispatch(updateOrgsInfo([])));
-      fetchLocalJSONAPI(`teams/?team_role=PROJECT_MANAGER&member=${userDetails.id}`, encodedToken)
+      fetchLocalJSONAPI(
+        `teams/?omitMemberList=true&team_role=PROJECT_MANAGER&member=${userDetails.id}`,
+        encodedToken,
+      )
         .then((teams) => dispatch(updatePMsTeams(teams.teams.map((team) => team.teamId))))
         .catch((error) => dispatch(updatePMsTeams([])));
       dispatch(setLoader(false));


### PR DESCRIPTION
Per chat w/ project managers for 8999 - we figured out that with the new query parameter `omitMemberList`, private team details are not appended for a user since permissions check is overridden because of a conditional placement check.

As a result if a user is a member of a private team and if `omitMemberList=True` then team data is not appended to the final list, thereby interrupting the user from contributing to the project. This fix updates the logic in team_service.