### PR TITLE
Complete markdown support in project chat

### DIFF
--- a/backend/models/postgis/project_chat.py
+++ b/backend/models/postgis/project_chat.py
@@ -1,4 +1,5 @@
 import bleach
+from markdown import markdown
 from flask import current_app
 from backend import db
 from backend.models.postgis.user import User
@@ -30,7 +31,31 @@ class ProjectChat(db.Model):
         new_message.user_id = dto.user_id
 
         # Use bleach to remove any potential mischief
-        clean_message = bleach.clean(dto.message)
+        allowed_tags = [
+            "a",
+            "b",
+            "blockquote",
+            "br",
+            "code",
+            "em",
+            "h1",
+            "h2",
+            "h3",
+            "img",
+            "i",
+            "li",
+            "ol",
+            "p",
+            "pre",
+            "strong",
+            "ul",
+        ]
+        allowed_atrributes = {"a": ["href", "rel"], "img": ["src", "alt"]}
+        clean_message = bleach.clean(
+            markdown(dto.message, output_format="html"),
+            tags=allowed_tags,
+            attributes=allowed_atrributes,
+        )
         clean_message = bleach.linkify(clean_message)
         new_message.message = clean_message
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ idna==2.10
 itsdangerous==1.1.0
 Jinja2==2.11.2
 Mako==1.1.3
+markdown==3.2.2
 MarkupSafe==1.1.1
 mccabe==0.6.1
 newrelic==5.14.1.144


### PR DESCRIPTION
Per chat w/ @willemarcel - some of the markdown features are not supported with bleach methods. Here we're testing the possibility of including images, breaks in the project comment.