### PR TITLE
force nominatim to return results in English

### DIFF
--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -260,7 +260,7 @@ class Project(db.Model):
 
         centroid = to_shape(self.centroid)
         lat, lng = (centroid.y, centroid.x)
-        url = "{0}/reverse?format=jsonv2&lat={1}&lon={2}".format(
+        url = "{0}/reverse?format=jsonv2&lat={1}&lon={2}&accept-language=en".format(
             current_app.config["OSM_NOMINATIM_SERVER_URL"], lat, lng
         )
         try:


### PR DESCRIPTION
@ramyaragupathy I found one of the reasons why some projects received a country name in another language: https://nominatim.org/release-docs/develop/api/Reverse/#language-of-results

If we don't pass the language it will return the content of the "name" tag on OSM. You can confirm querying a location in Norway.