### PR TITLE
Add `last_updated` query param.

### DIFF
--- a/backend/api/projects/resources.py
+++ b/backend/api/projects/resources.py
@@ -478,7 +478,7 @@ class ProjectsRestAPI(Resource):
 
 class ProjectSearchBase(Resource):
     @token_auth.login_required(optional=True)
-    def setup_search_dto(self):
+    def setup_search_dto(self) -> ProjectSearchDTO:
         search_dto = ProjectSearchDTO()
         search_dto.preferred_locale = request.environ.get("HTTP_ACCEPT_LANGUAGE")
         search_dto.mapper_level = request.args.get("mapperLevel")
@@ -497,6 +497,7 @@ class ProjectSearchBase(Resource):
         search_dto.omit_map_results = strtobool(
             request.args.get("omitMapResults", "false")
         )
+        search_dto.last_updated = request.args.get("lastUpdated")
 
         # See https://github.com/hotosm/tasking-manager/pull/922 for more info
         try:

--- a/backend/models/dtos/project_dto.py
+++ b/backend/models/dtos/project_dto.py
@@ -303,6 +303,7 @@ class ProjectSearchDTO(Model):
     favorited_by = IntType(required=False)
     managed_by = IntType(required=False)
     omit_map_results = BooleanType(required=False)
+    last_updated = BooleanType(required=False)
 
     def __hash__(self):
         """ Make object hashable so we can cache user searches"""

--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -313,6 +313,9 @@ class ProjectSearchService:
                 sq.c.country.ilike("%{}%".format(search_dto.country))
             ).filter(Project.id == sq.c.id)
 
+        if search_dto.last_updated:
+            query = query.filter(Project.last_updated > search_dto.last_updated)
+
         order_by = search_dto.order_by
         if search_dto.order_by_type == "DESC":
             order_by = desc(search_dto.order_by)


### PR DESCRIPTION
Fixes #4159

I would add tests, but I'm not sure where to put them.

Note that this currently filters for items which were updated after the `lastUpdated` query string provided.