### PR TITLE
Reduce ASG min instances and quicken updates

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -132,8 +132,8 @@ const Resources = {
     Properties: {
       AutoScalingGroupName: cf.stackName,
       Cooldown: 300,
-      MinSize: cf.if('IsTaskingManagerProduction', 3, 1),
-      DesiredCapacity: cf.if('IsTaskingManagerProduction', 3, 1),
+      MinSize: cf.if('IsTaskingManagerProduction', 2, 1),
+      DesiredCapacity: cf.if('IsTaskingManagerProduction', 2, 1),
       MaxSize: cf.if('IsTaskingManagerProduction', 9, cf.if('IsTaskingManagerDemo', 3, 1)),
       HealthCheckGracePeriod: 600,
       LaunchConfigurationName: cf.ref('TaskingManagerLaunchConfiguration'),
@@ -149,6 +149,7 @@ const Resources = {
     UpdatePolicy: {
       AutoScalingRollingUpdate: {
         PauseTime: 'PT60M',
+        MaxBatchSize: 2,
         WaitOnResourceSignals: true
       }
     }


### PR DESCRIPTION
- Reduces the minimum number of running instances from 3 to 2 on production. Cloudwatch monitoring shows that this will have no negative effect on performance and will help reduce costs during low-usage. 
- Changes the update policy to update the ASG in batches of 2, which will halve the amount of time it takes to make an update. Since we are now using a maintenance page to block users from accessing TM during updates, it is not necessary to update instances one at a time. 