### PR TITLE
Ensure mappers receive notifications on project chat

### DIFF
--- a/backend/services/messaging/message_service.py
+++ b/backend/services/messaging/message_service.py
@@ -239,6 +239,7 @@ class MessageService:
             user_from = User.query.get(comment_from)
             if user_from is None:
                 raise ValueError("Username not found")
+            user_link = MessageService.get_user_link(user_from.username)
 
             task_link = MessageService.get_task_link(project_id, task_id)
             messages = []
@@ -258,7 +259,9 @@ class MessageService:
                 message.from_user_id = comment_from
                 message.task_id = task_id
                 message.to_user_id = user.id
-                message.subject = f"{user_from.username} left a comment in {task_link} of Project {project_id}"
+                message.subject = (
+                    f"{user_link} left a comment in {task_link} of Project {project_id}"
+                )
                 message.message = comment
                 messages.append(dict(message=message, user=user))
 
@@ -419,6 +422,8 @@ class MessageService:
             users_to_notify = list(set(contributed_users + favorited_users))
 
             if len(users_to_notify) != 0:
+                from_user = User.query.get(chat_from)
+                from_user_link = MessageService.get_user_link(from_user.username)
                 project_link = MessageService.get_project_link(
                     project_id, include_chat_section=True
                 )
@@ -427,14 +432,15 @@ class MessageService:
                     try:
                         user = UserService.get_user_dto_by_id(user_id)
                     except NotFound:
-                        print("User not found")
                         continue  # If we can't find the user, keep going no need to fail
                     message = Message()
                     message.message_type = MessageType.PROJECT_CHAT_NOTIFICATION.value
                     message.project_id = project_id
                     message.from_user_id = chat_from
                     message.to_user_id = user.id
-                    message.subject = f"{chat_from} left a comment in {project_link}"
+                    message.subject = (
+                        f"{from_user_link} left a comment in {project_link}"
+                    )
                     message.message = chat
                     messages.append(dict(message=message, user=user))
 

--- a/backend/services/messaging/message_service.py
+++ b/backend/services/messaging/message_service.py
@@ -401,7 +401,9 @@ class MessageService:
                 MessageService._push_messages(messages)
 
             query = """ select user_id from project_favorites where project_id = :project_id"""
-            favorited_users_results = db.engine.execute(text(query), project_id=project_id)
+            favorited_users_results = db.engine.execute(
+                text(query), project_id=project_id
+            )
             favorited_users = [r[0] for r in favorited_users_results]
 
             # Notify all contributors except the user that created the comment.
@@ -435,7 +437,7 @@ class MessageService:
                     message.subject = f"{chat_from} left a comment in {project_link}"
                     message.message = chat
                     messages.append(dict(message=message, user=user))
-   
+
                 # it's important to keep that line inside the if to avoid duplicated emails
                 MessageService._push_messages(messages)
 

--- a/backend/services/messaging/message_service.py
+++ b/backend/services/messaging/message_service.py
@@ -181,6 +181,7 @@ class MessageService:
                 message["message"].id,
                 UserService.get_user_by_id(message["message"].from_user_id).username,
                 message["message"].project_id,
+                message["message"].task_id,
                 clean_html(message["message"].subject),
                 message["message"].message,
                 obj.message_type,
@@ -375,58 +376,66 @@ class MessageService:
         app = create_app()
         with app.app_context():
             usernames = MessageService._parse_message_for_username(chat, project_id)
-            if len(usernames) == 0:
-                return  # Nobody @'d so return
-
-            link = MessageService.get_project_link(
-                project_id, include_chat_section=True
-            )
-
-            messages = []
-            for username in usernames:
-                current_app.logger.debug(f"Searching for {username}")
-                try:
-                    user = UserService.get_user_by_username(username)
-                except NotFound:
-                    current_app.logger.error(f"Username {username} not found")
-                    continue  # If we can't find the user, keep going no need to fail
-
-                message = Message()
-                message.message_type = MessageType.MENTION_NOTIFICATION.value
-                message.project_id = project_id
-                message.from_user_id = chat_from
-                message.to_user_id = user.id
-                message.subject = f"You were mentioned in {link} chat"
-                message.message = chat
-                messages.append(dict(message=message, user=user))
-
-            MessageService._push_messages(messages)
-
-            query = """ select user_id from project_favorites where project_id = :project_id"""
-            result = db.engine.execute(text(query), project_id=project_id)
-            favorited_users = [r[0] for r in result]
-
-            if len(favorited_users) != 0:
-                project_link = MessageService.get_project_link(
+            if len(usernames) != 0:
+                link = MessageService.get_project_link(
                     project_id, include_chat_section=True
                 )
-                # project_title = ProjectService.get_project_title(project_id)
                 messages = []
-                for user_id in favorited_users:
-
+                for username in usernames:
+                    current_app.logger.debug(f"Searching for {username}")
                     try:
-                        user = UserService.get_user_dto_by_id(user_id)
+                        user = UserService.get_user_by_username(username)
                     except NotFound:
+                        current_app.logger.error(f"Username {username} not found")
                         continue  # If we can't find the user, keep going no need to fail
 
                     message = Message()
+                    message.message_type = MessageType.MENTION_NOTIFICATION.value
+                    message.project_id = project_id
+                    message.from_user_id = chat_from
+                    message.to_user_id = user.id
+                    message.subject = f"You were mentioned in {link} chat"
+                    message.message = chat
+                    messages.append(dict(message=message, user=user))
+
+                MessageService._push_messages(messages)
+
+            query = """ select user_id from project_favorites where project_id = :project_id"""
+            favorited_users_results = db.engine.execute(text(query), project_id=project_id)
+            favorited_users = [r[0] for r in favorited_users_results]
+
+            # Notify all contributors except the user that created the comment.
+            contributed_users_results = (
+                TaskHistory.query.with_entities(TaskHistory.user_id.distinct())
+                .filter(TaskHistory.project_id == project_id)
+                .filter(TaskHistory.user_id != chat_from)
+                .filter(TaskHistory.action == TaskAction.STATE_CHANGE.name)
+                .all()
+            )
+            contributed_users = [r[0] for r in contributed_users_results]
+
+            users_to_notify = list(set(contributed_users + favorited_users))
+
+            if len(users_to_notify) != 0:
+                project_link = MessageService.get_project_link(
+                    project_id, include_chat_section=True
+                )
+                messages = []
+                for user_id in users_to_notify:
+                    try:
+                        user = UserService.get_user_dto_by_id(user_id)
+                    except NotFound:
+                        print("User not found")
+                        continue  # If we can't find the user, keep going no need to fail
+                    message = Message()
                     message.message_type = MessageType.PROJECT_CHAT_NOTIFICATION.value
                     message.project_id = project_id
+                    message.from_user_id = chat_from
                     message.to_user_id = user.id
                     message.subject = f"{chat_from} left a comment in {project_link}"
                     message.message = chat
                     messages.append(dict(message=message, user=user))
-
+   
                 # it's important to keep that line inside the if to avoid duplicated emails
                 MessageService._push_messages(messages)
 

--- a/backend/services/messaging/smtp_service.py
+++ b/backend/services/messaging/smtp_service.py
@@ -52,6 +52,7 @@ class SMTPService:
         message_id: int,
         from_username: str,
         project_id: int,
+        task_id: int,
         subject: str,
         content: str,
         message_type: int,
@@ -60,6 +61,7 @@ class SMTPService:
         current_app.logger.debug(f"Test if email required {to_address}")
         from_user_link = f"{current_app.config['APP_BASE_URL']}/users/{from_username}"
         project_link = f"{current_app.config['APP_BASE_URL']}/projects/{project_id}"
+        task_link = f"{current_app.config['APP_BASE_URL']}/projects/{project_id}/tasks/?search={task_id}"
         settings_url = "{}/settings#notifications".format(
             current_app.config["APP_BASE_URL"]
         )
@@ -76,6 +78,8 @@ class SMTPService:
             "FROM_USERNAME": from_username,
             "PROJECT_LINK": project_link,
             "PROJECT_ID": str(project_id) if project_id is not None else None,
+            "TASK_LINK": task_link,
+            "TASK_ID": str(task_id) if task_id is not None else None,
             "PROFILE_LINK": inbox_url,
             "SETTINGS_LINK": settings_url,
             "CONTENT": format_username_link(content),

--- a/backend/services/messaging/templates/message_alert_en.html
+++ b/backend/services/messaging/templates/message_alert_en.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-  {% if values['MESSAGE_TYPE'] in [3, 8, 9] %}
+  {% if values['MESSAGE_TYPE'] == 3 %}
     <p style="font-size: 14px; font-weight: 600"><a style="color: #d73f3f" href="{{values['FROM_USER_LINK']}}">@{{values['FROM_USERNAME']}}</a> mentioned you in a comment on <a style="color: #d73f3f" href="{{values['PROJECT_LINK']}}">Project {{values['PROJECT_ID']}}</a>:</p>
   {% endif %}
   {% if values['MESSAGE_TYPE'] == 4 %}
@@ -8,6 +8,12 @@
   {% endif %}
   {% if values['MESSAGE_TYPE'] == 5 %}
     <p style="font-size: 14px; font-weight: 600">Task on <a style="color: #d73f3f" href="{{values['PROJECT_LINK']}}">Project {{values['PROJECT_ID']}}</a> needs more mapping:</p>
+  {% endif %}
+  {% if values['MESSAGE_TYPE'] == 8 %}
+    <p style="font-size: 14px; font-weight: 600"><a style="color: #d73f3f" href="{{values['FROM_USER_LINK']}}">@{{values['FROM_USERNAME']}}</a> left a comment on <a style="color: #d73f3f" href="{{values['TASK_LINK']}}">Task {{values['TASK_ID']}}</a> in <a style="color: #d73f3f" href="{{values['PROJECT_LINK']}}">Project {{values['PROJECT_ID']}}</a>:</p>
+  {% endif %}
+  {% if values['MESSAGE_TYPE'] == 9 %}
+    <p style="font-size: 14px; font-weight: 600"><a style="color: #d73f3f" href="{{values['FROM_USER_LINK']}}">@{{values['FROM_USERNAME']}}</a> left a comment on <a style="color: #d73f3f" href="{{values['PROJECT_LINK']}}">Project {{values['PROJECT_ID']}}</a>:</p>
   {% endif %}
   <p>
     {{ values['CONTENT']|safe }}


### PR DESCRIPTION
* Modified `send_message_after_chat` to send messages to contributed and favorited users of a project when a comment is left in project chat
* Improved `send_message_after_chat` function to continue sending messages even if there are no usernames mentioned
* Updated the html message template

![image](https://user-images.githubusercontent.com/12103383/103496971-1f148000-4e66-11eb-9186-41b66bcd9f31.png)
![image](https://user-images.githubusercontent.com/12103383/103496979-26d42480-4e66-11eb-8f1b-2308c6df6f09.png)
