### PR TITLE
Load imagery on JOSM using its id instead of the url

### DIFF
--- a/frontend/src/utils/openEditor.js
+++ b/frontend/src/utils/openEditor.js
@@ -149,17 +149,21 @@ export function getImageryInfo(url) {
 }
 
 function loadImageryonJosm(project) {
-  if (project.imagery && project.imagery.includes('http')) {
-    const [type, minZoom, maxZoom] = getImageryInfo(project.imagery);
-    const imageryParams = {
-      title: project.imagery,
-      type: type,
-    };
-    if (minZoom) imageryParams.min_zoom = minZoom;
-    if (maxZoom) imageryParams.max_zoom = maxZoom;
-    imageryParams.url = project.imagery.substr(project.imagery.indexOf('http'));
+  if (project.imagery) {
+    if (project.imagery.includes('http')) {
+      const [type, minZoom, maxZoom] = getImageryInfo(project.imagery);
+      const imageryParams = {
+        title: project.imagery,
+        type: type,
+      };
+      if (minZoom) imageryParams.min_zoom = minZoom;
+      if (maxZoom) imageryParams.max_zoom = maxZoom;
+      imageryParams.url = project.imagery.substr(project.imagery.indexOf('http'));
 
-    return callJosmRemoteControl(formatJosmUrl('imagery', imageryParams));
+      return callJosmRemoteControl(formatJosmUrl('imagery', imageryParams));
+    } else {
+      return callJosmRemoteControl(formatJosmUrl('imagery', { id: project.imagery }));
+    }
   }
 }
 


### PR DESCRIPTION
Change needed after #4404 

It's only supported by JOSM 17655 or superior (https://josm.openstreetmap.de/ticket/20660)