### PR TITLE
Rename tasksNo to tasksNumber and update it when going back to Step 2

### DIFF
--- a/frontend/src/components/projectCreate/index.js
+++ b/frontend/src/components/projectCreate/index.js
@@ -264,7 +264,7 @@ const ProjectCreate = (props) => {
   const [metadata, updateMetadata] = useState({
     geom: null,
     area: 0,
-    tasksNo: 0,
+    tasksNumber: 0,
     taskGrid: null,
     projectName: '',
     zoomLevel: 9,
@@ -384,7 +384,7 @@ const ProjectCreate = (props) => {
           <p className="fl bg-blue-light white mr2 pa1 f7-ns">
             <FormattedMessage
               {...messages.taskNumber}
-              values={{ n: <FormattedNumber value={metadata.tasksNo} /> }}
+              values={{ n: <FormattedNumber value={metadata.tasksNumber} /> }}
             />
           </p>
         </div>

--- a/frontend/src/components/projectCreate/navButtons.js
+++ b/frontend/src/components/projectCreate/navButtons.js
@@ -8,10 +8,14 @@ const clearParamsStep = (props) => {
   switch (props.index) {
     case 2: //clear Tasks
       props.mapObj.map.removeLayer('grid');
-      props.updateMetadata({ ...props.metadata, tasksNo: 0 });
+      props.updateMetadata({ ...props.metadata, tasksNumber: 0 });
       break;
     case 3:
-      props.updateMetadata({ ...props.metadata, taskGrid: props.metadata.tempTaskGrid });
+      props.updateMetadata({
+        ...props.metadata,
+        taskGrid: props.metadata.tempTaskGrid,
+        tasksNumber: props.metadata.tempTaskGrid.features.length,
+      });
       break;
     default:
       break;
@@ -44,7 +48,7 @@ const NavButtons = (props) => {
           addLayer('aoi', props.metadata.geom, props.mapObj.map);
           props.updateMetadata({
             ...props.metadata,
-            tasksNo: props.metadata.taskGrid.features.length,
+            tasksNumber: props.metadata.taskGrid.features.length,
           });
         }
 

--- a/frontend/src/components/projectCreate/review.js
+++ b/frontend/src/components/projectCreate/review.js
@@ -56,7 +56,10 @@ export default function Review({ metadata, updateMetadata, token, projectId, clo
         <FormattedMessage {...messages.step4} />
       </h3>
       <p className="pt2">
-        <FormattedMessage {...messages.reviewTaskNumberMessage} values={{ n: metadata.tasksNo }} />
+        <FormattedMessage
+          {...messages.reviewTaskNumberMessage}
+          values={{ n: metadata.tasksNumber }}
+        />
       </p>
 
       {cloneProjectData.name === null ? (

--- a/frontend/src/components/projectCreate/setTaskSizes.js
+++ b/frontend/src/components/projectCreate/setTaskSizes.js
@@ -136,7 +136,7 @@ export default function SetTaskSizes({ metadata, mapObj, updateMetadata }) {
       updateMetadata({
         ...metadata,
         taskGrid: featureCollection(newTaskGrid),
-        tasksNo: featureCollection(newTaskGrid).features.length,
+        tasksNumber: featureCollection(newTaskGrid).features.length,
       });
     },
     [updateMetadata, metadata, mapObj.map],
@@ -182,7 +182,7 @@ export default function SetTaskSizes({ metadata, mapObj, updateMetadata }) {
       updateMetadata({
         ...metadata,
         taskGrid: featureCollection(newTaskGrid),
-        tasksNo: featureCollection(newTaskGrid).features.length,
+        tasksNumber: featureCollection(newTaskGrid).features.length,
       });
       setSplitMode(null);
     });
@@ -202,7 +202,7 @@ export default function SetTaskSizes({ metadata, mapObj, updateMetadata }) {
       zoomLevel: zoomLevel,
       tempTaskGrid: squareGrid,
       taskGrid: squareGrid,
-      tasksNo: squareGrid.features.length,
+      tasksNumber: squareGrid.features.length,
     });
   }, [metadata, updateMetadata]);
 
@@ -215,7 +215,7 @@ export default function SetTaskSizes({ metadata, mapObj, updateMetadata }) {
         zoomLevel: zoomLevel,
         tempTaskGrid: squareGrid,
         taskGrid: squareGrid,
-        tasksNo: squareGrid.features.length,
+        tasksNumber: squareGrid.features.length,
       });
     }
   }, [metadata, updateMetadata]);
@@ -290,7 +290,7 @@ export default function SetTaskSizes({ metadata, mapObj, updateMetadata }) {
         <p className="f6 blue-grey lh-title mt3 mb2">
           <FormattedMessage
             {...messages.taskNumberMessage}
-            values={{ n: <strong>{metadata.tasksNo || 0}</strong> }}
+            values={{ n: <strong>{metadata.tasksNumber || 0}</strong> }}
           />
         </p>
         <p className="f6 blue-grey lh-title mt1">

--- a/frontend/src/components/projectCreate/trimProject.js
+++ b/frontend/src/components/projectCreate/trimProject.js
@@ -18,7 +18,7 @@ const clipProject = (clip, metadata, map, updateMetadata, token) => {
   });
 
   pushToLocalJSONAPI(url, body, token).then((grid) => {
-    updateMetadata({ ...metadata, tasksNo: grid.features.length, taskGrid: grid });
+    updateMetadata({ ...metadata, tasksNumber: grid.features.length, taskGrid: grid });
   });
 };
 


### PR DESCRIPTION
After trimming the tasks grid on the Step 3 of project creation and going back to step 2, the number of tasks were not being updated. This PR fixes it.