### PR TITLE
Style project edit section checkbox inputs

### DIFF
--- a/frontend/src/components/projectEdit/metadataForm.js
+++ b/frontend/src/components/projectEdit/metadataForm.js
@@ -5,7 +5,8 @@ import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
 import typesMessages from '../messages';
-import { StateContext, styleClasses, handleCheckButton } from '../../views/projectEdit';
+import { StateContext, styleClasses } from '../../views/projectEdit';
+import { CheckBox } from '../formInputs';
 import { ProjectInterests } from './projectInterests';
 import { fetchLocalJSONAPI } from '../../network/genericJSONRequest';
 import { ID_PRESETS } from '../../config/presets';
@@ -41,10 +42,7 @@ export const MetadataForm = () => {
 
   const mapperLevels = ['BEGINNER', 'INTERMEDIATE', 'ADVANCED'];
 
-  const handleMappingTypes = (event) => {
-    let types = projectInfo.mappingTypes;
-
-    types = handleCheckButton(event, types);
+  const handleMappingTypes = (types) => {
     setProjectInfo({ ...projectInfo, mappingTypes: types });
   };
 
@@ -106,17 +104,18 @@ export const MetadataForm = () => {
             <FormattedMessage {...messages.mappingTypes} />*
           </label>
           {elements.map((elm) => (
-            <label className="db pv2">
-              <input
-                className="mr2 h"
-                name="mapping_types"
-                checked={projectInfo.mappingTypes.includes(elm.item)}
-                onChange={handleMappingTypes}
-                type="checkbox"
-                value={elm.item}
-              />
-              <FormattedMessage {...typesMessages[elm.messageId]} />
-            </label>
+            <div className="pv3 pr3" aria-label="mapping_types" key={elm.messageId}>
+              <div className="ph0 pt1 fl" aria-labelledby={elm.messageId}>
+                <CheckBox
+                  activeItems={projectInfo.mappingTypes}
+                  toggleFn={handleMappingTypes}
+                  itemId={elm.item}
+                />
+              </div>
+              <span className="fl pt2 mr1 ph2" id={elm.messageId}>
+                <FormattedMessage {...typesMessages[elm.messageId]} />
+              </span>
+            </div>
           ))}
         </div>
         <div className="w-50 fl">

--- a/frontend/src/components/projectEdit/settingsForm.js
+++ b/frontend/src/components/projectEdit/settingsForm.js
@@ -2,26 +2,22 @@ import React, { useContext } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
-import { SwitchToggle } from '../formInputs';
+import { SwitchToggle, CheckBox } from '../formInputs';
 import { getEditors } from '../../utils/editorsList';
-import { StateContext, styleClasses, handleCheckButton } from '../../views/projectEdit';
+import { StateContext, styleClasses } from '../../views/projectEdit';
 
 export const SettingsForm = ({ languages, defaultLocale }) => {
   const { projectInfo, setProjectInfo } = useContext(StateContext);
 
-  const handleMappingEditors = event => {
-    let editors = projectInfo.mappingEditors;
-    editors = handleCheckButton(event, editors);
+  const handleMappingEditors = (editors) => {
     setProjectInfo({ ...projectInfo, mappingEditors: editors });
   };
 
-  const handleValidationEditors = event => {
-    let editors = projectInfo.validationEditors;
-    editors = handleCheckButton(event, editors);
+  const handleValidationEditors = (editors) => {
     setProjectInfo({ ...projectInfo, validationEditors: editors });
   };
 
-  const updateDefaultLocale = event => {
+  const updateDefaultLocale = (event) => {
     setProjectInfo({ ...projectInfo, defaultLocale: event.target.value });
   };
 
@@ -33,7 +29,7 @@ export const SettingsForm = ({ languages, defaultLocale }) => {
           <FormattedMessage {...messages.language} />
         </label>
         <select name="defaultLocale" onChange={updateDefaultLocale} className="pa2">
-          {languages.map(l => (
+          {languages.map((l) => (
             <option selected={l.code === defaultLocale ? true : false} value={l.code}>
               {l.language} ({l.code})
             </option>
@@ -44,64 +40,68 @@ export const SettingsForm = ({ languages, defaultLocale }) => {
         <label className={styleClasses.labelClass}>
           <FormattedMessage {...messages.mappingEditors} />
         </label>
-        {editors.map(elm => (
-          <label className="db pv2">
-            <input
-              className="mr2"
-              name="mapping_editors"
-              onChange={handleMappingEditors}
-              checked={projectInfo.mappingEditors.includes(elm.value)}
-              type="checkbox"
-              value={elm.value}
-            />
-            {elm.label}
-          </label>
+        {editors.map((elm) => (
+          <div className="pv3 pr3" aria-label="mapping editor" key={elm.value}>
+            <div className="ph0 pt1 fl" aria-labelledby={elm.value}>
+              <CheckBox
+                activeItems={projectInfo.mappingEditors}
+                toggleFn={handleMappingEditors}
+                itemId={elm.value}
+              />
+            </div>
+            <span className="fl pt2 mr1 ph2" id={elm.value}>
+              {elm.label}
+            </span>
+          </div>
         ))}
         {projectInfo.hasOwnProperty('customEditor') && projectInfo.customEditor && (
-          <label className="db pv2">
-            <input
-              className="mr2"
-              name="mapping_editors"
-              onChange={handleMappingEditors}
-              checked={projectInfo.mappingEditors.includes('CUSTOM')}
-              type="checkbox"
-              value={'CUSTOM'}
-            />
-            <FormattedMessage {...messages.customEditor} />
-            <span className="">: {projectInfo.customEditor.name}</span>
-          </label>
+          <div className="pv3 pr3" aria-label="mapping editor">
+            <div className="ph0 pt1 fl" aria-labelledby={'Custom'}>
+              <CheckBox
+                activeItems={projectInfo.mappingEditors}
+                toggleFn={handleMappingEditors}
+                itemId={'CUSTOM'}
+              />
+            </div>
+            <span className="fl dib pt2 mr1 ph2" id={'Custom'}>
+              <FormattedMessage {...messages.customEditor} />
+              <span className="">: {projectInfo.customEditor.name}</span>
+            </span>
+          </div>
         )}
       </div>
       <div className={styleClasses.divClass}>
         <label className={styleClasses.labelClass}>
           <FormattedMessage {...messages.validationEditors} />
         </label>
-        {editors.map(elm => (
-          <label className="db pv2">
-            <input
-              className="mr2"
-              name="validation_editors"
-              onChange={handleValidationEditors}
-              checked={projectInfo.validationEditors.includes(elm.value)}
-              type="checkbox"
-              value={elm.value}
-            />
-            {elm.label}
-          </label>
+        {editors.map((elm) => (
+          <div className="pv3 pr3" aria-label="validation editor" key={elm.value}>
+            <div className="ph0 pt1 fl" aria-labelledby={elm.value}>
+              <CheckBox
+                activeItems={projectInfo.validationEditors}
+                toggleFn={handleValidationEditors}
+                itemId={elm.value}
+              />
+            </div>
+            <span className="fl pt2 mr1 ph2" id={elm.value}>
+              {elm.label}
+            </span>
+          </div>
         ))}
         {projectInfo.hasOwnProperty('customEditor') && projectInfo.customEditor && (
-          <label className="db pv2">
-            <input
-              className="mr2"
-              name="validation_editors"
-              onChange={handleValidationEditors}
-              checked={projectInfo.validationEditors.includes('CUSTOM')}
-              type="checkbox"
-              value={'CUSTOM'}
-            />
-            <FormattedMessage {...messages.customEditor} />
-            <span className="">: {projectInfo.customEditor.name}</span>
-          </label>
+          <div className="pv3 pr3" aria-label="validation editor">
+            <div className="ph0 pt1 fl" aria-labelledby={'Custom'}>
+              <CheckBox
+                activeItems={projectInfo.validationEditors}
+                toggleFn={handleValidationEditors}
+                itemId={'CUSTOM'}
+              />
+            </div>
+            <span className="fl dib pt2 mr1 ph2" id={'Custom'}>
+              <FormattedMessage {...messages.customEditor} />
+              <span className="">: {projectInfo.customEditor.name}</span>
+            </span>
+          </div>
         )}
       </div>
       <div className={styleClasses.divClass}>


### PR DESCRIPTION
**What does this PR do?**
- Styles the checkbox inputs in the Project Edit section to match the ones in the Notifications. 

**Issues:**
Fixes #3799 

**Screenshot:**

- Settings Form: Editors for mapping and validation
<img width="297" alt="checkboxes" src="https://user-images.githubusercontent.com/31903212/98875501-6c3f2b80-248d-11eb-8fd5-472b1cc05958.png">

- Metadata Form: Mapping types
<img width="232" alt="mapping_type" src="https://user-images.githubusercontent.com/31903212/98912167-c1535f80-24d6-11eb-9b3a-c45148b65d5a.png">
