### PR TITLE
Reset arbitrary tasks option when clicking the Reset button

### DIFF
--- a/frontend/src/components/projectCreate/index.js
+++ b/frontend/src/components/projectCreate/index.js
@@ -206,7 +206,7 @@ const ProjectCreate = (props) => {
     if (mapObj.map.getSource(layer_name)) {
       mapObj.map.removeSource(layer_name);
     }
-    updateMetadata({ ...metadata, area: 0, geom: null });
+    updateMetadata({ ...metadata, area: 0, geom: null, arbitraryTasks: false });
   };
 
   const drawHandler = () => {


### PR DESCRIPTION
When we imported a file and enabled the "Arbitrary tasks" option, it was keeping that option active even if we reset the AoI and draw a new one. That PR fixes it by resetting the "Arbitrary tasks" option when clicking on reset