### PR TITLE
[WIP] Encode URI for images in markdown comments

### DIFF
--- a/frontend/src/components/comments/commentInput.js
+++ b/frontend/src/components/comments/commentInput.js
@@ -12,7 +12,8 @@ import { DROPZONE_SETTINGS } from '../../config';
 
 export const CommentInputField = ({ comment, setComment, enableHashtagPaste = false }: Object) => {
   const token = useSelector((state) => state.auth.get('token'));
-  const appendImgToComment = (url) => setComment(`${comment}\n![image](${url})\n`);
+  const appendImgToComment = (url) =>
+    setComment(`${comment}\n![${url.substring(url.lastIndexOf('/') + 1)}](${encodeURI(url)})\n`);
   const [uploadError, uploading, onDrop] = useOnDrop(appendImgToComment);
   const { fileRejections, getRootProps, getInputProps } = useDropzone({
     onDrop,


### PR DESCRIPTION
Fixes #3917. 

I have had some issues with my setup, so I can't test/verify the changes right now. It should be solved tomorrow.
I'll add test cases as soon as my local setup works. As always, add/change/delete anything.

- [x] Encodes the image URL in the task comments markdown (`![alt](url)`)
- [x] Use file name instead of 'image' as alternative text (this gives the user some control over the alternative text, albeit it is unlikely to be useful)
- [ ] Check if any other Dropzone has the same issue.
- [ ] Add test cases
