### PR TITLE
Skip membership check after first match

### DIFF
--- a/backend/services/team_service.py
+++ b/backend/services/team_service.py
@@ -250,13 +250,12 @@ class TeamService:
             team_dto.organisation_id = team.organisation.id
             team_dto.members = []
             team_members = TeamService._get_team_members(team.id)
-            is_team_manager = False
             is_team_member = False
             for member in team_members:
                 user = UserService.get_user_by_id(member.user_id)
                 member_function = TeamMemberFunctions(member.function).name
-                is_team_member = True if member.user_id == user_id else False
-                is_team_manager = True if member_function == "MANAGER" else False
+                if not (is_team_member):
+                    is_team_member = True if member.user_id == user_id else False
                 # Skip if members are not included
                 if omit_members:
                     continue
@@ -268,7 +267,7 @@ class TeamService:
                 team_dto.members.append(member_dto)
 
             if team_dto.visibility == "PRIVATE" and not is_admin:
-                if is_team_manager or is_team_member:
+                if is_team_member:
                     teams_list_dto.teams.append(team_dto)
             else:
                 teams_list_dto.teams.append(team_dto)

--- a/backend/services/team_service.py
+++ b/backend/services/team_service.py
@@ -249,22 +249,19 @@ class TeamService:
             team_dto.organisation = team.organisation.name
             team_dto.organisation_id = team.organisation.id
             team_dto.members = []
-            team_members = TeamService._get_team_members(team.id)
-            is_team_member = False
-            for member in team_members:
-                user = UserService.get_user_by_id(member.user_id)
-                member_function = TeamMemberFunctions(member.function).name
-                if not (is_team_member):
-                    is_team_member = True if member.user_id == user_id else False
-                # Skip if members are not included
-                if omit_members:
-                    continue
-                member_dto = TeamMembersDTO()
-                member_dto.username = user.username
-                member_dto.function = member_function
-                member_dto.picture_url = user.picture_url
-                member_dto.active = member.active
-                team_dto.members.append(member_dto)
+            is_team_member = TeamService.is_user_an_active_team_member(team.id, user_id)
+            # Skip if members are not included
+            if not omit_members:
+                team_members = TeamService._get_team_members(team.id)
+                for member in team_members:
+                    user = UserService.get_user_by_id(member.user_id)
+                    member_function = TeamMemberFunctions(member.function).name
+                    member_dto = TeamMembersDTO()
+                    member_dto.username = user.username
+                    member_dto.function = member_function
+                    member_dto.picture_url = user.picture_url
+                    member_dto.active = member.active
+                    team_dto.members.append(member_dto)
 
             if team_dto.visibility == "PRIVATE" and not is_admin:
                 if is_team_member:

--- a/frontend/src/components/projectEdit/teamSelect.js
+++ b/frontend/src/components/projectEdit/teamSelect.js
@@ -27,7 +27,7 @@ export const TeamSelect = () => {
     fetchLocalJSONAPI('organisations/?omitManagerList=true', token).then((r) =>
       setOrgs(r.organisations),
     );
-    fetchLocalJSONAPI('teams/', token).then((t) => setTeams(t.teams));
+    fetchLocalJSONAPI('teams/?omitMemberList=true', token).then((t) => setTeams(t.teams));
   }, [token]);
 
   const teamRoles = [

--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -65,7 +65,7 @@ export function TaskSelection({ project, type, loading }: Object) {
 
   // get teams the user is part of
   const [userTeamsError, userTeamsLoading, userTeams] = useFetch(
-    `teams/?member=${user.id}`,
+    `teams/?omitMemberList=true&member=${user.id}`,
     user.id !== undefined,
   );
   //eslint-disable-next-line

--- a/frontend/src/store/actions/auth.js
+++ b/frontend/src/store/actions/auth.js
@@ -129,7 +129,7 @@ export const setUserDetails = (username, encodedToken, update = false) => (dispa
           dispatch(updateOrgsInfo(orgs.organisations.map((org) => org.organisationId))),
         )
         .catch((error) => dispatch(updateOrgsInfo([])));
-      fetchLocalJSONAPI(`teams/?team_role=PROJECT_MANAGER&member=${userDetails.id}`, encodedToken)
+      fetchLocalJSONAPI(`teams/?omitMemberList=true&team_role=PROJECT_MANAGER&member=${userDetails.id}`, encodedToken)
         .then((teams) => dispatch(updatePMsTeams(teams.teams.map((team) => team.teamId))))
         .catch((error) => dispatch(updatePMsTeams([])));
       dispatch(setLoader(false));


### PR DESCRIPTION
While fetching teams, exclude membership check after the first match with the current user ID. If this check is repeated the flag is overwritten per the status of last member check, thereby affecting DTO append for private teams