### PR TITLE
Allow users to filter task history comments and state changes

### DIFF
--- a/frontend/src/components/formInputs.js
+++ b/frontend/src/components/formInputs.js
@@ -110,7 +110,7 @@ export function UserCountrySelect({ className }: Object) {
   );
 }
 
-const CheckBoxInput = ({ isActive, changeState, className = '' }) => (
+export const CheckBoxInput = ({ isActive, changeState, className = '' }) => (
   <div
     role="checkbox"
     aria-checked={isActive}

--- a/frontend/src/components/taskSelection/action.js
+++ b/frontend/src/components/taskSelection/action.js
@@ -222,7 +222,7 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
                   )}
                 </div>
               </div>
-              <div className="pt3">
+              <div className="pt1">
                 {activeSection === 'completion' && (
                   <>
                     {action === 'MAPPING' && (
@@ -308,6 +308,7 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
                     projectId={project.projectId}
                     taskId={tasksIds[0]}
                     commentPayload={taskHistory}
+                    mapperLevel={userDetails['mappingLevel']}
                   />
                 )}
               </div>

--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -108,9 +108,12 @@ export function CompletionTabForMapping({
         </Popup>
       )}
       {showReadCommentsAlert && (
-        <div class="tc pa2 mb1 bg-grey-light blue-dark pointer" onClick={() => historyTabSwitch()}>
+        <div
+          className="tc pa2 mb1 bg-grey-light blue-dark pointer"
+          onClick={() => historyTabSwitch()}
+        >
           <InfoIcon className="v-mid h1 w1" />
-          <span class="ml2 fw1 pa1">
+          <span className="ml2 fw1 pa1">
             <FormattedMessage {...messages.readTaskComments} />
           </span>
         </div>

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -321,7 +321,7 @@ export default defineMessages({
   },
   taskStateChanges: {
     id: 'project.tasks.history.stateChanges',
-    defaultMessage: 'Task Changes',
+    defaultMessage: 'Activities',
   },
   finishMappingTitle: {
     id: 'project.tasks.action.finish_mapping.title',

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -315,6 +315,14 @@ export default defineMessages({
     id: 'project.tasks.action.history',
     defaultMessage: 'History',
   },
+  taskComments: {
+    id: 'project.tasks.history.comments',
+    defaultMessage: 'Comments',
+  },
+  taskStateChanges: {
+    id: 'project.tasks.history.stateChanges',
+    defaultMessage: 'Task Changes',
+  },
   finishMappingTitle: {
     id: 'project.tasks.action.finish_mapping.title',
     defaultMessage: 'Once you have finished mapping',

--- a/frontend/src/components/taskSelection/taskActivity.js
+++ b/frontend/src/components/taskSelection/taskActivity.js
@@ -63,9 +63,10 @@ const PostComment = ({ projectId, taskId, setCommentPayload }) => {
 export const TaskHistory = ({ projectId, taskId, commentPayload, mapperLevel }) => {
   const token = useSelector((state) => state.auth.get('token'));
   const [history, setHistory] = useState([]);
-  const [showTaskComments, setShowTaskComments] = useState(false);
+  const taskChangeSetting = mapperLevel === 'BEGINNER' ? false : true;
+  const [showTaskComments, setShowTaskComments] = useState(true);
   const [taskComments, setTaskComments] = useState([]);
-  const [showTaskChanges, setShowTaskChanges] = useState(false);
+  const [showTaskChanges, setShowTaskChanges] = useState(taskChangeSetting);
   const [taskChanges, setTaskChanges] = useState([]);
   const [shownHistory, setShownHistory] = useState([]);
 
@@ -94,11 +95,6 @@ export const TaskHistory = ({ projectId, taskId, commentPayload, mapperLevel }) 
   }, [projectId, taskId, token, commentPayload, getTaskInfo]);
 
   useEffect(() => {
-    // automatically show comments for beginner mappers
-    if (mapperLevel === 'BEGINNER') {
-      setShowTaskComments(true);
-    }
-
     if (showTaskComments && showTaskChanges) {
       setShownHistory(history);
     } else if (showTaskComments) {
@@ -166,7 +162,7 @@ export const TaskHistory = ({ projectId, taskId, commentPayload, mapperLevel }) 
   } else {
     return (
       <>
-        <div className="pb4" aria-label="view task history options">
+        <div className="ml3 pl1 pb4" aria-label="view task history options">
           <div className="pt1 fl" aria-labelledby="comments">
             <CheckBoxInput
               isActive={showTaskComments}


### PR DESCRIPTION
**What does this PR do?** 
Resolves #3977 

**Screenshots:**

- Comments only
<img width="403" alt="Screenshot 2020-12-22 at 03 11 57" src="https://user-images.githubusercontent.com/31903212/102834101-1f436300-4404-11eb-972d-1f59a643d86c.png">


- State Changes only
<img width="374" alt="Screenshot 2020-12-22 at 03 11 48" src="https://user-images.githubusercontent.com/31903212/102834086-15216480-4404-11eb-93ca-f62d612e3f21.png">
