### PR TITLE
Replace TM Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine as base
+FROM quay.io/hotosm/base-python-image as base
 LABEL version=0.1
 LABEL maintainer="HOT Sysadmin <sysadmin@hotosm.org>"
 LABEL description="Builds backend docker image"


### PR DESCRIPTION
**What does this PR do?**
- Solve for the broken auto builds caused by Docker's new rate-limiting by pulling the python base image from quay.io. 