### PR TITLE
Exclude  already validated tasks to be locked for validation again

### DIFF
--- a/backend/services/stats_service.py
+++ b/backend/services/stats_service.py
@@ -78,7 +78,6 @@ class StatsService:
 
         # Make sure you are aware that users table has it as incrementing counters,
         # while projects table reflect the actual state, and both increment and decrement happens
-
         if new_state == last_state:
             return project, user
 

--- a/backend/services/validator_service.py
+++ b/backend/services/validator_service.py
@@ -52,11 +52,11 @@ class ValidatorService:
 
             if TaskStatus(task.task_status) not in [
                 TaskStatus.MAPPED,
-                TaskStatus.VALIDATED,
+                TaskStatus.INVALIDATED,
                 TaskStatus.BADIMAGERY,
             ]:
                 raise ValidatorServiceError(
-                    f"Task {task_id} is not MAPPED, BADIMAGERY or VALIDATED"
+                    f"Task {task_id} is not MAPPED, BADIMAGERY or INVALIDATED"
                 )
             user_can_validate = ValidatorService._user_can_validate_task(
                 validation_dto.user_id, task.mapped_by


### PR DESCRIPTION
Update the TaskStatus list so that tasks that have been validated already are not locked for validtation again. This could help with the project statistics update on the backend