### PR TITLE
Set default mapping/validation editors as iD, JOSM and custom

### DIFF
--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -172,8 +172,6 @@ class Project(db.Model):
         default=[
             Editors.ID.value,
             Editors.JOSM.value,
-            Editors.POTLATCH_2.value,
-            Editors.FIELD_PAPERS.value,
             Editors.CUSTOM.value,
         ],
         index=True,
@@ -184,8 +182,6 @@ class Project(db.Model):
         default=[
             Editors.ID.value,
             Editors.JOSM.value,
-            Editors.POTLATCH_2.value,
-            Editors.FIELD_PAPERS.value,
             Editors.CUSTOM.value,
         ],
         index=True,


### PR DESCRIPTION
Remove Potlatch and FieldPapers from the default values, as they are not used often.