### PR TITLE
Simplify CircleCI config and fix sentry envvar setting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,111 +263,16 @@ jobs:
             aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-latest
           fi
   frontend_deploy:
+    working_directory: /home/circleci/tasking-manager
+    docker:
+    - image: circleci/python:3.7-buster-node
     parameters:
       stack_name:
         description: "the name of the stack for cfn-config"
         type: string
-      environment_name:
-        description: "The environment (staging or production) on AWS"
-        type: enum
-        enum: ["staging", "production"]
-      autoscaling_policy:
-        description: "Setting autoscaling parameters"
-        type: enum
-        enum: ['development', 'demo', 'production']
-      new_relic_license:
-        type: env_var_name
-        default: NEW_RELIC_LICENSE
-      postgres_db:
-        type: env_var_name
-      postgres_password:
-        type: env_var_name
-      postgres_user:
-        type: env_var_name
-      base_url:
-        type: env_var_name
-      app_url:
-        type: env_var_name
-      api_version:
-        type: env_var_name
-      consumer_key:
-        type: env_var_name
-      consumer_secret:
-        type: env_var_name
-      tm_secret:
-        type: env_var_name
-      tm_default_changeset_comment:
-        type: env_var_name
-      email_from_address:
-        type: env_var_name
-      email_contact_address:
-        type: env_var_name
-      smtp_host:
-        type: env_var_name
-      smtp_password:
-        type: env_var_name
-      smtp_user:
-        type: env_var_name
-      smtp_port:
-        type: env_var_name
-      log_dir:
-        type: env_var_name
-      db_size:
-        type: env_var_name
-      elb_subnets:
-        type: env_var_name
-      ssl_cert:
-        type: env_var_name
-      matomo_site_id:
-        type: env_var_name
-      matomo_endpoint:
-        type: env_var_name
-      mapbox_token:
-        type: env_var_name
-      org_name:
-        type: env_var_name
-      org_code:
-        type: env_var_name
-      org_url:
-        type: env_var_name
-      org_privacy_policy:
-        type: env_var_name
-      org_twitter:
-        type: env_var_name
-      org_fb:
-        type: env_var_name
-      org_instagram:
-        type: env_var_name
-      org_youtube:
-        type: env_var_name
-      org_github:
-        type: env_var_name
-      org_homepage_video_url:
-        type: env_var_name
-      log_level:
-        type: enum
-        enum: ["INFO", "DEBUG"]
-        default: "INFO"
-      upload_api_url:
-        type: env_var_name
-      upload_api_key:
-        type: env_var_name
-      user_stats_api_url:
-        type: env_var_name
-      homepage_stats_api_url:
-        type: env_var_name
-      sentry_frontend_dsn:
-        type: env_var_name
-    working_directory: /home/circleci/tasking-manager
-    docker:
-    - image: circleci/python:3.7-buster-node
     steps:
     - checkout
     - setup_remote_docker
-    - run:
-        name: Set Environment Variables
-        command: |
-          echo "export JSON_CONFIG='{\"GitSha\":\"$CIRCLE_SHA1\", \"NetworkEnvironment\":\"<< parameters.environment_name >>\", \"AutoscalingPolicy\":\"<< parameters.autoscaling_policy >>\", \"DBSnapshot\":\"\", \"DatabaseDump\":\"\", \"NewRelicLicense\":\"${<< parameters.new_relic_license >>}\", \"PostgresDB\":\"${<< parameters.postgres_db >>}\", \"PostgresEndpoint\":\"\", \"PostgresPassword\":\"${<< parameters.postgres_password >>}\", \"PostgresUser\":\"${<< parameters.postgres_user >>}\", \"DatabaseSize\":\"${<< parameters.db_size >>}\",\"ELBSubnets\":\"${<< parameters.elb_subnets >>}\", \"SSLCertificateIdentifier\":\"${<< parameters.ssl_cert >>}\", \"TaskingManagerLogDirectory\":\"${<< parameters.log_dir >>}\", \"TaskingManagerConsumerKey\":\"${<< parameters.consumer_key >>}\",\"TaskingManagerConsumerSecret\":\"${<< parameters.consumer_secret >>}\",\"TaskingManagerSecret\":\"${<< parameters.tm_secret >>}\",\"TaskingManagerLogLevel\":\"<< parameters.log_level >>\",\"TaskingManagerImageUploadAPIURL\":\"${<< parameters.upload_api_url >>}\", \"TaskingManagerImageUploadAPIKey\":\"${<< parameters.upload_api_key >>}\",\"TaskingManagerURL\":\"${<< parameters.app_url >>}\", \"TaskingManagerEmailContactAddress\":\"${<< parameters.email_contact_address >>}\"}'" >> $BASH_ENV
     - run:
         name: Install modules
         command: |
@@ -392,38 +297,6 @@ jobs:
     - run:
         name: Deploy Frontend to S3
         command: |
-          export TM_APP_BASE_URL=${<< parameters.base_url >>}
-          export TM_APP_API_VERSION=${<< parameters.api_version >>}
-          export TM_CONSUMER_KEY=${<< parameters.consumer_key >>}
-          export TM_CONSUMER_SECRET=${<< parameters.consumer_secret >>}
-          export TM_EMAIL_FROM_ADDRESS=${<< parameters.email_from_address >>}
-          export TM_EMAIL_CONTACT_ADDRESS=${<< parameters.email_contact_address >>}
-          export TM_LOG_LEVEL=<< parameters.log_level >>
-          export TM_LOG_DIR=${<< parameters.log_dir >>}
-          export TM_SECRET=${<< parameters.tm_secret >>}
-          export TM_SMTP_HOST=${<< parameters.smtp_host >>}
-          export TM_SMTP_PASSWORD=${<< parameters.smtp_password >>}
-          export TM_SMTP_PORT=${<< parameters.smtp_port >>}
-          export TM_SMTP_USER=${<< parameters.smtp_user >>}
-          export TM_DEFAULT_CHANGESET_COMMENT=${<< parameters.tm_default_changeset_comment >>}
-          export TM_MATOMO_ID=${<< parameters.matomo_site_id >>}
-          export TM_MATOMO_ENDPOINT=${<< parameters.matomo_endpoint >>}
-          export TM_MAPBOX_TOKEN=${<< parameters.mapbox_token >>}
-          export TM_ORG_NAME=${<< parameters.org_name >>}
-          export TM_ORG_CODE=${<< parameters.org_code >>}
-          export TM_ORG_URL=${<< parameters.org_url >>}
-          export TM_ORG_PRIVACY_POLICY_URL=${<< parameters.org_privacy_policy >>}
-          export TM_ORG_TWITTER=${<< parameters.org_twitter >>}
-          export TM_ORG_FB=${<< parameters.org_fb >>}
-          export TM_ORG_INSTAGRAM=${<< parameters.org_instagram >>}
-          export TM_ORG_YOUTUBE=${<< parameters.org_youtube >>}
-          export TM_ORG_GITHUB=${<< parameters.org_github >>}
-          export TM_HOMEPAGE_VIDEO_URL=${<< parameters.org_homepage_video_url >>}
-          export TM_APP_API_URL="https://tasking-manager-<< parameters.stack_name >>-api.hotosm.org"
-          export TM_IMAGE_UPLOAD_API_URL=${<< parameters.upload_api_url >>}
-          export TM_USER_STATS_API_URL=${<< parameters.user_stats_api_url >>}
-          export TM_HOMEPAGE_STATS_API_URL=${<< parameters.homepage_stats_api_url >>}
-          export TM_SENTRY_FRONTEND_DSN=${<< parameters.sentry_frontend_dsn >>}
           cd ${CIRCLE_WORKING_DIRECTORY}/frontend/
           yarn
           CI=true GENERATE_SOURCEMAP=false yarn build
@@ -495,48 +368,8 @@ workflows:
             - develop
         requires:
           - build
+        context: tasking-manager-staging
         stack_name: "staging"
-        environment_name: "staging"
-        autoscaling_policy: "development"
-        postgres_db: POSTGRES_DB_STAGING
-        postgres_password: POSTGRES_PASSWORD_STAGING
-        postgres_user: POSTGRES_USER_STAGING
-        base_url: TM_APP_BASE_URL_STAGING
-        app_url: TM_APP_URL_STAGING
-        api_version: TM_APP_API_VERSION_STAGING
-        consumer_key: TM_CONSUMER_KEY_STAGING
-        consumer_secret: TM_CONSUMER_SECRET_STAGING
-        tm_secret: TM_SECRET_STAGING
-        email_from_address: TM_EMAIL_FROM_ADDRESS_STAGING
-        email_contact_address: TM_EMAIL_CONTACT_ADDRESS_STAGING
-        log_level: "INFO"
-        smtp_host: TM_SMTP_HOST_STAGING
-        smtp_password: TM_SMTP_PASSWORD_STAGING
-        smtp_user: TM_SMTP_USER_STAGING
-        smtp_port: TM_SMTP_PORT_STAGING
-        log_dir: TM_LOG_DIR_STAGING
-        db_size: DATABASE_SIZE_STAGING
-        elb_subnets: ELB_SUBNETS_STAGING
-        ssl_cert: SSL_CERTIFICATE_ID_STAGING
-        tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_STAGING
-        matomo_site_id: MATOMO_SITE_ID_STAGING
-        matomo_endpoint: MATOMO_ENDPOINT_STAGING
-        mapbox_token: MAPBOX_TOKEN
-        org_name: TM_ORG_NAME                       #='Humanitarian OpenStreetMap Team'
-        org_code: TM_ORG_CODE                       #=HOT
-        org_url: TM_ORG_URL                         #='hotosm.org' # Don't use http or https
-        org_privacy_policy: TM_ORG_PRIVACY_POLICY   #='hotosm.org/privacy'
-        org_twitter: TM_ORG_TWITTER                 #=http://twitter.com/hotosm/
-        org_fb: TM_ORG_FB                           #=https://www.facebook.com/hotosm
-        org_instagram: TM_ORG_INSTAGRAM             #=https://www.instagram.com/hot.osm/
-        org_youtube: TM_ORG_YOUTUBE                 #=https://www.youtube.com/user/hotosm
-        org_github: TM_ORG_GITHUB                   #=https://github.com/hotosm/
-        org_homepage_video_url: TM_HOMEPAGE_VIDEO_URL #=https://cdn.hotosm.org/tasking-manager/mapping.mp4
-        upload_api_url: TM_IMAGE_UPLOAD_API_URL
-        upload_api_key: TM_IMAGE_UPLOAD_API_KEY
-        user_stats_api_url: TM_USER_STATS_API_URL
-        homepage_stats_api_url: TM_HOMEPAGE_STATS_API_URL
-        sentry_frontend_dsn: TM_SENTRY_FRONTEND_DSN
     - backend_deploy:
         name: teachosm
         filters:
@@ -593,48 +426,8 @@ workflows:
               - deployment/teachosm-tasking-manager
         requires:
           - build
+        context: tasking-manager-teachosm
         stack_name: "teachosm"
-        environment_name: "production"
-        autoscaling_policy: "demo"
-        postgres_db: POSTGRES_DB_TEACHOSM
-        postgres_password: POSTGRES_PASSWORD_TEACHOSM
-        postgres_user: POSTGRES_USER_TEACHOSM
-        base_url: TM_APP_BASE_URL_TEACHOSM
-        app_url: TM_APP_URL_TEACHOSM
-        api_version: TM_APP_API_VERSION_TEACHOSM
-        consumer_key: TM_CONSUMER_KEY_TEACHOSM
-        consumer_secret: TM_CONSUMER_SECRET_TEACHOSM
-        tm_secret: TM_SECRET_TEACHOSM
-        email_from_address: TM_EMAIL_FROM_ADDRESS_TEACHOSM
-        email_contact_address: TM_EMAIL_CONTACT_ADDRESS_TEACHOSM
-        log_level: "INFO"
-        smtp_host: TM_SMTP_HOST_TEACHOSM
-        smtp_password: TM_SMTP_PASSWORD_TEACHOSM
-        smtp_user: TM_SMTP_USER_TEACHOSM
-        smtp_port: TM_SMTP_PORT_TEACHOSM
-        log_dir: TM_LOG_DIR_TEACHOSM
-        db_size: DATABASE_SIZE_TEACHOSM
-        elb_subnets: ELB_SUBNETS_TEACHOSM
-        ssl_cert: SSL_CERTIFICATE_ID_TEACHOSM
-        tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_TEACHOSM
-        matomo_site_id: MATOMO_SITE_ID_TEACHOSM
-        matomo_endpoint: MATOMO_ENDPOINT_TEACHOSM
-        mapbox_token: MAPBOX_TOKEN
-        org_name: TM_ORG_NAME
-        org_code: TM_ORG_CODE
-        org_url: TM_ORG_URL
-        org_privacy_policy: TM_ORG_PRIVACY_POLICY
-        org_twitter: TM_ORG_TWITTER
-        org_fb: TM_ORG_FB
-        org_instagram: TM_ORG_INSTAGRAM
-        org_youtube: TM_ORG_YOUTUBE
-        org_github: TM_ORG_GITHUB
-        org_homepage_video_url: TM_HOMEPAGE_VIDEO_URL
-        upload_api_url: TM_IMAGE_UPLOAD_API_URL
-        upload_api_key: TM_IMAGE_UPLOAD_API_KEY
-        user_stats_api_url: TM_USER_STATS_API_URL
-        homepage_stats_api_url: TM_HOMEPAGE_STATS_API_URL
-        sentry_frontend_dsn: TM_SENTRY_FRONTEND_DSN
     - backend_deploy:
         name: assisted
         filters:
@@ -692,47 +485,7 @@ workflows:
         requires:
           - build
         stack_name: "assisted"
-        environment_name: "staging"
-        autoscaling_policy: "demo"
-        postgres_db: POSTGRES_DB_ASSISTED
-        postgres_password: POSTGRES_PASSWORD_ASSISTED
-        postgres_user: POSTGRES_USER_ASSISTED
-        base_url: TM_APP_BASE_URL_ASSISTED
-        app_url: TM_APP_URL_ASSISTED
-        api_version: TM_APP_API_VERSION_ASSISTED
-        consumer_key: TM_CONSUMER_KEY_ASSISTED
-        consumer_secret: TM_CONSUMER_SECRET_ASSISTED
-        tm_secret: TM_SECRET_ASSISTED
-        email_from_address: TM_EMAIL_FROM_ADDRESS_ASSISTED
-        email_contact_address: TM_EMAIL_CONTACT_ADDRESS_ASSISTED
-        log_level: "INFO"
-        smtp_host: TM_SMTP_HOST_ASSISTED
-        smtp_password: TM_SMTP_PASSWORD_ASSISTED
-        smtp_user: TM_SMTP_USER_ASSISTED
-        smtp_port: TM_SMTP_PORT_ASSISTED
-        log_dir: TM_LOG_DIR_ASSISTED
-        db_size: DATABASE_SIZE_ASSISTED
-        elb_subnets: ELB_SUBNETS_ASSISTED
-        ssl_cert: SSL_CERTIFICATE_ID_ASSISTED
-        tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_ASSISTED
-        matomo_site_id: MATOMO_SITE_ID_ASSISTED
-        matomo_endpoint: MATOMO_ENDPOINT_ASSISTED
-        mapbox_token: MAPBOX_TOKEN
-        org_name: TM_ORG_NAME
-        org_code: TM_ORG_CODE
-        org_url: TM_ORG_URL
-        org_privacy_policy: TM_ORG_PRIVACY_POLICY
-        org_twitter: TM_ORG_TWITTER
-        org_fb: TM_ORG_FB
-        org_instagram: TM_ORG_INSTAGRAM
-        org_youtube: TM_ORG_YOUTUBE
-        org_github: TM_ORG_GITHUB
-        org_homepage_video_url: TM_HOMEPAGE_VIDEO_URL
-        upload_api_url: TM_IMAGE_UPLOAD_API_URL
-        upload_api_key: TM_IMAGE_UPLOAD_API_KEY
-        user_stats_api_url: TM_USER_STATS_API_URL
-        homepage_stats_api_url: TM_HOMEPAGE_STATS_API_URL
-        sentry_frontend_dsn: TM_SENTRY_FRONTEND_DSN
+        context: tasking-manager-assisted
   backend-production:
     jobs:
     - backend_deploy:
@@ -791,44 +544,4 @@ workflows:
               - deployment/hot-tasking-manager-frontend
               - deployment/hot-tasking-manager
         stack_name: "tm4-production"
-        environment_name: "production"
-        autoscaling_policy: "production"
-        postgres_db: POSTGRES_DB_PRODUCTION
-        postgres_password: POSTGRES_PASSWORD_PRODUCTION
-        postgres_user: POSTGRES_USER_PRODUCTION
-        base_url: TM_APP_BASE_URL_PRODUCTION
-        app_url: TM_APP_URL_PRODUCTION
-        api_version: TM_APP_API_VERSION_PRODUCTION
-        consumer_key: TM_CONSUMER_KEY_PRODUCTION
-        consumer_secret: TM_CONSUMER_SECRET_PRODUCTION
-        tm_secret: TM_SECRET_PRODUCTION
-        email_from_address: TM_EMAIL_FROM_ADDRESS_PRODUCTION
-        email_contact_address: TM_EMAIL_CONTACT_ADDRESS_PRODUCTION
-        log_level: "INFO"
-        smtp_host: TM_SMTP_HOST_PRODUCTION
-        smtp_password: TM_SMTP_PASSWORD_PRODUCTION
-        smtp_user: TM_SMTP_USER_PRODUCTION
-        smtp_port: TM_SMTP_PORT_PRODUCTION
-        log_dir: TM_LOG_DIR_PRODUCTION
-        db_size: DATABASE_SIZE_PRODUCTION
-        elb_subnets: ELB_SUBNETS_PRODUCTION
-        ssl_cert: SSL_CERTIFICATE_ID_PRODUCTION
-        tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_PRODUCTION
-        matomo_site_id: MATOMO_SITE_ID_PRODUCTION
-        matomo_endpoint: MATOMO_ENDPOINT_PRODUCTION
-        mapbox_token: MAPBOX_TOKEN
-        org_name: TM_ORG_NAME
-        org_code: TM_ORG_CODE
-        org_url: TM_ORG_URL
-        org_privacy_policy: TM_ORG_PRIVACY_POLICY
-        org_twitter: TM_ORG_TWITTER
-        org_fb: TM_ORG_FB
-        org_instagram: TM_ORG_INSTAGRAM
-        org_youtube: TM_ORG_YOUTUBE
-        org_github: TM_ORG_GITHUB
-        org_homepage_video_url: TM_HOMEPAGE_VIDEO_URL
-        upload_api_url: TM_IMAGE_UPLOAD_API_URL
-        upload_api_key: TM_IMAGE_UPLOAD_API_KEY
-        user_stats_api_url: TM_USER_STATS_API_URL
-        homepage_stats_api_url: TM_HOMEPAGE_STATS_API_URL
-        sentry_frontend_dsn: TM_SENTRY_FRONTEND_DSN
+        context: tasking-manager-tm4-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,93 +77,6 @@ jobs:
       stack_name:
         description: "the name of the stack for cfn-config"
         type: string
-      environment_name:
-        description: "The environment (staging or production) on AWS"
-        type: enum
-        enum: ["staging", "production"]
-      autoscaling_policy:
-        description: "Setting autoscaling parameters"
-        type: enum
-        enum: ['development', 'demo', 'production']
-      new_relic_license:
-        type: env_var_name
-        default: NEW_RELIC_LICENSE
-      postgres_db:
-        type: env_var_name
-      postgres_password:
-        type: env_var_name
-      postgres_user:
-        type: env_var_name
-      base_url:
-        type: env_var_name
-      app_url:
-        type: env_var_name
-      api_version:
-        type: env_var_name
-      consumer_key:
-        type: env_var_name
-      consumer_secret:
-        type: env_var_name
-      tm_secret:
-        type: env_var_name
-      tm_default_changeset_comment:
-        type: env_var_name
-      email_from_address:
-        type: env_var_name
-      email_contact_address:
-        type: env_var_name
-      smtp_host:
-        type: env_var_name
-      smtp_password:
-        type: env_var_name
-      smtp_user:
-        type: env_var_name
-      smtp_port:
-        type: env_var_name
-      log_dir:
-        type: env_var_name
-      db_size:
-        type: env_var_name
-      elb_subnets:
-        type: env_var_name
-      ssl_cert:
-        type: env_var_name
-      matomo_site_id:
-        type: env_var_name
-      matomo_endpoint:
-        type: env_var_name
-      mapbox_token:
-        type: env_var_name
-      org_name:
-        type: env_var_name
-      org_code:
-        type: env_var_name
-      org_url:
-        type: env_var_name
-      org_privacy_policy:
-        type: env_var_name
-      org_twitter:
-        type: env_var_name
-      org_fb:
-        type: env_var_name
-      org_instagram:
-        type: env_var_name
-      org_youtube:
-        type: env_var_name
-      org_github:
-        type: env_var_name
-      org_homepage_video_url:
-        type: env_var_name
-      log_level:
-        type: enum
-        enum: ["INFO", "DEBUG"]
-        default: "INFO"
-      upload_api_url:
-        type: env_var_name
-      upload_api_key:
-        type: env_var_name
-      sentry_backend_dsn: 
-        type: env_var_name
     working_directory: /home/circleci/tasking-manager
     docker:
     - image: circleci/python:3.7-buster-node
@@ -173,7 +86,7 @@ jobs:
     - run:
         name: Set Environment Variables
         command: |
-          echo "export JSON_CONFIG='{\"GitSha\":\"$CIRCLE_SHA1\", \"NetworkEnvironment\":\"<< parameters.environment_name >>\", \"AutoscalingPolicy\":\"<< parameters.autoscaling_policy >>\", \"DBSnapshot\":\"\", \"DatabaseDump\":\"\", \"NewRelicLicense\":\"${<< parameters.new_relic_license >>}\", \"PostgresDB\":\"${<< parameters.postgres_db >>}\", \"PostgresEndpoint\":\"\", \"PostgresPassword\":\"${<< parameters.postgres_password >>}\", \"PostgresUser\":\"${<< parameters.postgres_user >>}\", \"DatabaseSize\":\"${<< parameters.db_size >>}\",\"ELBSubnets\":\"${<< parameters.elb_subnets >>}\", \"SSLCertificateIdentifier\":\"${<< parameters.ssl_cert >>}\", \"TaskingManagerLogDirectory\":\"${<< parameters.log_dir >>}\", \"TaskingManagerConsumerKey\":\"${<< parameters.consumer_key >>}\",\"TaskingManagerConsumerSecret\":\"${<< parameters.consumer_secret >>}\",\"TaskingManagerSecret\":\"${<< parameters.tm_secret >>}\",\"TaskingManagerLogLevel\":\"<< parameters.log_level >>\",\"TaskingManagerImageUploadAPIURL\":\"${<< parameters.upload_api_url >>}\", \"TaskingManagerImageUploadAPIKey\":\"${<< parameters.upload_api_key >>}\",\"TaskingManagerURL\":\"${<< parameters.app_url >>}\", \"TaskingManagerOrgName\":\"${<< parameters.org_name >>}\", \"TaskingManagerOrgCode\":\"${<< parameters.org_code >>}\", \"SentryBackendDSN\":\"${<< parameters.sentry_backend_dsn >>}\", \"TaskingManagerEmailContactAddress\":\"${<< parameters.email_contact_address >>}\"}'" >> $BASH_ENV
+          echo "export JSON_CONFIG='{\"GitSha\": \"$CIRCLE_SHA1\", \"NetworkEnvironment\": \"${ENVIRONMENT_NAME}\", \"AutoscalingPolicy\": \"${AUTOSCALING_POLICY}\", \"DBSnapshot\": \"\", \"DatabaseDump\": \"\", \"NewRelicLicense\": \"${NEW_RELIC_LICENSE}\", \"PostgresDB\": \"${POSTGRES_DB}\", \"PostgresPassword\": \"${POSTGRES_PASSWORD}\", \"PostgresUser\": \"${<POSTGRES_USER}\", \"DatabaseSize\": \"${DB_SIZE}\", \"ELBSubnets\": \"${ELB_SUBNETS}\", \"SSLCertificateIdentifier\": \"${SSL_CERTIFICATE_ID}\", \"TaskingManagerLogDirectory\": \"${TM_LOG_DIR}\", \"TaskingManagerConsumerKey\": \"${TM_CONSUMER_KEY}\", \"TaskingManagerConsumerSecret\": \"${TM_CONSUMER_SECRET}\", \"TaskingManagerSecret\": \"${TM_SECRET}\", \"TaskingManagerLogLevel\": \"${TM_LOG_LEVEL}\", \"TaskingManagerImageUploadAPIURL\": \"${TM_IMAGE_UPLOAD_API_URL}\", \"TaskingManagerImageUploadAPIKey\": \"${TM_IMAGE_UPLOAD_API_KEY}\", \"TaskingManagerURL\": \"${TM_APP_URL}\", \"TaskingManagerOrgName\": \"${TM_ORG_NAME}\", \"TaskingManagerOrgCode\": \"${TM_ORG_CODE}\", \"SentryBackendDSN\": \"${TM_SENTRY_BACKEND_DSN}\", \"TaskingManagerEmailContactAddress\": \"${TM_EMAIL_CONTACT_ADDRESS}\"}'" >> $BASH_ENV
     - run:
         name: Install modules
         command: |
@@ -298,6 +211,7 @@ jobs:
         name: Deploy Frontend to S3
         command: |
           cd ${CIRCLE_WORKING_DIRECTORY}/frontend/
+          export TM_ENVIRONMENT=<< parameters.stack_name >>
           yarn
           CI=true GENERATE_SOURCEMAP=false yarn build
           aws s3 sync build/ s3://tasking-manager-<< parameters.stack_name >>-react-app --delete
@@ -321,45 +235,7 @@ workflows:
         requires:
           - build
         stack_name: "staging"
-        environment_name: "staging"
-        autoscaling_policy: "development"
-        postgres_db: POSTGRES_DB_STAGING
-        postgres_password: POSTGRES_PASSWORD_STAGING
-        postgres_user: POSTGRES_USER_STAGING
-        base_url: TM_APP_BASE_URL_STAGING
-        app_url: TM_APP_URL_STAGING
-        api_version: TM_APP_API_VERSION_STAGING
-        consumer_key: TM_CONSUMER_KEY_STAGING
-        consumer_secret: TM_CONSUMER_SECRET_STAGING
-        tm_secret: TM_SECRET_STAGING
-        email_from_address: TM_EMAIL_FROM_ADDRESS_STAGING
-        email_contact_address: TM_EMAIL_CONTACT_ADDRESS_STAGING
-        log_level: "INFO"
-        smtp_host: TM_SMTP_HOST_STAGING
-        smtp_password: TM_SMTP_PASSWORD_STAGING
-        smtp_user: TM_SMTP_USER_STAGING
-        smtp_port: TM_SMTP_PORT_STAGING
-        log_dir: TM_LOG_DIR_STAGING
-        db_size: DATABASE_SIZE_STAGING
-        elb_subnets: ELB_SUBNETS_STAGING
-        ssl_cert: SSL_CERTIFICATE_ID_STAGING
-        tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_STAGING
-        matomo_site_id: MATOMO_SITE_ID_STAGING
-        matomo_endpoint: MATOMO_ENDPOINT_STAGING
-        mapbox_token: MAPBOX_TOKEN
-        org_name: TM_ORG_NAME                       #='Humanitarian OpenStreetMap Team'
-        org_code: TM_ORG_CODE                       #=HOT
-        org_url: TM_ORG_URL                         #='hotosm.org' # Don't use http or https
-        org_privacy_policy: TM_ORG_PRIVACY_POLICY   #='hotosm.org/privacy'
-        org_twitter: TM_ORG_TWITTER                 #=http://twitter.com/hotosm/
-        org_fb: TM_ORG_FB                           #=https://www.facebook.com/hotosm
-        org_instagram: TM_ORG_INSTAGRAM             #=https://www.instagram.com/hot.osm/
-        org_youtube: TM_ORG_YOUTUBE                 #=https://www.youtube.com/user/hotosm
-        org_github: TM_ORG_GITHUB                   #=https://github.com/hotosm/
-        org_homepage_video_url: TM_HOMEPAGE_VIDEO_URL #=https://cdn.hotosm.org/tasking-manager/mapping.mp4
-        upload_api_url: TM_IMAGE_UPLOAD_API_URL
-        upload_api_key: TM_IMAGE_UPLOAD_API_KEY
-        sentry_backend_dsn: TM_SENTRY_BACKEND_DSN
+        context: tasking-manager-staging
     - frontend_deploy:
         name: staging
         filters:
@@ -379,45 +255,7 @@ workflows:
         requires:
           - build
         stack_name: "teachosm"
-        environment_name: "production"
-        autoscaling_policy: "demo"
-        postgres_db: POSTGRES_DB_TEACHOSM
-        postgres_password: POSTGRES_PASSWORD_TEACHOSM
-        postgres_user: POSTGRES_USER_TEACHOSM
-        base_url: TM_APP_BASE_URL_TEACHOSM
-        app_url: TM_APP_URL_TEACHOSM
-        api_version: TM_APP_API_VERSION_TEACHOSM
-        consumer_key: TM_CONSUMER_KEY_TEACHOSM
-        consumer_secret: TM_CONSUMER_SECRET_TEACHOSM
-        tm_secret: TM_SECRET_TEACHOSM
-        email_from_address: TM_EMAIL_FROM_ADDRESS_TEACHOSM
-        email_contact_address: TM_EMAIL_CONTACT_ADDRESS_TEACHOSM
-        log_level: "INFO"
-        smtp_host: TM_SMTP_HOST_TEACHOSM
-        smtp_password: TM_SMTP_PASSWORD_TEACHOSM
-        smtp_user: TM_SMTP_USER_TEACHOSM
-        smtp_port: TM_SMTP_PORT_TEACHOSM
-        log_dir: TM_LOG_DIR_TEACHOSM
-        db_size: DATABASE_SIZE_TEACHOSM
-        elb_subnets: ELB_SUBNETS_TEACHOSM
-        ssl_cert: SSL_CERTIFICATE_ID_TEACHOSM
-        tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_TEACHOSM
-        matomo_site_id: MATOMO_SITE_ID_TEACHOSM
-        matomo_endpoint: MATOMO_ENDPOINT_TEACHOSM
-        mapbox_token: MAPBOX_TOKEN
-        org_name: TM_ORG_NAME
-        org_code: TM_ORG_CODE
-        org_url: TM_ORG_URL
-        org_privacy_policy: TM_ORG_PRIVACY_POLICY
-        org_twitter: TM_ORG_TWITTER
-        org_fb: TM_ORG_FB
-        org_instagram: TM_ORG_INSTAGRAM
-        org_youtube: TM_ORG_YOUTUBE
-        org_github: TM_ORG_GITHUB
-        org_homepage_video_url: TM_HOMEPAGE_VIDEO_URL
-        upload_api_url: TM_IMAGE_UPLOAD_API_URL
-        upload_api_key: TM_IMAGE_UPLOAD_API_KEY
-        sentry_backend_dsn: TM_SENTRY_BACKEND_DSN
+        context: tasking-manager-teachosm
     - frontend_deploy:
         name: teachosm
         filters:
@@ -437,45 +275,7 @@ workflows:
         requires:
           - build
         stack_name: "assisted"
-        environment_name: "staging"
-        autoscaling_policy: "demo"
-        postgres_db: POSTGRES_DB_ASSISTED
-        postgres_password: POSTGRES_PASSWORD_ASSISTED
-        postgres_user: POSTGRES_USER_ASSISTED
-        base_url: TM_APP_BASE_URL_ASSISTED
-        app_url: TM_APP_URL_ASSISTED
-        api_version: TM_APP_API_VERSION_ASSISTED
-        consumer_key: TM_CONSUMER_KEY_ASSISTED
-        consumer_secret: TM_CONSUMER_SECRET_ASSISTED
-        tm_secret: TM_SECRET_ASSISTED
-        email_from_address: TM_EMAIL_FROM_ADDRESS_ASSISTED
-        email_contact_address: TM_EMAIL_CONTACT_ADDRESS_ASSISTED
-        log_level: "INFO"
-        smtp_host: TM_SMTP_HOST_ASSISTED
-        smtp_password: TM_SMTP_PASSWORD_ASSISTED
-        smtp_user: TM_SMTP_USER_ASSISTED
-        smtp_port: TM_SMTP_PORT_ASSISTED
-        log_dir: TM_LOG_DIR_ASSISTED
-        db_size: DATABASE_SIZE_ASSISTED
-        elb_subnets: ELB_SUBNETS_ASSISTED
-        ssl_cert: SSL_CERTIFICATE_ID_ASSISTED
-        tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_ASSISTED
-        matomo_site_id: MATOMO_SITE_ID_ASSISTED
-        matomo_endpoint: MATOMO_ENDPOINT_ASSISTED
-        mapbox_token: MAPBOX_TOKEN
-        org_name: TM_ORG_NAME
-        org_code: TM_ORG_CODE
-        org_url: TM_ORG_URL
-        org_privacy_policy: TM_ORG_PRIVACY_POLICY
-        org_twitter: TM_ORG_TWITTER
-        org_fb: TM_ORG_FB
-        org_instagram: TM_ORG_INSTAGRAM
-        org_youtube: TM_ORG_YOUTUBE
-        org_github: TM_ORG_GITHUB
-        org_homepage_video_url: TM_HOMEPAGE_VIDEO_URL
-        upload_api_url: TM_IMAGE_UPLOAD_API_URL
-        upload_api_key: TM_IMAGE_UPLOAD_API_KEY
-        sentry_backend_dsn: TM_SENTRY_BACKEND_DSN
+        context: tasking-manager-assisted
     - frontend_deploy:
         name: assisted
         filters:
@@ -495,45 +295,7 @@ workflows:
             only:
               - deployment/hot-tasking-manager
         stack_name: "tm4-production"
-        environment_name: "production"
-        autoscaling_policy: "production"
-        postgres_db: POSTGRES_DB_PRODUCTION
-        postgres_password: POSTGRES_PASSWORD_PRODUCTION
-        postgres_user: POSTGRES_USER_PRODUCTION
-        base_url: TM_APP_BASE_URL_PRODUCTION
-        app_url: TM_APP_URL_PRODUCTION
-        api_version: TM_APP_API_VERSION_PRODUCTION
-        consumer_key: TM_CONSUMER_KEY_PRODUCTION
-        consumer_secret: TM_CONSUMER_SECRET_PRODUCTION
-        tm_secret: TM_SECRET_PRODUCTION
-        email_from_address: TM_EMAIL_FROM_ADDRESS_PRODUCTION
-        email_contact_address: TM_EMAIL_CONTACT_ADDRESS_PRODUCTION
-        log_level: "INFO"
-        smtp_host: TM_SMTP_HOST_PRODUCTION
-        smtp_password: TM_SMTP_PASSWORD_PRODUCTION
-        smtp_user: TM_SMTP_USER_PRODUCTION
-        smtp_port: TM_SMTP_PORT_PRODUCTION
-        log_dir: TM_LOG_DIR_PRODUCTION
-        db_size: DATABASE_SIZE_PRODUCTION
-        elb_subnets: ELB_SUBNETS_PRODUCTION
-        ssl_cert: SSL_CERTIFICATE_ID_PRODUCTION
-        tm_default_changeset_comment: TM_DEFAULT_CHANGESET_COMMENT_PRODUCTION
-        matomo_site_id: MATOMO_SITE_ID_PRODUCTION
-        matomo_endpoint: MATOMO_ENDPOINT_PRODUCTION
-        mapbox_token: MAPBOX_TOKEN
-        org_name: TM_ORG_NAME
-        org_code: TM_ORG_CODE
-        org_url: TM_ORG_URL
-        org_privacy_policy: TM_ORG_PRIVACY_POLICY
-        org_twitter: TM_ORG_TWITTER
-        org_fb: TM_ORG_FB
-        org_instagram: TM_ORG_INSTAGRAM
-        org_youtube: TM_ORG_YOUTUBE
-        org_github: TM_ORG_GITHUB
-        org_homepage_video_url: TM_HOMEPAGE_VIDEO_URL
-        upload_api_url: TM_IMAGE_UPLOAD_API_URL
-        upload_api_key: TM_IMAGE_UPLOAD_API_KEY
-        sentry_backend_dsn: TM_SENTRY_BACKEND_DSN
+        context: tasking-manager-tm4-production
   frontend-production:
     jobs:
     - frontend_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,9 @@ jobs:
       stack_name:
         description: "the name of the stack for cfn-config"
         type: string
+      gitsha:
+        description: "The 40 char hash of the git commit"
+        type: string
     working_directory: /home/circleci/tasking-manager
     docker:
     - image: circleci/python:3.7-buster-node
@@ -84,14 +87,10 @@ jobs:
     - checkout
     - setup_remote_docker
     - run:
-        name: Set Environment Variables
-        command: |
-          echo "export JSON_CONFIG='{\"GitSha\": \"$CIRCLE_SHA1\", \"NetworkEnvironment\": \"${ENVIRONMENT_NAME}\", \"AutoscalingPolicy\": \"${AUTOSCALING_POLICY}\", \"DBSnapshot\": \"\", \"DatabaseDump\": \"\", \"NewRelicLicense\": \"${NEW_RELIC_LICENSE}\", \"PostgresDB\": \"${POSTGRES_DB}\", \"PostgresPassword\": \"${POSTGRES_PASSWORD}\", \"PostgresUser\": \"${<POSTGRES_USER}\", \"DatabaseSize\": \"${DB_SIZE}\", \"ELBSubnets\": \"${ELB_SUBNETS}\", \"SSLCertificateIdentifier\": \"${SSL_CERTIFICATE_ID}\", \"TaskingManagerLogDirectory\": \"${TM_LOG_DIR}\", \"TaskingManagerConsumerKey\": \"${TM_CONSUMER_KEY}\", \"TaskingManagerConsumerSecret\": \"${TM_CONSUMER_SECRET}\", \"TaskingManagerSecret\": \"${TM_SECRET}\", \"TaskingManagerLogLevel\": \"${TM_LOG_LEVEL}\", \"TaskingManagerImageUploadAPIURL\": \"${TM_IMAGE_UPLOAD_API_URL}\", \"TaskingManagerImageUploadAPIKey\": \"${TM_IMAGE_UPLOAD_API_KEY}\", \"TaskingManagerURL\": \"${TM_APP_URL}\", \"TaskingManagerOrgName\": \"${TM_ORG_NAME}\", \"TaskingManagerOrgCode\": \"${TM_ORG_CODE}\", \"SentryBackendDSN\": \"${TM_SENTRY_BACKEND_DSN}\", \"TaskingManagerEmailContactAddress\": \"${TM_EMAIL_CONTACT_ADDRESS}\"}'" >> $BASH_ENV
-    - run:
         name: Install modules
         command: |
           sudo apt-get update
-          sudo apt-get install -y libgeos-dev # Required for shapely
+          sudo apt-get install -y libgeos-dev jq # Required for shapely
           sudo yarn global add @mapbox/cfn-config @mapbox/cloudfriend
           sudo pip3 install awscli --upgrade
     - run:
@@ -147,15 +146,16 @@ jobs:
             exit 125
           fi
     - run:
-        name: Create config file
+        name: Download config file
         command: |
-          touch $CIRCLE_WORKING_DIRECTORY/cfn-config-<< parameters.stack_name >>.json
-          echo $JSON_CONFIG > $CIRCLE_WORKING_DIRECTORY/cfn-config-<< parameters.stack_name >>.json
+          export GITSHA=<< parameters.gitsha >>
+          aws s3 cp s3://hot-cfn-config/tasking-manager/tasking-manager-<< parameters.stack_name >>-${AWS_REGION}.cfn.json - | jq -c --arg GITSHA "$GITSHA" '.GitSha = $GITSHA' > $CIRCLE_WORKING_DIRECTORY/cfn-config-<< parameters.stack_name >>.json
     - deploy:
         name: Deploy to << parameters.stack_name >>
         command: |
           export NODE_PATH=/usr/local/share/.config/yarn/global/node_modules/
           validate-template $CIRCLE_WORKING_DIRECTORY/scripts/aws/cloudformation/tasking-manager.template.js
+          export JSON_CONFIG="$(cat $CIRCLE_WORKING_DIRECTORY/cfn-config-<< parameters.stack_name >>.json)"
           cfn-config update << parameters.stack_name >> $CIRCLE_WORKING_DIRECTORY/scripts/aws/cloudformation/tasking-manager.template.js -f -c hot-cfn-config -t hot-cfn-config -r $AWS_REGION -p "$JSON_CONFIG"
     - run:
         name: Cleanup
@@ -235,6 +235,7 @@ workflows:
         requires:
           - build
         stack_name: "staging"
+        gitsha: $CIRCLE_SHA1
         context: tasking-manager-staging
     - frontend_deploy:
         name: staging
@@ -246,6 +247,28 @@ workflows:
           - build
         context: tasking-manager-staging
         stack_name: "staging"
+
+    - backend_deploy:
+        name: test
+        filters:
+          branches:
+            only:
+            - fix/sentry-environments
+        requires:
+          - build
+        stack_name: "test"
+        gitsha: $CIRCLE_SHA1
+        context: tasking-manager-staging
+    - frontend_deploy:
+        name: test
+        filters:
+          branches:
+            only:
+            - fix/sentry-environments
+        requires:
+          - build
+        context: tasking-manager-staging
+        stack_name: "test"
     - backend_deploy:
         name: teachosm
         filters:
@@ -255,6 +278,7 @@ workflows:
         requires:
           - build
         stack_name: "teachosm"
+        gitsha: $CIRCLE_SHA1
         context: tasking-manager-teachosm
     - frontend_deploy:
         name: teachosm
@@ -275,6 +299,7 @@ workflows:
         requires:
           - build
         stack_name: "assisted"
+        gitsha: $CIRCLE_SHA1
         context: tasking-manager-assisted
     - frontend_deploy:
         name: assisted
@@ -295,6 +320,7 @@ workflows:
             only:
               - deployment/hot-tasking-manager
         stack_name: "tm4-production"
+        gitsha: $CIRCLE_SHA1
         context: tasking-manager-tm4-production
   frontend-production:
     jobs:


### PR DESCRIPTION
Despite the branch name, the primary feature here is the improvement on the circleci config. Using [contexts](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-context), we simplify the circleci script. The context will be set on CircleCI for each deployment (so far only for staging frontend, hence WIP) removing the need for most of the parameters, except the stack name. CircleCI does not allow us to use the reserved "name" key for the job parameters. 

Incidentally this PR will also fix the missing frontend environment variable for Sentry integration by simplifying the envvar setting. We can use `${STACK_NAME}` for the frontend and backend sentry `environment` parameter. 