### PR TITLE
Add opsgenie integration to CircleCI to push alerts there

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,3 +334,6 @@ workflows:
               - deployment/hot-tasking-manager
         stack_name: "tm4-production"
         context: tasking-manager-tm4-production
+notify:
+  webhooks:
+    -url: https://api.opsgenie.com/v1/json/circleci?apiKey=$OPSGENIE_API


### PR DESCRIPTION
via https://www.opsgenie.com/docs/integrations/circleci-integration

This will set up the integration with OpsGenie so we can pass CI alerts such as build failures through that platform. 