### PR TITLE
Remove requests dependencies from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,6 @@ attrs==20.2.0
 black==20.8b1
 bleach==3.2.1
 cachetools==4.1.1
-certifi==2020.6.20
-chardet==3.0.4
 Click==7.1.2
 coverage==5.3
 entrypoints==0.3
@@ -27,7 +25,6 @@ geojson==1.3.4
 glob2==0.7
 greenlet==0.4.17
 gunicorn==20.0.4
-idna==2.10
 itsdangerous==1.1.0
 Jinja2==2.11.2
 Mako==1.1.3
@@ -58,6 +55,5 @@ SQLAlchemy==1.3.19
 text-unidecode==1.3
 toml==0.10.1
 Unidecode==1.1.1
-urllib3==1.25.10
 webencodings==0.5.1
 Werkzeug==0.16.1


### PR DESCRIPTION
Those are [dependencies from requests](https://github.com/psf/requests/blob/master/setup.py#L44-L48) and are automatically installed when we run `pip install`.

How to test:

- uninstall manually those dependencies;
- run pip install -r requirements.txt;
- check on the console that it was installed again;
- run the server and check that everything works normally