### PR TITLE
Change responsive behaviour of notification pop-up

### DIFF
--- a/frontend/src/assets/styles/_extra.scss
+++ b/frontend/src/assets/styles/_extra.scss
@@ -49,6 +49,9 @@ html {
   .user-popup-content {
     width: 13% !important;
   }
+  .right-4-ns {
+    right: 4rem;
+  }
 }
 
 @media screen and (min-width: 66rem) {

--- a/frontend/src/views/notifications.js
+++ b/frontend/src/views/notifications.js
@@ -17,8 +17,8 @@ import { Login } from './login';
 export const NotificationPopout = (props) => {
   return (
     <div
-      style={{ minWidth: '390px', width: '390px', zIndex: '100', right: '4rem' }}
-      className={`fr ${props.isPopoutFocus ? '' : 'dn'} mt2 br2 absolute shadow-2 ph4 pb3 bg-white`}
+      style={{ minWidth: '390px', width: '390px', zIndex: '100'}}
+      className={`fr ${props.isPopoutFocus ? '' : 'dn'} mt2 br2 absolute shadow-2 ph4 pb3 bg-white right-0 right-4-ns`}
     >
       <span className="absolute top-0 left-2 nt2 w1 h1 bg-white bl ml7 bt b--grey-light rotate-45"></span>
       <InboxNavMini


### PR DESCRIPTION
Attempts to improve on "Notifications pop-up misplaced" in #2342. As always, add/remove/change/discard/comment on this PR, whichever suits best.

The PR sets the distance from the right side of the browser window to 0 for small displays, while keeping the current solution for all other browser sizes.

This is the "low hanging fruit" version of "solving" this issue.

**Alternatively**
I can take a look att anchoring the arrow to the bell icon. However, I don't think I can solve that problem without using `flexbox` and limiting the display width of the user name for medium screen sizes. I can go into more depth regarding why if that is interesting. The attached image shows two issues not addressed with the current approach
1. The header wraps for long names
2. The pop-up arrow isn't pointing towards the bell icon

<img width="456" alt="Skärmavbild 2020-10-01 kl  17 05 53" src="https://user-images.githubusercontent.com/2598631/94863482-8571a880-0408-11eb-88db-2d930b4e3ea7.png">
