### PR TITLE
Improve logic of reset pagination in the TaskList component

### DIFF
--- a/frontend/src/components/taskSelection/taskList.js
+++ b/frontend/src/components/taskSelection/taskList.js
@@ -394,10 +394,12 @@ function PaginatedList({
 }: Object) {
   const [page, setPage] = useQueryParam('page', NumberParam);
   const lastPage = howManyPages(items.length, pageSize);
-  // change page to 1 if the page number is not valid
-  if (items && page && page > lastPage) {
-    setPage(1);
-  }
+  // reset page number to 1 if it is not valid any more
+  useEffect(() => {
+    if (items && page > 1 && page > lastPage) {
+      setPage(1);
+    }
+  }, [items, page, lastPage, setPage]);
 
   const latestItems = useRef(items);
   useEffect(() => {


### PR DESCRIPTION
How to reproduce the bug: go the task selection page, click on a task on the map, then click on a filter like "unavailable", start typing some letters on the search field until the result got empty. The application will break, or you'll see some errors messages on the console.

This PR fixes the problem by improving the logic on when the pagination should be reset.