### PR TITLE
Correct the setup documentation in example.env

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,6 +1,6 @@
 # Tasking Manager configuration file
 
-# Copy to `example.env` and adjust to make it work!
+# Copy to `tasking-manager.env` and adjust to make it work!
 #
 
 # The TM_APP_BASE_URL defines the URL of the frontend and is used by the backend


### PR DESCRIPTION
It looks like the rest of the app is looking for "tasking-manager.env", but the comment in the env file says "Copy to 'example.env'".