### PR TITLE
Request users to view task history comments

### DIFF
--- a/frontend/src/components/svgIcons/index.js
+++ b/frontend/src/components/svgIcons/index.js
@@ -72,3 +72,4 @@ export { SidebarIcon } from './sidebar';
 export { QuestionCircleIcon } from './questionCircle';
 export { ChartLineIcon } from './chart';
 export { EditIcon } from './edit';
+export { InfoIcon } from './info';

--- a/frontend/src/components/svgIcons/info.js
+++ b/frontend/src/components/svgIcons/info.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export class InfoIcon extends React.PureComponent {
+  render() {
+    return (
+      <svg class="w1" data-icon="info" viewBox="0 0 32 32" {...this.props}>
+        <title>info icon</title>
+        <path
+          fill="currentColor"
+          d="M16 0 A16 16 0 0 1 16 32 A16 16 0 0 1 16 0 M19 15 L13 15 L13 26 L19 26 z M16 6 A3 3 0 0 0 16 12 A3 3 0 0 0 16 6"
+        />
+      </svg>
+    );
+  }
+}

--- a/frontend/src/components/svgIcons/info.js
+++ b/frontend/src/components/svgIcons/info.js
@@ -3,8 +3,7 @@ import React from 'react';
 export class InfoIcon extends React.PureComponent {
   render() {
     return (
-      <svg class="w1" data-icon="info" viewBox="0 0 32 32" {...this.props}>
-        <title>info icon</title>
+      <svg viewBox="0 0 32 32" {...this.props}>
         <path
           fill="currentColor"
           d="M16 0 A16 16 0 0 1 16 32 A16 16 0 0 1 16 0 M19 15 L13 15 L13 26 L19 26 z M16 6 A3 3 0 0 0 16 12 A3 3 0 0 0 16 6"

--- a/frontend/src/components/taskSelection/action.js
+++ b/frontend/src/components/taskSelection/action.js
@@ -17,6 +17,7 @@ import { TaskHistory } from './taskActivity';
 import { ChangesetCommentTags } from './changesetComment';
 import { useSetProjectPageTitleTag } from '../../hooks/UseMetaTags';
 import { useFetch } from '../../hooks/UseFetch';
+import useReadTaskComments from '../../hooks/useReadTaskComments';
 import { DueDateBox } from '../projectCard/dueDateBox';
 import {
   CompletionTabForMapping,
@@ -37,6 +38,7 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
   const [disabled, setDisable] = useState(false);
   const [taskComment, setTaskComment] = useState('');
   const [selectedStatus, setSelectedStatus] = useState();
+  const [historyTabChecked, setHistoryTabChecked] = useState(false);
   const intl = useIntl();
 
   const activeTask = activeTasks && activeTasks[0];
@@ -47,9 +49,15 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
     `projects/${project.projectId}/tasks/${tasksIds[0]}/`,
     project.projectId && tasksIds && tasksIds.length === 1,
   );
+  const readTaskComments = useReadTaskComments(taskHistory);
 
   const getTaskGpxUrlCallback = useCallback((project, tasks) => getTaskGpxUrl(project, tasks), []);
   const formatImageryUrlCallback = useCallback((imagery) => formatImageryUrl(imagery), []);
+
+  const historyTabSwitch = () => {
+    setHistoryTabChecked(true);
+    setActiveSection('history');
+  };
 
   useEffect(() => {
     if (!editor && projectIsReady && userDetails.defaultEditor && tasks && tasksIds) {
@@ -197,7 +205,7 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
                       className={`pb2 pointer truncate ${
                         activeSection === 'history' && 'bb b--blue-dark'
                       }`}
-                      onClick={() => setActiveSection('history')}
+                      onClick={() => historyTabSwitch()}
                     >
                       <FormattedMessage {...messages.history} />
                       {taskHistory &&
@@ -221,7 +229,8 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
                       <CompletionTabForMapping
                         project={project}
                         tasksIds={tasksIds}
-                        taskHistory={taskHistory}
+                        showReadCommentsAlert={readTaskComments && !historyTabChecked}
+                        historyTabSwitch={historyTabSwitch}
                         taskInstructions={
                           activeTasks && activeTasks.length === 1
                             ? activeTasks[0].perTaskInstructions

--- a/frontend/src/components/taskSelection/action.js
+++ b/frontend/src/components/taskSelection/action.js
@@ -221,6 +221,7 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
                       <CompletionTabForMapping
                         project={project}
                         tasksIds={tasksIds}
+                        taskHistory={taskHistory}
                         taskInstructions={
                           activeTasks && activeTasks.length === 1
                             ? activeTasks[0].perTaskInstructions

--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -15,16 +15,19 @@ import {
   QuestionCircleIcon,
   ChevronRightIcon,
   ChevronDownIcon,
+  InfoIcon,
 } from '../svgIcons';
 import { getEditors } from '../../utils/editorsList';
 import { htmlFromMarkdown } from '../../utils/htmlFromMarkdown';
 import { pushToLocalJSONAPI, fetchLocalJSONAPI } from '../../network/genericJSONRequest';
 import { CommentInputField } from '../comments/commentInput';
 import { useFetchLockedTasks, useClearLockedTasks } from '../../hooks/UseLockedTasks';
+import useReadTaskComments from '../../hooks/useReadTaskComments';
 
 export function CompletionTabForMapping({
   project,
   tasksIds,
+  taskHistory,
   taskInstructions,
   disabled,
   taskComment,
@@ -38,6 +41,7 @@ export function CompletionTabForMapping({
   const radioInput = 'radio-input input-reset pointer v-mid dib h2 w2 mr2 br-100 ba b--blue-light';
   const fetchLockedTasks = useFetchLockedTasks();
   const clearLockedTasks = useClearLockedTasks();
+  const readTaskComments = useReadTaskComments(taskHistory);
 
   const splitTask = () => {
     if (!disabled) {
@@ -103,6 +107,14 @@ export function CompletionTabForMapping({
         >
           {(close) => <UnsavedMapChangesModalContent close={close} action={showMapChangesModal} />}
         </Popup>
+      )}
+      {readTaskComments && (
+        <div class="flex items-center justify-center pa1 mb1 bg-grey-light blue-grey">
+          <InfoIcon />
+          <span class="ml2 fw1 pa1">
+            <FormattedMessage {...messages.readTaskComments} />
+          </span>
+        </div>
       )}
       <div className="cf">
         {taskInstructions && <TaskSpecificInstructions instructions={taskInstructions} />}

--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -22,12 +22,12 @@ import { htmlFromMarkdown } from '../../utils/htmlFromMarkdown';
 import { pushToLocalJSONAPI, fetchLocalJSONAPI } from '../../network/genericJSONRequest';
 import { CommentInputField } from '../comments/commentInput';
 import { useFetchLockedTasks, useClearLockedTasks } from '../../hooks/UseLockedTasks';
-import useReadTaskComments from '../../hooks/useReadTaskComments';
 
 export function CompletionTabForMapping({
   project,
   tasksIds,
-  taskHistory,
+  showReadCommentsAlert,
+  historyTabSwitch,
   taskInstructions,
   disabled,
   taskComment,
@@ -41,7 +41,6 @@ export function CompletionTabForMapping({
   const radioInput = 'radio-input input-reset pointer v-mid dib h2 w2 mr2 br-100 ba b--blue-light';
   const fetchLockedTasks = useFetchLockedTasks();
   const clearLockedTasks = useClearLockedTasks();
-  const readTaskComments = useReadTaskComments(taskHistory);
 
   const splitTask = () => {
     if (!disabled) {
@@ -108,9 +107,9 @@ export function CompletionTabForMapping({
           {(close) => <UnsavedMapChangesModalContent close={close} action={showMapChangesModal} />}
         </Popup>
       )}
-      {readTaskComments && (
-        <div class="flex items-center justify-center pa1 mb1 bg-grey-light blue-grey">
-          <InfoIcon />
+      {showReadCommentsAlert && (
+        <div class="tc pa2 mb1 bg-grey-light blue-dark pointer" onClick={() => historyTabSwitch()}>
+          <InfoIcon className="v-mid h1 w1" />
           <span class="ml2 fw1 pa1">
             <FormattedMessage {...messages.readTaskComments} />
           </span>

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -303,6 +303,10 @@ export default defineMessages({
     id: 'project.tasks.filter.noTasksFound',
     defaultMessage: 'No tasks were found.',
   },
+  readTaskComments: {
+    id: 'project.tasks.readComments',
+    defaultMessage: 'Please check history for relevant task comments.',
+  },
   completion: {
     id: 'project.tasks.action.completion',
     defaultMessage: 'Completion',

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -305,7 +305,7 @@ export default defineMessages({
   },
   readTaskComments: {
     id: 'project.tasks.readComments',
-    defaultMessage: 'Please check history for relevant task comments.',
+    defaultMessage: 'Please check the history tab for relevant comments.',
   },
   completion: {
     id: 'project.tasks.action.completion',

--- a/frontend/src/hooks/tests/useReadTaskComments.test.js
+++ b/frontend/src/hooks/tests/useReadTaskComments.test.js
@@ -1,0 +1,29 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { invalidatedTaskHistory, history } from '../../network/tests/mockData/taskHistory';
+import useReadTaskComments from '../useReadTaskComments';
+
+describe('test useReadTaskComments hook', () => {
+  it('returns false when there is no task history', () => {
+    const { result } = renderHook(() => useReadTaskComments({}));
+    const readTaskComments = result.current;
+    expect(readTaskComments).toBe(false);
+  });
+
+  it('returns false if task has not been previously invalidated', () => {
+    const { result } = renderHook(() => useReadTaskComments(history));
+    const readTaskComments = result.current;
+    expect(readTaskComments).toBe(false);
+  });
+
+  it('returns false if task history does not have comments', () => {
+    const { result } = renderHook(() => useReadTaskComments(history));
+    const readTaskComments = result.current;
+    expect(readTaskComments).toBe(false);
+  });
+
+  it('returns true if was invalidated and has comments', () => {
+    const { result } = renderHook(() => useReadTaskComments(invalidatedTaskHistory));
+    const readTaskComments = result.current;
+    expect(readTaskComments).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useReadTaskComments.js
+++ b/frontend/src/hooks/useReadTaskComments.js
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+const useReadTaskComments = (history) => {
+  const [readTaskComments, setReadTaskComments] = useState(false);
+
+  useEffect(() => {
+    if (history && history.taskHistory && history.taskHistory.length > 1) {
+      const invalidatedTaskHistory = history.taskHistory.filter(
+        (task) => task.actionText === 'INVALIDATED',
+      );
+      const taskComments = history.taskHistory.filter((task) => task.action === 'COMMENT');
+
+      if (invalidatedTaskHistory.length > 0 && taskComments.length > 0) {
+        setReadTaskComments(true);
+      }
+    }
+  }, [history]);
+  return readTaskComments;
+};
+
+export default useReadTaskComments;

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -572,7 +572,7 @@
   "project.tasks.filter.readyToValidate": "Ready for validation",
   "project.tasks.filter.readyToMap": "Available for mapping",
   "project.tasks.filter.noTasksFound": "No tasks were found.",
-  "project.tasks.readComments": "Please check history for relevant task comments.",
+  "project.tasks.readComments": "Please check the history tab for relevant comments.",
   "project.tasks.action.completion": "Completion",
   "project.tasks.action.history": "History",
   "project.tasks.action.finish_mapping.title": "Once you have finished mapping",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -572,6 +572,7 @@
   "project.tasks.filter.readyToValidate": "Ready for validation",
   "project.tasks.filter.readyToMap": "Available for mapping",
   "project.tasks.filter.noTasksFound": "No tasks were found.",
+  "project.tasks.readComments": "Please check history for relevant task comments.",
   "project.tasks.action.completion": "Completion",
   "project.tasks.action.history": "History",
   "project.tasks.action.finish_mapping.title": "Once you have finished mapping",

--- a/frontend/src/network/tests/mockData/taskHistory.js
+++ b/frontend/src/network/tests/mockData/taskHistory.js
@@ -42,3 +42,28 @@ export const history = {
     },
   ],
 };
+
+export const invalidatedTaskHistory = {
+  taskHistory: [
+    {
+      historyId: 12001,
+      taskId: 1,
+      action: 'COMMENT',
+      actionText: 'More buildings need to be mapped',
+      actionDate: '2020-10-04T14:35:30.174515Z',
+      actionBy: 'test_user',
+      pictureUrl: null,
+      issues: null,
+    },
+    {
+      historyId: 12000,
+      taskId: 1,
+      action: 'STATE_CHANGE',
+      actionText: 'INVALIDATED',
+      actionDate: '2020-10-04T14:35:20.174515Z',
+      actionBy: 'test_user',
+      pictureUrl: null,
+      issues: null,
+    },
+  ],
+};


### PR DESCRIPTION
What does this PR do?
Resolves #3507 

Steps taken:
- Create a custom hook for conditional render of request to read comments if the task was previously invalidated and has comments to guide the mapper.

Screenshot:
<img width="421" alt="Screenshot 2020-12-13 at 15 54 50" src="https://user-images.githubusercontent.com/31903212/102015574-865e7900-3d6d-11eb-8f76-6ffebfd067d6.png">



