### PR TITLE
add notification status filter and use that query on the notification bell

### DIFF
--- a/backend/api/notifications/resources.py
+++ b/backend/api/notifications/resources.py
@@ -124,7 +124,6 @@ class NotificationsAllAPI(Resource):
               name: messageType
               type: string
               description: Optional message-type filter; leave blank to retrieve all
-              default: 1,2
             - in: query
               name: from
               description: Optional from username filter
@@ -137,6 +136,10 @@ class NotificationsAllAPI(Resource):
               name: taskId
               description: Optional task filter
               type: integer
+            - in: query
+              name: status
+              description: Optional status filter (read or unread)
+              type: string
             - in: query
               name: sortBy
               description:
@@ -172,6 +175,7 @@ class NotificationsAllAPI(Resource):
             from_username = request.args.get("from")
             project = request.args.get("project", None, int)
             task_id = request.args.get("taskId", None, int)
+            status = request.args.get("status", None, str)
             user_messages = MessageService.get_all_messages(
                 token_auth.current_user(),
                 preferred_locale,
@@ -183,6 +187,7 @@ class NotificationsAllAPI(Resource):
                 from_username,
                 project,
                 task_id,
+                status,
             )
             return user_messages.to_primitive(), 200
         except Exception as e:

--- a/backend/services/messaging/message_service.py
+++ b/backend/services/messaging/message_service.py
@@ -560,6 +560,7 @@ class MessageService:
         from_username=None,
         project=None,
         task_id=None,
+        status=None,
     ):
         """ Get all messages for user """
         sort_column = Message.__table__.columns.get(sort_by)
@@ -575,6 +576,9 @@ class MessageService:
 
         if task_id is not None:
             query = query.filter(Message.task_id == task_id)
+
+        if status in ["read", "unread"]:
+            query = query.filter(Message.read == (True if status == "read" else False))
 
         if message_type:
             message_type_filters = map(int, message_type.split(","))

--- a/frontend/src/components/header/notificationBell.js
+++ b/frontend/src/components/header/notificationBell.js
@@ -17,7 +17,7 @@ export const NotificationBell = (props) => {
 
   /* these below make the references stable so hooks doesn't re-request forever */
   const notificationBellRef = useRef(null);
-  const params = useRef({ sortBy: 'read', sortDirection: 'asc' });
+  const params = useRef({ status: 'unread' });
   const readNotifications = useRef(false);
   const [notificationState] = useInboxQueryAPI(
     notificationBellRef.current,

--- a/frontend/src/components/header/notificationBell.js
+++ b/frontend/src/components/header/notificationBell.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 
 import { TopNavLink } from './NavLink';
@@ -14,11 +14,9 @@ export const NotificationBell = (props) => {
   const token = useSelector((state) => state.auth.get('token'));
   const trigger = token !== null;
   const [forceUpdated, forceUpdate] = useForceUpdate();
-
   /* these below make the references stable so hooks doesn't re-request forever */
   const notificationBellRef = useRef(null);
   const params = useRef({ status: 'unread' });
-  const readNotifications = useRef(false);
   const [notificationState] = useInboxQueryAPI(
     notificationBellRef.current,
     params.current,
@@ -26,17 +24,40 @@ export const NotificationBell = (props) => {
   );
 
   const [isPopoutFocus, setPopoutFocus] = useState(false);
-  /*TODO Replace this backend with websockets, eventsource or RESTSockets
-    to save batteries and capacity*/
-  const [unreadNotifsStartError, unreadNotifsStartLoading, unreadNotifsStart] = useFetch(
-    `/api/v2/notifications/queries/own/count-unread/`,
+  const [unreadNotifications, setUnreadNotifications] = useState(false);
+  const [initialUnreadCountError, initialUnreadCountLoading, initialUnreadCount] = useFetch(
+    '/api/v2/notifications/queries/own/count-unread/',
     trigger,
   );
-  const [unreadNotifsRepeatError, unreadNotifsRepeat] = useFetchIntervaled(
-    `/api/v2/notifications/queries/own/count-unread/`,
+  const [unreadCountError, unreadCount] = useFetchIntervaled(
+    '/api/v2/notifications/queries/own/count-unread/',
     30000,
     trigger,
   );
+
+  useEffect(() => {
+    // unreadCount will receive a value only after 30 seconds,
+    //so while it's undefined, we rely on initialUnreadCount
+    if (
+      (!unreadCount && initialUnreadCount && initialUnreadCount.newMessages) ||
+      (unreadCount && unreadCount.newMessages)
+    ) {
+      setUnreadNotifications(true);
+    } else {
+      setUnreadNotifications(false);
+    }
+  }, [initialUnreadCount, unreadCount]);
+
+  const handleBellClick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setPopoutFocus(!isPopoutFocus);
+    if (unreadNotifications) {
+      forceUpdate(); // update the notifications when user clicks and there are unread messages
+      pushToLocalJSONAPI('/api/v2/notifications/queries/own/post-unread/', null, token);
+      setUnreadNotifications(false);
+    }
+  };
 
   useOnClickOutside(notificationBellRef, () => setPopoutFocus(false));
 
@@ -46,52 +67,24 @@ export const NotificationBell = (props) => {
       : { className: `link barlow-condensed blue-dark f4 ttu v-mid pt1` };
   };
 
-  let lightTheBell =
-    (!unreadNotifsStartLoading &&
-      !unreadNotifsStartError &&
-      unreadNotifsStart &&
-      unreadNotifsStart.newMessages) ||
-    (!unreadNotifsRepeatError && unreadNotifsRepeat && unreadNotifsRepeat.newMessages);
   const liveUnreadCount =
-    (!unreadNotifsRepeatError && unreadNotifsRepeat && unreadNotifsRepeat.unread) ||
-    (!unreadNotifsStartLoading &&
-      !unreadNotifsStartError &&
-      unreadNotifsStart &&
-      unreadNotifsStart.unread);
-
-  // When user clicks on the bell. Update notifications model in the backend.
-  if (isPopoutFocus === true) {
-    pushToLocalJSONAPI(`/api/v2/notifications/queries/own/post-unread/`, null, token);
-    readNotifications.current = true;
-  }
-
-  // Do not light the bell when user has pressed the button previously and there is no notifications update.
-  if (
-    readNotifications.current === true &&
-    unreadNotifsRepeat &&
-    unreadNotifsRepeat.newMessages === true
-  ) {
-    readNotifications.current = false;
-  }
-
-  if (readNotifications.current === true) {
-    lightTheBell = false;
-  }
+    (!unreadCountError && unreadCount && unreadCount.unread) ||
+    (!initialUnreadCountLoading &&
+      !initialUnreadCountError &&
+      initialUnreadCount &&
+      initialUnreadCount.unread);
 
   return (
     <span ref={notificationBellRef}>
       <TopNavLink
         to={'inbox/'}
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          setPopoutFocus(!isPopoutFocus);
-        }}
+        onClick={handleBellClick}
+        onKeyPress={handleBellClick}
         isActive={isNotificationBellActive}
       >
         <div className="relative dib">
-          <BellIcon aria-label="Notifications" />
-          {lightTheBell && <div className="redicon"></div>}
+          <BellIcon aria-label="Notifications" role="button" />
+          {unreadNotifications && <div className="redicon"></div>}
         </div>
       </TopNavLink>
       <NotificationPopout

--- a/frontend/src/components/notifications/notificationResults.js
+++ b/frontend/src/components/notifications/notificationResults.js
@@ -97,17 +97,7 @@ const NotificationCards = ({ pageOfCards, useMiniCard, retryFn }) => {
   if (pageOfCards.length === 0) {
     return (
       <div className="mb3 blue-grey">
-        <FormattedMessage {...messages.noMessages} />
-      </div>
-    );
-  }
-  const filterFn = useMiniCard ? (n) => !n.read : (n) => n;
-  const filteredCards = pageOfCards.filter(filterFn);
-
-  if (filteredCards.length < 1) {
-    return (
-      <div className="mb3 blue-grey">
-        <FormattedMessage {...messages.noUnreadMessages} />
+        <FormattedMessage {...messages[useMiniCard ? 'noUnreadMessages' : 'noMessages']} />
       </div>
     );
   }
@@ -131,8 +121,8 @@ const NotificationCards = ({ pageOfCards, useMiniCard, retryFn }) => {
       )}
       {useMiniCard
         ? // show only 5 messages when on miniCard
-          filteredCards.slice(0, 5).map((card, n) => <NotificationCardMini {...card} key={n} />)
-        : filteredCards.map((card, n) => (
+          pageOfCards.slice(0, 5).map((card, n) => <NotificationCardMini {...card} key={n} />)
+        : pageOfCards.map((card, n) => (
             <NotificationCard
               {...card}
               key={n}

--- a/frontend/src/hooks/UseInboxQueryAPI.js
+++ b/frontend/src/hooks/UseInboxQueryAPI.js
@@ -40,6 +40,7 @@ const backendToQueryConversion = {
   fromUsername: 'from',
   project: 'project',
   taskId: 'taskId',
+  status: 'status',
   orderByType: 'sortBy',
   orderBy: 'sortDirection',
   page: 'page',

--- a/frontend/src/store/reducers/notifications.js
+++ b/frontend/src/store/reducers/notifications.js
@@ -17,13 +17,13 @@ export const notificationsReducer = (state = initialState, action) => {
         isError: false,
       };
     case types.NOTIFICATIONS_SUCCESS:
-      const pagedNotifs = action.payload.userMessages.map(n => ({
+      const pagedNotifs = action.payload.userMessages.map((n) => ({
         ...n,
         page: action.payload.pagination.page,
       }));
       const goodForMiniResults =
-        action.params['sortBy'] &&
-        action.params['sortBy'] === 'read' &&
+        action.params['status'] &&
+        action.params['status'] === 'unread' &&
         action.payload.pagination.page === 1;
 
       return {


### PR DESCRIPTION
Ordering notifications by `read` status to load it on the notification bell caused the date ordering to be inconsistent:

![Screenshot from 2020-09-15 17-43-43](https://user-images.githubusercontent.com/666291/93262844-47735400-f77b-11ea-86a3-c3e4af895a09.png)

So I added a status filter on the endpoint and updated the frontend to use that query param, so now the notification bell is more consistent.

![image](https://user-images.githubusercontent.com/666291/93263398-19dada80-f77c-11ea-89f8-ce99e9fa55fa.png)
