### PR TITLE
Bleach & Jinja version update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ appdirs==1.4.4
 apscheduler==3.6.3
 attrs==20.2.0
 black==20.8b1
-bleach==3.2.1
+bleach==3.3.0
 cachetools==4.1.1
 certifi==2020.6.20
 chardet==3.0.4
@@ -29,7 +29,7 @@ greenlet==0.4.17
 gunicorn==20.0.4
 idna==2.10
 itsdangerous==1.1.0
-Jinja2==2.11.2
+Jinja2==2.11.3
 Mako==1.1.3
 markdown==3.3.3
 MarkupSafe==1.1.1


### PR DESCRIPTION
Based on security alert we received updated the following dependency versions:
* Bleach 3.2.1 -> 3.3.0
* Jinja2 2.11.2 -> 2.11.3

These libraries impact the chat and the api-docs section. I don't see any issues with the version upgrade.
