### PR TITLE
Improve check for existing email addresses

### DIFF
--- a/backend/services/users/user_service.py
+++ b/backend/services/users/user_service.py
@@ -777,7 +777,7 @@ class UserService:
     def register_user_with_email(user_dto: UserRegisterEmailDTO):
         # Validate that user is not within the general users table.
         user_email = user_dto.email.lower()
-        user = User.query.filter(func.lower(User.email_address) == user_email).one_or_none()
+        user = User.query.filter(func.lower(User.email_address) == user_email).first()
         if user is not None:
             details_msg = f"Email address {user_email} already exists"
             raise ValueError(details_msg)

--- a/backend/services/users/user_service.py
+++ b/backend/services/users/user_service.py
@@ -776,14 +776,15 @@ class UserService:
     @staticmethod
     def register_user_with_email(user_dto: UserRegisterEmailDTO):
         # Validate that user is not within the general users table.
-        user = User.query.filter(User.email_address == user_dto.email).one_or_none()
+        user_email = user_dto.email.lower()
+        user = User.query.filter(func.lower(User.email_address) == user_email).one_or_none()
         if user is not None:
-            details_msg = f"Email address {user_dto.email} already exists"
+            details_msg = f"Email address {user_email} already exists"
             raise ValueError(details_msg)
 
-        user = UserEmail.query.filter(UserEmail.email == user_dto.email).one_or_none()
+        user = UserEmail.query.filter(func.lower(UserEmail.email) == user_email).one_or_none()
         if user is None:
-            user = UserEmail(email=user_dto.email)
+            user = UserEmail(email=user_email)
             user.create()
 
         return user

--- a/backend/services/users/user_service.py
+++ b/backend/services/users/user_service.py
@@ -782,7 +782,9 @@ class UserService:
             details_msg = f"Email address {user_email} already exists"
             raise ValueError(details_msg)
 
-        user = UserEmail.query.filter(func.lower(UserEmail.email) == user_email).one_or_none()
+        user = UserEmail.query.filter(
+            func.lower(UserEmail.email) == user_email
+        ).one_or_none()
         if user is None:
             user = UserEmail(email=user_email)
             user.create()


### PR DESCRIPTION
**Background**
When a user attempts to register a new account, the provided e-mail address is checked against the existing e-mails in the database to detect if there already exists an account with that e-mail address.

**The proposed changes** 
1. Perform the e-mail address comparison in lower-case to make it case-insensitive
2. If there are two or more users with the same e-mail address, return a 400 error (user already exists) instead of a 500 error (internal server error)