### PR TITLE
Pointing out that email won't send without a from address

### DIFF
--- a/example.env
+++ b/example.env
@@ -113,11 +113,13 @@ POSTGRES_PASSWORD=tm
 # POSTGRES_PORT=5432
 
 
-# The address to use as the sender on auto generated emails (optional)
+# The address to use as the sender on auto generated emails
+# (optional, but required to send email)
 #
 # TM_EMAIL_FROM_ADDRESS=noreply@localhost
 
 # The address to use as the receiver in contact form.
+#
 # TM_EMAIL_CONTACT_ADDRESS=sysadmin@localhost
 
 # Email sending server configuration (optional)


### PR DESCRIPTION
Noticed that without setting this variable the system won't send email, so I made its status a bit more clear.