### PR TITLE
Parse new database connection parameters

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -56,6 +56,22 @@ class EnvironmentConfig:
     # Assamble the database uri
     if os.getenv("TM_DB", False):
         SQLALCHEMY_DATABASE_URI = os.getenv("TM_DB", None)
+    elif os.getenv("TM_DB_CONNECT_PARAM_JSON", False):
+        """
+        This section reads JSON formatted Database connection parameters passed
+        from AWS Secrets Manager with the ENVVAR key `TM_DB_CONNECT_PARAM_JSON`
+        and forms a valid SQLALCHEMY DATABASE URI
+        """
+        import json
+
+        _params = json.loads(os.getenv("TM_DB_CONNECT_PARAM_JSON", None))
+        SQLALCHEMY_DATABASE_URI = (
+            f"postgresql://{_params.get('username')}"
+            + f":{_params.get('password')}"
+            + f"@{_params.get('host')}"
+            + f":{_params.get('port')}"
+            + f"/{_params.get('dbname')}"
+        )
     else:
         SQLALCHEMY_DATABASE_URI = (
             f"postgresql://{POSTGRES_USER}"

--- a/example.env
+++ b/example.env
@@ -104,8 +104,21 @@ TM_CONSUMER_SECRET=s0m3l0ngr4nd0mstr1ng-b3cr34tiv3
 #
 # TM_DEFAULT_CHANGESET_COMMENT="#{nameofyourorganisation}-project"
 
+####################################################
+#
+#          DATABASE CONNECTION PARAMETRS
+#
+####################################################
 # The connection to the postgres database (required)
 #
+# The parameter TM_DB_CONNECT_PARAM_JSON needs to be a JSON string readable by
+# json.loads() with the following keys: "username", "password", "host", "port"
+# and "dbname"
+#
+# If this parameter is set, then individual DB connection parameters are ignored
+# TM_DB_CONNECT_PARAM_JSON='{ "username": "tm", "password": "myprivatesecret", "host": "tm4-database.example.org", "port": "5432", "dbname": "taskingmanager }'
+#
+# NOTE: These are ignored if TM_DB_CONNECT_PARAM_JSON is set
 POSTGRES_DB=tasking-manager
 POSTGRES_USER=tm
 POSTGRES_PASSWORD=tm


### PR DESCRIPTION
Problem:

There's no straightforward way to prevent PostgreSQL password 
from being displayed in AWS console (our current application host).
This is a shortcoming of AWS Cloudformation and available options
for AWS ECS `ValueFrom` field.

Solution:

Instead of trying to parse the secrets manager entry and pick specific 
parameters in the CloudFormation template, we do the parsing in 
config.py and pass the whole JSON stored in secrets manager. 

This is agnostic of AWS and can be extended to any cloud provider or
server host in the future.