### PR TITLE
Add data to project stats page and adjust layout 

### DIFF
--- a/frontend/src/components/projectStats/contributorsStats.js
+++ b/frontend/src/components/projectStats/contributorsStats.js
@@ -65,53 +65,53 @@ function ContributorsStats(props) {
       <h3 className="f3 ttu barlow-condensed pv3 ma0">
         <FormattedMessage {...messages.contributors} />
       </h3>
-      <div className="cf w-third-l w-100 fl tc">
-        <div className="mb3 ph2">
-          <StatsCardContent
-            value={stats.mappers}
-            label={<FormattedMessage {...messages.mappers} />}
-            className="pv3-l pv2 shadow-1"
-          />
+      <div className="cf w-third-l w-100 fl pa2">
+          <div className="cf bg-tan tc">
+            <StatsCardContent
+              value={stats.mappers}
+              label={<FormattedMessage {...messages.mappers} />}
+              className="pv3-l pv2 mb3 shadow-4 bg-white"
+            />
+            <StatsCardContent
+              value={stats.validators}
+              label={<FormattedMessage {...messages.validators} />}
+              className="pv3-l pv2 mb3 shadow-4 bg-white"
+            />
+            <StatsCardContent
+              value={props.contributors.userContributions.length}
+              label={<FormattedMessage {...messages.totalContributors} />}
+              className="pv3-l pv2 mb3 shadow-4 bg-white"
+            />
+            </div>
         </div>
-        <div className="mv3 ph2">
-          <StatsCardContent
-            value={stats.validators}
-            label={<FormattedMessage {...messages.validators} />}
-            className="pv3-l pv2 shadow-1"
-          />
+        <div className="w-third-l w-100 fl pa2">
+          <div className="cf bg-white pb4 ph3 pt2 shadow-4">
+            <h3 className="f4 mv3 fw6">
+              <FormattedMessage {...messages.usersExperience} />
+            </h3>
+            <Bar
+              data={formatChartData(userExperienceReference, stats)}
+              options={{
+                legend: { display: false },
+                tooltips: { callbacks: { label: (tooltip, data) => formatTooltip(tooltip, data) } },
+              }}
+            />
+          </div>
         </div>
-        <div className="mv3 ph2">
-          <StatsCardContent
-            value={props.contributors.userContributions.length}
-            label={<FormattedMessage {...messages.totalContributors} />}
-            className="pv3-l pv2 shadow-1"
-          />
+        <div className="w-third-l w-100 fl pa2">
+          <div className="cf bg-white pb4 ph3 pt2 shadow-4">
+            <h3 className="f4 mv3 fw6">
+              <FormattedMessage {...messages.usersLevel} />
+            </h3>
+            <Doughnut
+              data={formatChartData(userLevelsReference, stats)}
+              options={{
+                legend: { position: 'right', labels: { boxWidth: 12 } },
+                tooltips: { callbacks: { label: (tooltip, data) => formatTooltip(tooltip, data) } },
+              }}
+            />
+          </div>
         </div>
-      </div>
-      <div className="cf w-third-l w-100 fl ph2 mv0-l mv3">
-        <h3 className="f4 ttu barlow-condensed pb3 ph2 ma0">
-          <FormattedMessage {...messages.usersExperience} />
-        </h3>
-        <Bar
-          data={formatChartData(userExperienceReference, stats)}
-          options={{
-            legend: { display: false },
-            tooltips: { callbacks: { label: (tooltip, data) => formatTooltip(tooltip, data) } },
-          }}
-        />
-      </div>
-      <div className="cf w-third-l w-100 fl mv0-l mv3">
-        <h3 className="f4 ttu barlow-condensed pb3 ph2 ma0">
-          <FormattedMessage {...messages.usersLevel} />
-        </h3>
-        <Doughnut
-          data={formatChartData(userLevelsReference, stats)}
-          options={{
-            legend: { position: 'right', labels: { boxWidth: 12 } },
-            tooltips: { callbacks: { label: (tooltip, data) => formatTooltip(tooltip, data) } },
-          }}
-        />
-      </div>
     </div>
   );
 }

--- a/frontend/src/components/projectStats/elementsCreated.js
+++ b/frontend/src/components/projectStats/elementsCreated.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import projectMessages from './messages';
+import userMessages from '../user/messages';
+import userDetailMessages from '../userDetail/messages';
+import { MappingIcon, HomeIcon, RoadIcon, EditIcon } from '../svgIcons';
+import { StatsCardContent } from '../statsCardContent';
+
+const getFieldData = (field) => {
+  const iconClass = 'h-50 w-50';
+  const iconStyle = { height: '45px' };
+  switch (field) {
+    case 'buildings':
+      return {
+        icon: <HomeIcon className={iconClass} style={iconStyle} />,
+        message: <FormattedMessage {...userDetailMessages.buildingsMapped} />,
+      };
+    case 'roads':
+      return {
+        icon: <RoadIcon className={iconClass} style={iconStyle} />,
+        message: <FormattedMessage {...userDetailMessages.roadMapped} />,
+      };
+    case 'changesets':
+      return {
+        icon: <MappingIcon className={iconClass} style={iconStyle} />,
+        message: <FormattedMessage {...userMessages.totalChangesets} />,
+      };
+    case 'edits':
+      return {
+        icon: <EditIcon className={iconClass} style={iconStyle} />,
+      message: <FormattedMessage {...projectMessages.totalEdits} />,
+      };
+    default:
+      return null;
+  }
+};
+
+const Element = ({ field, value }) => {
+  const element = getFieldData(field);
+  return (
+    <div className={`w-25-ns w-100 ph2-ns fl`}>
+      <div
+        className={`cf shadow-4 pt3 pb3 ph2 bg-white blue-dark`}
+      >
+        <div className="w-30 w-100-m fl tc">{element.icon}</div>
+        <StatsCardContent
+          value={Math.trunc(value)}
+          label={element.message}
+          className="w-70 w-100-m pt3-m mb1 fl tc"
+        />
+      </div>
+    </div>
+  );
+};
+
+export const ElementsCreated = (props) => {
+  const { changesets, buildings, roads, edits } = props.data;
+
+  return(
+    <div className="cf w-100 mb3 ph2 ph4-ns blue-dark">
+      <h3 className="barlow-condensed ttu f3">
+        <FormattedMessage {...projectMessages.taskStats} />
+      </h3>
+      <Element field="changesets" value={changesets || 0} />
+      <Element field="buildings" value={buildings || 0} />
+      <Element field="roads" value={roads || 0} />
+      <Element field="edits" value={edits || 0} />
+  </div>
+  )
+}

--- a/frontend/src/components/projectStats/messages.js
+++ b/frontend/src/components/projectStats/messages.js
@@ -77,4 +77,12 @@ export default defineMessages({
     id: 'project.stats.contributors.experience.year',
     defaultMessage: 'More than 1 year',
   },
+  totalEdits: {
+    id: 'project.stats.totalEdits',
+    defaultMessage: 'Total edits',
+  },
+  taskStats: {
+    id: 'project.stats.tasks.stats',
+    defaultMessage: 'Task statistics',
+  },
 });

--- a/frontend/src/components/projectStats/taskStatus.js
+++ b/frontend/src/components/projectStats/taskStatus.js
@@ -57,11 +57,11 @@ const TasksByStatus = (props) => {
   const data = formatChartData(reference, props.stats);
 
   return (
-    <div className="cf w-100 mb3 ph2 ph4-ns bg-tan blue-dark">
+    <div className="cf w-100 mb3 ph2 ph4-ns blue-dark">
       <h3 className="barlow-condensed ttu f3">
         <FormattedMessage {...messages.status} />
       </h3>
-      <div className="cf w-100">
+      <div className="cf w-100 bg-white pv2 shadow-4">
         <div className="w-third-ns w-100 fl pv3">
           <Doughnut
             data={data}

--- a/frontend/src/components/projectStats/tests/elementsCreated.test.js
+++ b/frontend/src/components/projectStats/tests/elementsCreated.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ElementsCreated } from '../elementsCreated'
+import { ConnectedIntl } from '../../../utils/internationalization';
+import { Provider } from 'react-redux';
+import { store } from '../../../store';
+
+describe('ElementsCreated component', () => {
+  const data = {
+    changesets: 22153,
+    roads: 2739.51998662114,
+    buildings: 269809,
+    edits: 310483
+  }
+
+  it('component is rendered', () => {
+    const { getByText } = render(
+      <Provider store={store}>
+        <ConnectedIntl>
+          <ElementsCreated data={data}/>
+        </ConnectedIntl>
+      </Provider>
+    )
+
+    expect(getByText('Task statistics')).toBeTruthy();
+    expect(getByText('Total changesets')).toBeTruthy();
+    expect(getByText('Buildings mapped')).toBeTruthy();
+    expect(getByText('Km road mapped')).toBeTruthy();
+    expect(getByText('Total edits')).toBeTruthy();
+  })
+})

--- a/frontend/src/components/svgIcons/index.js
+++ b/frontend/src/components/svgIcons/index.js
@@ -68,3 +68,4 @@ export { ZoomPlusIcon } from './zoomPlus';
 export { SidebarIcon } from './sidebar';
 export { QuestionCircleIcon } from './questionCircle';
 export { ChartLineIcon } from './chart';
+export { EditIcon } from './edit';

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -483,6 +483,7 @@
   "projects.stats.time_finish_mapping": "Time to finish mapping",
   "projects.stats.time_finish_validation": "Time to finish validation",
   "project.stats.tasks.tatus": "Tasks by status",
+  "project.stats.tasks.stats": "Task statistics",
   "project.stats.tasks.needs_mapping": "Tasks to map",
   "project.stats.tasks.needs_validation": "Tasks to validate",
   "project.stats.contributors.title": "Contributors",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -486,6 +486,7 @@
   "project.stats.tasks.stats": "Task statistics",
   "project.stats.tasks.needs_mapping": "Tasks to map",
   "project.stats.tasks.needs_validation": "Tasks to validate",
+  "project.stats.totalEdits": "Total edits",
   "project.stats.contributors.title": "Contributors",
   "project.stats.contributors.total": "Total contributors",
   "project.stats.experience.title": "Users by experience on Tasking Manager",

--- a/frontend/src/views/projectStats.js
+++ b/frontend/src/views/projectStats.js
@@ -9,6 +9,7 @@ import { useSetTitleTag } from '../hooks/UseMetaTags';
 import { ProjectHeader } from '../components/projectDetail/header';
 import { TimeStats } from '../components/projectStats/timeStats';
 import { CompletionStats } from '../components/projectStats/completion';
+import { ElementsCreated } from '../components/projectStats/elementsCreated';
 
 const ContributorsStats = React.lazy(() => import('../components/projectStats/contributorsStats'));
 const TasksByStatus = React.lazy(() => import('../components/projectStats/taskStatus'));
@@ -28,6 +29,10 @@ export function ProjectStats({ id }: Object) {
     `projects/${id}/contributions/queries/day/`,
     id,
   );
+  const osmData = useFetch(
+    `http://osm-stats-production-api.azurewebsites.net/stats/hotosm-project-${id}`,
+    id
+  );
 
   return (
     <ReactPlaceholder
@@ -36,13 +41,18 @@ export function ProjectStats({ id }: Object) {
       ready={!error && !loading}
       className="pr3"
     >
-      <div className="pt3 cf bg-white blue-dark">
-        <div className="w-100 fl ph2 ph4-ns">
+      <div className="cf bg-tan">
+        <div className="w-100 fl pv3 ph2 ph4-ns bg-white blue-dark">
           <ProjectHeader project={project} showEditLink={true} />
         </div>
-        <div className="w-100 fl mt3 bg-tan">
+        <div className="w-100 fl mt3">
           <React.Suspense fallback={<div className={`w7 h5`}>Loading...</div>}>
             <TasksByStatus stats={tasksByStatus} />
+          </React.Suspense>
+        </div>
+        <div className="w-100 fl mt3">
+          <React.Suspense fallback={<div className={`w7 h5`}>Loading...</div>}>
+            <ElementsCreated data={osmData[2]} />
           </React.Suspense>
         </div>
         <div className="w-100 fl pb3">
@@ -57,30 +67,34 @@ export function ProjectStats({ id }: Object) {
             </ReactPlaceholder>
           </React.Suspense>
         </div>
-        <div className="w-100 mb4 fl ph2 ph4-ns">
+        <div className="w-100 mb2 fl ph2 ph4-ns">
           <h3 className="barlow-condensed ttu f3">
             <FormattedMessage {...messages.projectTimeline} />
           </h3>
-          <div className="w-100 w-50-l fl">
-            <React.Suspense fallback={<div className={`w7 h5`}>Loading...</div>}>
-              <ReactPlaceholder
-                showLoadingAnimation={true}
-                rows={3}
-                delay={500}
-                ready={!visualError && !visualLoading}
-              >
-                <ProjectTimeline tasksByDay={visualData.stats} />
-              </ReactPlaceholder>
-            </React.Suspense>
-          </div>
-          <div className="w-100 w-50-l fl">
-            <CompletionStats tasksByStatus={tasksByStatus} />
+          <div className="bg-white pv3 ph2 fl w-100 shadow-4">
+            <div className="w-100 w-50-l fl">
+              <React.Suspense fallback={<div className={`w7 h5`}>Loading...</div>}>
+                <ReactPlaceholder
+                  showLoadingAnimation={true}
+                  rows={3}
+                  delay={500}
+                  ready={!visualError && !visualLoading}
+                >
+                  <ProjectTimeline tasksByDay={visualData.stats} />
+                </ReactPlaceholder>
+              </React.Suspense>
+            </div>
+            <div className="w-100 w-50-l fl">
+              <CompletionStats tasksByStatus={tasksByStatus} />
+            </div>
           </div>
         </div>
-        <div className="w-100 fl bg-tan pb3">
+        <div className="w-100 fl bg-tan pb3 mb4">
           <TimeStats id={id} />
         </div>
       </div>
     </ReactPlaceholder>
   );
 }
+
+export default ProjectStats;

--- a/frontend/src/views/tests/projectStats.test.js
+++ b/frontend/src/views/tests/projectStats.test.js
@@ -9,7 +9,7 @@ import { ProjectStats } from '../projectStats';
 
 describe('ProjectStats dashboard', () => {
   it('fetch urls and render information', async () => {
-    const { container } = await render(
+    const { container, findByText } = await render(
       <Provider store={store}>
         <ConnectedIntl>
           <ProjectStats id={1} />
@@ -19,8 +19,13 @@ describe('ProjectStats dashboard', () => {
 
     await waitFor(() => screen.getByText('#1'));
     await waitFor(() => container.querySelector('[aria-valuenow="28"]'));
-
-    expect(screen.getByText('#1')).toBeInTheDocument();
-    expect(screen.getByText('Urgent')).toBeInTheDocument();
+    
+    expect(findByText('#1')).toBeTruthy();
+    expect(findByText('Urgent')).toBeTruthy();
+    expect(findByText('Tasks by status')).toBeTruthy();
+    expect(findByText('Task statistics')).toBeTruthy();
+    expect(findByText('Contributors')).toBeTruthy();
+    expect(findByText('Project timeline')).toBeTruthy();
+    expect(findByText('Time statistics')).toBeTruthy();
   }, 10000);
 });


### PR DESCRIPTION
Implemented #3339 request. 

Added a new **Task Statistics** section in project stats page with "Total changesets", "Buildings mapped", "Roads mapped", and "Total edits" data. 

Also modified the page layout to be the same as user details page. 