### PR TITLE
Add condition for custom URL in cfn template

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -114,7 +114,9 @@ const Parameters = {
   },
   TaskingManagerURL: {
     Description: 'URL for setting CNAME in Distribution; Ex: example.hotosm.org',
-    Type: 'String'
+    Type: 'String',
+    AllowedPattern: '^([a-zA-Z0-9-]*\\.){2}(\\w){2,20}$',
+    ConstraintDescription: 'Parameter must be in the form of a url with subdomain.'
   },
   TaskingManagerOrgName: {
     Description: 'Org Name',
@@ -134,7 +136,10 @@ const Conditions = {
   UseASnapshot: cf.notEquals(cf.ref('DBSnapshot'), ''),
   DatabaseDumpFileGiven: cf.notEquals(cf.ref('DatabaseDump'), ''),
   IsTaskingManagerProduction: cf.equals(cf.ref('AutoscalingPolicy'), 'production'),
-  IsTaskingManagerDemo: cf.equals(cf.ref('AutoscalingPolicy'), 'Demo (max 3)')
+  IsTaskingManagerDemo: cf.equals(cf.ref('AutoscalingPolicy'), 'Demo (max 3)'),
+  IsHOTOSMUrl: cf.equals(
+    cf.select('1', cf.split('.', cf.ref('TaskingManagerURL')))
+    , 'hotosm')
 };
 
 const Resources = {
@@ -708,6 +713,7 @@ const Resources = {
   },
   TaskingManagerRoute53: {
     Type: 'AWS::Route53::RecordSet',
+    Condition: 'IsHOTOSMUrl',
     Properties: {
       Name: cf.ref('TaskingManagerURL'),
       Type: 'A',


### PR DESCRIPTION
In order to allow for non-hotosm urls (such as tasks.teachosm.org) in the cfn template, we add a condition for the url parameter to check if its a hotosm.org domain. We will not create the Route53 record in the case that it is an external url. 

In this case currently it only works when we also control the ssl certificate in ACM, so it is not fully generalized. that should come with future development. 

@willemarcel I would like to test this with `staging-test` before merging. 