### PR TITLE
Add staging-test branch to staging deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,7 @@ workflows:
           branches:
             only:
             - develop
+            - staging-test
         requires:
           - build
         stack_name: "staging"
@@ -243,6 +244,7 @@ workflows:
           branches:
             only:
             - develop
+            - staging-test
         requires:
           - build
         context: tasking-manager-staging


### PR DESCRIPTION
This branch will be useful for testing changes that could affect the server or database performance without merging into `develop`, or for testing infrastructure changes. 

Other than this time, the `staging-test` branch should not generally be merged into `develop` branch. but any feature tested on this branch should be merged upstream to `develop` directly after testing. 