### PR TITLE
Split up Frontend and Backend certificate manager certificates

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -51,6 +51,14 @@ const Parameters = {
     Type: 'String',
     Description: 'SSL certificate for HTTPS protocol'
   },
+  FrontendSSLCertID: {
+    Type: 'String',
+    Description: 'Cloudfront SSL certificate for frontend'
+  },
+  BackendSSLCertID: {
+    Type: 'String',
+    Description: 'ELB SSL certificate for backend'
+  },
   TaskingManagerLogDirectory: {
     Description: 'TM_LOG_DIR environment variable',
     Type: 'String'
@@ -580,7 +588,7 @@ const Resources = {
     Type: 'AWS::ElasticLoadBalancingV2::Listener',
     Properties: {
       Certificates: [ {
-        CertificateArn: cf.arn('acm', cf.ref('SSLCertificateIdentifier'))
+        CertificateArn: cf.arn('acm', cf.ref('BackendSSLCertID'))
       }],
       DefaultActions: [{
         Type: 'forward',
@@ -709,7 +717,7 @@ const Resources = {
           ViewerProtocolPolicy: "redirect-to-https"
         },
         ViewerCertificate: {
-          AcmCertificateArn: cf.arn('acm', cf.ref('SSLCertificateIdentifier')),
+          AcmCertificateArn: cf.arn('acm', cf.ref('FrontendSSLCertID')),
           MinimumProtocolVersion: 'TLSv1.2_2018',
           SslSupportMethod: 'sni-only'
         }


### PR DESCRIPTION
- Cloudfront for TeachOSM points to tasks.teachosm.org
- Backend API points to tasking-manager-tm4-teachosm.hotosm.org
- Different domains need different certificates from ACM

This commit splits the single SSL Certificate Identifier variable
into separate Frontend and Backend SSL Certificate ID variables.

Relevant cfn parameter JSON file in S3 has been modified to include
two new parameters `FrontendSSLCertID` and `BackendSSLCertID`