### PR TITLE
Don't log known exceptions on tasks stats endpoint

### DIFF
--- a/backend/api/tasks/statistics.py
+++ b/backend/api/tasks/statistics.py
@@ -99,7 +99,6 @@ class TasksStatisticsAPI(Resource):
             return task_stats.to_primitive(), 200
         except (KeyError, ValueError) as e:
             error_msg = f"Task Statistics GET - {str(e)}"
-            current_app.logger.critical(error_msg)
             return {"Error": error_msg}, 400
         except Exception as e:
             error_msg = f"Task Statistics GET - unhandled error: {str(e)}"


### PR DESCRIPTION
When an exception is known, we don't need to log it, as it is not a bug in the software and shouldn't generate an entry on Sentry