### PR TITLE
Exclude tasks that are not on mapped status, when locking tasks of a user

### DIFF
--- a/frontend/src/components/taskSelection/footer.js
+++ b/frontend/src/components/taskSelection/footer.js
@@ -72,15 +72,25 @@ const TaskSelectionFooter = ({ defaultUserEditor, project, tasks, taskAction, se
       windowObjectReference = window.open('', `TM-${project.projectId}-${selectedTasks}`);
     }
     if (['validateSelectedTask', 'validateAnotherTask', 'validateATask'].includes(taskAction)) {
-      pushToLocalJSONAPI(
-        `projects/${project.projectId}/tasks/actions/lock-for-validation/`,
-        JSON.stringify({ taskIds: selectedTasks }),
-        token,
-      )
-        .then((res) => {
-          lockSuccess('LOCKED_FOR_VALIDATION', 'validate', windowObjectReference);
-        })
-        .catch((e) => lockFailed(windowObjectReference, e.message));
+      const mappedTasks = selectedTasks.filter(
+        (id) =>
+          tasks.features.filter(
+            (task) => task.properties.taskId === id && task.properties.taskStatus === 'MAPPED',
+          ).length,
+      );
+      if (!mappedTasks.length) {
+        setLockError('No mapped tasks selected');
+      } else {
+        pushToLocalJSONAPI(
+          `projects/${project.projectId}/tasks/actions/lock-for-validation/`,
+          JSON.stringify({ taskIds: mappedTasks }),
+          token,
+        )
+          .then((res) => {
+            lockSuccess('LOCKED_FOR_VALIDATION', 'validate', windowObjectReference);
+          })
+          .catch((e) => lockFailed(windowObjectReference, e.message));
+      }
     }
     if (['mapSelectedTask', 'mapAnotherTask', 'mapATask'].includes(taskAction)) {
       fetchLocalJSONAPI(

--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -72,7 +72,7 @@ export function TaskSelection({ project, type, loading }: Object) {
   );
   //eslint-disable-next-line
   const [priorityAreasError, priorityAreasLoading, priorityAreas] = useFetch(
-    `/api/v2/projects/${project.projectId}/queries/priority-areas/`,
+    `projects/${project.projectId}/queries/priority-areas/`,
     project.projectId !== undefined,
   );
 

--- a/frontend/src/components/taskSelection/lockedTasks.js
+++ b/frontend/src/components/taskSelection/lockedTasks.js
@@ -148,19 +148,42 @@ export function JosmError({ close }: Object) {
   );
 }
 
+export function NoMappedTasksError({ close }: Object) {
+  return (
+    <>
+      <h3 className="barlow-condensed f3 fw6 mv0">
+        <FormattedMessage {...messages.noMappedTasksSelected} />
+      </h3>
+      <div className="mv4 lh-title">
+        <FormattedMessage {...messages.noMappedTasksSelectedDescription} />
+      </div>
+      <div className="w-100 pt3">
+        <Button onClick={() => close()} className="bg-red white mr2">
+          <FormattedMessage {...messages.closeModal} />
+        </Button>
+      </div>
+    </>
+  );
+}
+
 export function LockedTaskModalContent({ project, error, close, lockTasks }: Object) {
   const lockedTasks = useGetLockedTasks();
   const action = lockedTasks.get('status') === 'LOCKED_FOR_VALIDATION' ? 'validate' : 'map';
   const licenseError =
     ['Conflict', 'CONFLICT', 'conflict'].includes(error) && !lockedTasks.get('project');
   const josmError = error === 'JOSM' && !lockedTasks.get('project');
+  const noMappedTasksSelectedError = error === 'No mapped tasks selected';
   return (
     <div className="blue-dark bg-white pv2 pv4-ns ph2 ph4-ns">
+      {noMappedTasksSelectedError && <NoMappedTasksError close={close} />}
       {licenseError && <LicenseError id={project.licenseId} close={close} lockTasks={lockTasks} />}
       {josmError && <JosmError close={close} />}
 
       {/* User has not tasks locked, but other error happened */}
-      {!lockedTasks.get('project') && !licenseError && !josmError && <LockError />}
+      {!lockedTasks.get('project') &&
+        !licenseError &&
+        !josmError &&
+        !noMappedTasksSelectedError && <LockError />}
       {/* User has tasks locked on another project */}
       {lockedTasks.get('project') && lockedTasks.get('project') !== project.projectId && (
         <AnotherProjectLock

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -20,6 +20,15 @@ export default defineMessages({
     id: 'project.tasks.unsaved_map_changes.actions.close_modal',
     defaultMessage: 'Close',
   },
+  noMappedTasksSelected: {
+    id: 'project.tasks.no_mapped_tasks_selected',
+    defaultMessage: 'No mapped tasks selected',
+  },
+  noMappedTasksSelectedDescription: {
+    id: 'project.tasks.no_mapped_tasks_selected.description',
+    defaultMessage:
+      'It was not possible to lock the selected tasks, as none of them are on the mapped status.',
+  },
   josmError: {
     id: 'project.tasks.josm_error',
     defaultMessage: 'Connection with JOSM failed',

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -509,6 +509,8 @@
   "project.tasks.unsaved_map_changes.split": "Save or undo it to be able to split the task",
   "project.tasks.unsaved_map_changes.unlock": "Save or undo it to be able to select another task",
   "project.tasks.unsaved_map_changes.actions.close_modal": "Close",
+  "project.tasks.no_mapped_tasks_selected": "No mapped tasks selected",
+  "project.tasks.no_mapped_tasks_selected.description": "It was not possible to lock the selected tasks, as none of them are on the mapped status.",
   "project.tasks.josm_error": "Connection with JOSM failed",
   "project.tasks.josm_error.description": "Please verify if JOSM is running on your computer and the remote control is enabled.",
   "project.tasks.lock_error.generic": "It wasn't possible to lock this task for you...",


### PR DESCRIPTION
Resolves https://github.com/hotosm/tasking-manager/issues/4128

**How to test:**

- **Case 1:** Select the tasks mapped by a user:
![Screen Shot 2021-01-22 at 10 05 22](https://user-images.githubusercontent.com/666291/105494348-69d12d00-5c99-11eb-8f76-24a6bd8314a0.png)

Although it shows "Validate 16 selected tasks" on the button, with that PR we are excluding the tasks that are not on the mapped status and lock only the mapped ones.


- **Case 2:** If the selected user has not tasks on mapped status, it will show an error message
![Screen Shot 2021-01-22 at 10 07 27](https://user-images.githubusercontent.com/666291/105494526-b3ba1300-5c99-11eb-9311-86e7eccc10dd.png)
