### PR TITLE
Include manager list for manage orgs page

### DIFF
--- a/frontend/src/views/organisations.js
+++ b/frontend/src/views/organisations.js
@@ -33,8 +33,8 @@ export function ListOrganisations() {
   const [userOrgsOnly, setUserOrgsOnly] = useState(true);
   useEffect(() => {
     if (token && userDetails && userDetails.id) {
-      const queryParam = `?omitManagerList=true${
-        userOrgsOnly ? `&manager_user_id=${userDetails.id}` : ''
+      const queryParam = `${
+        userOrgsOnly ? `?manager_user_id=${userDetails.id}` : ''
       }`;
       fetchLocalJSONAPI(`organisations/${queryParam}`, token).then((orgs) =>
         setOrganisations(orgs.organisations),


### PR DESCRIPTION
Per chat w/ @russdeffner - removing `omitManagerList` query parameter from org fetch so that manager list is displayed in cards