### PR TITLE
Order task history by action_date instead of id

### DIFF
--- a/backend/models/postgis/task.py
+++ b/backend/models/postgis/task.py
@@ -509,7 +509,7 @@ class Task(db.Model):
 
     # Mapped objects
     task_history = db.relationship(
-        TaskHistory, cascade="all", order_by=desc(TaskHistory.id)
+        TaskHistory, cascade="all", order_by=desc(TaskHistory.action_date)
     )
     task_annotations = db.relationship(TaskAnnotation, cascade="all")
     lock_holder = db.relationship(User, foreign_keys=[locked_by])


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/666291/103216433-d0f6fe00-48f4-11eb-9162-bd500f0eefc3.png)

The task history was ordered by id, what lead to errors sometimes. Link: https://tasking-manager-tm4-production-api.hotosm.org/api/v2/projects/9507/tasks/1832/