### PR TITLE
Truncate Project AoI and Task Grid to 6 decimal places

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "@turf/intersect": "^6.3.0",
     "@turf/line-to-polygon": "^6.3.0",
     "@turf/transform-scale": "^6.3.0",
+    "@turf/truncate": "^6.3.0",
     "@webscopeio/react-textarea-autocomplete": "^4.7.3",
     "axios": "^0.21.1",
     "chart.js": "^2.9.4",

--- a/frontend/src/components/projectCreate/review.js
+++ b/frontend/src/components/projectCreate/review.js
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
 import { navigate } from '@reach/router';
+import truncate from '@turf/truncate';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import messages from './messages';
 import { Button } from '../button';
@@ -27,10 +28,10 @@ export default function Review({ metadata, updateMetadata, token, projectId, clo
 
       store.dispatch(createProject(metadata));
       let projectParams = {
-        areaOfInterest: metadata.geom,
+        areaOfInterest: truncate(metadata.geom, { precision: 6 }),
         projectName: metadata.projectName,
         organisation: metadata.organisation || cloneProjectData.organisation,
-        tasks: metadata.taskGrid,
+        tasks: truncate(metadata.taskGrid, { precision: 6 }),
         arbitraryTasks: metadata.arbitraryTasks,
       };
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3325,6 +3325,14 @@
     "@turf/rhumb-destination" "^6.3.0"
     "@turf/rhumb-distance" "^6.3.0"
 
+"@turf/truncate@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/truncate/-/truncate-6.3.0.tgz#a2536f005d5f2ab575ad414fc49af4987cea8ea5"
+  integrity sha512-fvzR3BUODPciEBELLqqAggEEeb1L0d79WZYb9HKaoSB0GKTTgNrEbkTXiiGEjGJ1s1FMqXOEp0DKsLvvb1h4OA==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/meta" "^6.3.0"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"


### PR DESCRIPTION
This will reduce the size of the project's task grid and improve TM performance.