### PR TITLE
Add new CSS rule to hide "Improve this map" link

### DIFF
--- a/frontend/src/assets/styles/_extra.scss
+++ b/frontend/src/assets/styles/_extra.scss
@@ -229,7 +229,7 @@ div.messageBodyLinks {
   width: calc(100% - 4rem);
 }
 
-.mapbox-improve-map {
+.mapbox-improve-map, a[href="https://www.mapbox.com/map-feedback/"] {
   display: none;
 }
 


### PR DESCRIPTION
I have noticed that in the production instance, the link to the "Improve this map" has been shown, so I improved the CSS rule to hide it.
![image](https://user-images.githubusercontent.com/666291/117223753-ba9e0900-ade4-11eb-8190-3c70e04df143.png)
