### PR TITLE
Load perTaskInstructions in the user locale

### DIFF
--- a/frontend/src/views/taskAction.js
+++ b/frontend/src/views/taskAction.js
@@ -24,20 +24,21 @@ export function ValidateTask({ id }: Object) {
 export function TaskAction({ project, action }: Object) {
   const userDetails = useSelector((state) => state.auth.get('userDetails'));
   const token = useSelector((state) => state.auth.get('token'));
+  const locale = useSelector((state) => state.preferences.locale);
   // eslint-disable-next-line
   const [editor, setEditor] = useQueryParam('editor', StringParam);
   const [tasks, setTasks] = useState([]);
   const [loading, setLoading] = useState(true);
   useEffect(() => {
     if (userDetails.id && token && action && project) {
-      fetchLocalJSONAPI(`users/queries/tasks/locked/details/`, token)
+      fetchLocalJSONAPI(`users/queries/tasks/locked/details/`, token, 'GET', locale)
         .then((res) => {
           setTasks(res.tasks);
           setLoading(false);
         })
         .catch((e) => navigate(`/projects/${project}/tasks/`));
     }
-  }, [action, userDetails.id, token, project]);
+  }, [action, userDetails.id, token, project, locale]);
   if (token) {
     if (loading) {
       return (


### PR DESCRIPTION
**How to test:**
- Edit a project and set the Per Task Instructions in another language apart from English.
- Switch your TM settings to that same language
- Lock a task for mapping or validation

The specific task instructions section should show information on that other language, not in English.


- With TM language in Spanish 🇪🇸 :
![image](https://user-images.githubusercontent.com/666291/98846803-3e76ca00-242e-11eb-9f54-4a3ec9632bd4.png)

- TM in English 🇬🇧 
![image](https://user-images.githubusercontent.com/666291/98846922-61a17980-242e-11eb-8d39-7623412cfbde.png)
