### PR TITLE
Refactor Campaign Service and Campaign static methods

### DIFF
--- a/backend/api/organisations/campaigns.py
+++ b/backend/api/organisations/campaigns.py
@@ -52,7 +52,9 @@ class OrganisationsCampaignsAPI(Resource):
             if OrganisationService.can_user_manage_organisation(
                 organisation_id, token_auth.current_user()
             ):
-                if Campaign.campaign_organisation_exists(campaign_id, organisation_id):
+                if CampaignService.campaign_organisation_exists(
+                    campaign_id, organisation_id
+                ):
                     message = (
                         "Campaign {} is already assigned to organisation {}.".format(
                             campaign_id, organisation_id

--- a/backend/models/postgis/campaign.py
+++ b/backend/models/postgis/campaign.py
@@ -52,66 +52,6 @@ class Campaign(db.Model):
         self.description = dto.description if dto.description else self.description
         db.session.commit()
 
-    @staticmethod
-    def get_all_campaigns() -> CampaignListDTO:
-        query = Campaign.query.order_by(Campaign.name).distinct()
-        campaign_list_dto = CampaignListDTO()
-        for campaign in query:
-            campaign_dto = CampaignDTO()
-            campaign_dto.id = campaign.id
-            campaign_dto.name = campaign.name
-
-            campaign_list_dto.campaigns.append(campaign_dto)
-
-        return campaign_list_dto
-
-    @staticmethod
-    def get_project_campaigns_as_dto(project_id: int) -> CampaignListDTO:
-
-        query = (
-            Campaign.query.join(campaign_projects)
-            .filter(campaign_projects.c.project_id == project_id)
-            .all()
-        )
-        campaign_list_dto = CampaignListDTO()
-        for campaign in query:
-            campaign_dto = CampaignDTO()
-            campaign_dto.id = campaign.id
-            campaign_dto.name = campaign.name
-
-            campaign_list_dto.campaigns.append(campaign_dto)
-
-        return campaign_list_dto
-
-    @staticmethod
-    def campaign_organisation_exists(campaign_id: int, org_id: int):
-        return (
-            Campaign.query.join(campaign_organisations)
-            .filter(
-                campaign_organisations.c.organisation_id == org_id,
-                campaign_organisations.c.campaign_id == campaign_id,
-            )
-            .one_or_none()
-        )
-
-    @staticmethod
-    def get_organisation_campaigns_as_dto(org_id: int) -> CampaignListDTO:
-
-        query = (
-            Campaign.query.join(campaign_organisations)
-            .filter(campaign_organisations.c.organisation_id == org_id)
-            .all()
-        )
-        campaign_list_dto = CampaignListDTO()
-        for campaign in query:
-            campaign_dto = CampaignDTO()
-            campaign_dto.id = campaign.id
-            campaign_dto.name = campaign.name
-
-            campaign_list_dto.campaigns.append(campaign_dto)
-
-        return campaign_list_dto
-
     @classmethod
     def from_dto(cls, dto: CampaignDTO):
         """ Creates new message from DTO """
@@ -133,3 +73,16 @@ class Campaign(db.Model):
         campaign_dto.description = self.description
 
         return campaign_dto
+
+    @staticmethod
+    def campaign_list_as_dto(campaigns: list) -> CampaignListDTO:
+        """ Converts a collection of campaigns into DTO"""
+        campaign_list_dto = CampaignListDTO()
+        for campaign in campaigns:
+            campaign_dto = CampaignDTO()
+            campaign_dto.id = campaign.id
+            campaign_dto.name = campaign.name
+
+            campaign_list_dto.campaigns.append(campaign_dto)
+
+        return campaign_list_dto


### PR DESCRIPTION
**What does this PR do?**
This PR refactors the Campaign and Campaign Service static methods.

**Steps Taken:** 
- Add a new static method in the Organisation Service class to get all the organisations under a campaign
- Add a new static method to convert a collection of campaigns to a List DTO
- Move replicated static methods from the Campaign model to the Campaign Service class
- Refactor methods to make use of newly added ones.

**Some of the URLs to test:**
1) Via Postman. Method: `GET`. 
- `http://127.0.0.1:5000/api/v2/campaigns/`
- `http://127.0.0.1:5000/api/v2/campaigns/<int:campaign_id>/`
- `http://127.0.0.1:5000/api/v2/organisations/<int:organisation_id>/campaigns/`
- `http://127.0.0.1:5000/api/v2/projects/<int:project_id>/campaigns/`
2) Frontend
- `http://localhost:3000/manage/campaigns/`
- `http://localhost:3000/manage/campaigns/<int:campaign_id>`
