### PR TITLE
Add Docker support for additional frontend parameters

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -25,6 +25,8 @@ services:
       dockerfile: "./scripts/docker/Dockerfile.frontend"
       args:
         - TM_APP_API_URL=http://localhost/api
+        - TM_IMPORT_MAX_FILESIZE=1000000
+        - TM_MAX_AOI_AREA=5000
     volumes:
       - ".:/usr/src/app"
     labels:

--- a/scripts/docker/Dockerfile.frontend
+++ b/scripts/docker/Dockerfile.frontend
@@ -7,6 +7,8 @@ COPY frontend .
 RUN npm install
 
 ARG TM_APP_API_URL=http://localhost/api
+ARG TM_IMPORT_MAX_FILESIZE=1000000
+ARG TM_MAX_AOI_AREA=5000
 
 # SERVE
 RUN npm run build

--- a/scripts/docker/Dockerfile.frontend_development
+++ b/scripts/docker/Dockerfile.frontend_development
@@ -20,6 +20,8 @@ COPY --from=base /usr/src/app/frontend /usr/src/app
 RUN npm install
 
 ARG TM_APP_API_URL=http://localhost/api
+ARG TM_IMPORT_MAX_FILESIZE=1000000
+ARG TM_MAX_AOI_AREA=5000
 
 # SERVE
 CMD ["npm", "start"]


### PR DESCRIPTION
Fix #4009.

Docker does not support the `env_file` parameter at build time, so the variables have been copied like it has been done with `TM_APP_API_URL` and the defaults too. It is a bit redundant and setting those frontend arguments in `tasking-manager.env` has no effect. This PR does not change how those variables are handled in the Docker frontend, it just adds two more to allow the user to set them.

To avoid such kind of redundancy, it would be enough to rename `tasking-manager.env` as `.env`, but that would be a major change which is out of the scope of this PR.