### PR TITLE
Hide the option to mark task as BADIMAGERY if it was previously reverted

### DIFF
--- a/frontend/src/components/taskSelection/action.js
+++ b/frontend/src/components/taskSelection/action.js
@@ -17,7 +17,8 @@ import { TaskHistory } from './taskActivity';
 import { ChangesetCommentTags } from './changesetComment';
 import { useSetProjectPageTitleTag } from '../../hooks/UseMetaTags';
 import { useFetch } from '../../hooks/UseFetch';
-import useReadTaskComments from '../../hooks/useReadTaskComments';
+import { useReadTaskComments } from '../../hooks/UseReadTaskComments';
+import { useDisableBadImagery } from '../../hooks/UseDisableBadImagery';
 import { DueDateBox } from '../projectCard/dueDateBox';
 import {
   CompletionTabForMapping,
@@ -57,6 +58,7 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
   );
 
   const readTaskComments = useReadTaskComments(taskHistory);
+  const disableBadImagery = useDisableBadImagery(taskHistory);
 
   const getTaskGpxUrlCallback = useCallback((project, tasks) => getTaskGpxUrl(project, tasks), []);
   const formatImageryUrlCallback = useCallback((imagery) => formatImageryUrl(imagery), []);
@@ -221,6 +223,9 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
                         project={project}
                         tasksIds={tasksIds}
                         showReadCommentsAlert={readTaskComments && !historyTabChecked}
+                        disableBadImagery={
+                          userDetails.mappingLevel !== 'ADVANCED' && disableBadImagery
+                        }
                         historyTabSwitch={historyTabSwitch}
                         taskInstructions={
                           activeTasks && activeTasks.length === 1

--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -27,6 +27,7 @@ export function CompletionTabForMapping({
   project,
   tasksIds,
   showReadCommentsAlert,
+  disableBadImagery,
   historyTabSwitch,
   taskInstructions,
   disabled,
@@ -162,19 +163,21 @@ export function CompletionTabForMapping({
             <FormattedMessage {...messages.incomplete} />
           </label>
         </p>
-        <p>
-          <input
-            id="BADIMAGERY"
-            type="radio"
-            value="BADIMAGERY"
-            className={radioInput}
-            checked={selectedStatus === 'BADIMAGERY'}
-            onClick={() => setSelectedStatus('BADIMAGERY')}
-          />
-          <label htmlFor="BADIMAGERY">
-            <FormattedMessage {...messages.badImagery} />
-          </label>
-        </p>
+        {!disableBadImagery && (
+          <p>
+            <input
+              id="BADIMAGERY"
+              type="radio"
+              value="BADIMAGERY"
+              className={radioInput}
+              checked={selectedStatus === 'BADIMAGERY'}
+              onClick={() => setSelectedStatus('BADIMAGERY')}
+            />
+            <label htmlFor="BADIMAGERY">
+              <FormattedMessage {...messages.badImagery} />
+            </label>
+          </p>
+        )}
       </div>
       <div className="cf">
         <h4 className="ttu blue-grey f5">

--- a/frontend/src/hooks/UseDisableBadImagery.js
+++ b/frontend/src/hooks/UseDisableBadImagery.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+
+export const useDisableBadImagery = (history) => {
+  const [disableBadImagery, setDisableBadImagery] = useState(false);
+
+  useEffect(() => {
+    if (history && history.taskHistory && history.taskHistory.length > 1) {
+      const wasSetAsBadImagery = history.taskHistory.filter(
+        (task) => task.actionText === 'BADIMAGERY',
+      ).length;
+      console.log(wasSetAsBadImagery);
+      const wasRevertedToReady = history.taskHistory.filter(
+        (task) => task.actionText === 'Undo state from BADIMAGERY to READY',
+      ).length;
+      console.log(wasRevertedToReady);
+
+      if (wasSetAsBadImagery && wasRevertedToReady) {
+        setDisableBadImagery(true);
+      }
+    }
+  }, [history]);
+  return disableBadImagery;
+};

--- a/frontend/src/hooks/UseReadTaskComments.js
+++ b/frontend/src/hooks/UseReadTaskComments.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-const useReadTaskComments = (history) => {
+export const useReadTaskComments = (history) => {
   const [readTaskComments, setReadTaskComments] = useState(false);
 
   useEffect(() => {
@@ -17,5 +17,3 @@ const useReadTaskComments = (history) => {
   }, [history]);
   return readTaskComments;
 };
-
-export default useReadTaskComments;

--- a/frontend/src/hooks/tests/UseDisableBadImagery.test.js
+++ b/frontend/src/hooks/tests/UseDisableBadImagery.test.js
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react-hooks';
+import {
+  invalidatedTaskHistory,
+  history,
+  revertedBadImagery,
+} from '../../network/tests/mockData/taskHistory';
+import { useDisableBadImagery } from '../UseDisableBadImagery';
+
+describe('test useDisableBadImagery hook', () => {
+  it('returns false when the task history is empty', () => {
+    const { result } = renderHook(() => useDisableBadImagery({}));
+    const disableBadImagery = result.current;
+    expect(disableBadImagery).toBe(false);
+  });
+  it('returns false when the task was not reverted from BADIMAGERY to READY', () => {
+    const { result } = renderHook(() => useDisableBadImagery(history));
+    const disableBadImagery = result.current;
+    expect(disableBadImagery).toBe(false);
+  });
+  it('returns false when the task was not reverted from BADIMAGERY to READY', () => {
+    const { result } = renderHook(() => useDisableBadImagery(invalidatedTaskHistory));
+    const disableBadImagery = result.current;
+    expect(disableBadImagery).toBe(false);
+  });
+  it('returns true when the task was reverted from BADIMAGERY to READY', () => {
+    const { result } = renderHook(() => useDisableBadImagery(revertedBadImagery));
+    const disableBadImagery = result.current;
+    expect(disableBadImagery).toBeTruthy();
+  });
+});

--- a/frontend/src/hooks/tests/UseReadTaskComments.test.js
+++ b/frontend/src/hooks/tests/UseReadTaskComments.test.js
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { invalidatedTaskHistory, history } from '../../network/tests/mockData/taskHistory';
-import useReadTaskComments from '../useReadTaskComments';
+import { useReadTaskComments } from '../UseReadTaskComments';
 
 describe('test useReadTaskComments hook', () => {
   it('returns false when there is no task history', () => {

--- a/frontend/src/network/tests/mockData/taskHistory.js
+++ b/frontend/src/network/tests/mockData/taskHistory.js
@@ -67,3 +67,48 @@ export const invalidatedTaskHistory = {
     },
   ],
 };
+
+export const revertedBadImagery = {
+  taskHistory: [
+    {
+      historyId: 999,
+      taskId: 123,
+      action: 'STATE_CHANGE',
+      actionText: 'READY',
+      actionDate: '2021-01-18T13:47:31.858248Z',
+      actionBy: 'test_user',
+      pictureUrl: null,
+      issues: null,
+    },
+    {
+      historyId: 998,
+      taskId: 123,
+      action: 'COMMENT',
+      actionText: 'Undo state from BADIMAGERY to READY',
+      actionDate: '2021-01-18T13:47:31.857840Z',
+      actionBy: 'test_user',
+      pictureUrl: null,
+      issues: null,
+    },
+    {
+      historyId: 997,
+      taskId: 123,
+      action: 'STATE_CHANGE',
+      actionText: 'BADIMAGERY',
+      actionDate: '2021-01-18T13:47:21.368475Z',
+      actionBy: 'user_11',
+      pictureUrl: null,
+      issues: null,
+    },
+    {
+      historyId: 996,
+      taskId: 123,
+      action: 'LOCKED_FOR_MAPPING',
+      actionText: '00:00:05.111774',
+      actionDate: '2021-01-18T13:47:16.258317Z',
+      actionBy: 'user_1',
+      pictureUrl: null,
+      issues: null,
+    },
+  ],
+};


### PR DESCRIPTION
In the case a task was marked as bad imagery and a validator reverted it to ready, we only show the option to set the task again as bad imagery to advanced users. So beginners and intermediate can not mark it as bad imagery again.

Resolves #4082