### PR TITLE
Don't change map bounds when the user press the "Draw polygon" button

### DIFF
--- a/frontend/src/components/projectEdit/priorityAreasForm.js
+++ b/frontend/src/components/projectEdit/priorityAreasForm.js
@@ -239,9 +239,8 @@ export const PriorityAreasForm = () => {
       mapObj.map.on('load', () => {
         mapObj.map.addControl(mapObj.draw);
         addMapLayers(mapObj.map);
+        mapObj.map.fitBounds(projectInfo.aoiBBOX, { duration: 0, padding: 100 });
       });
-
-      mapObj.map.fitBounds(projectInfo.aoiBBOX, { duration: 0, padding: 100 });
 
       mapObj.map.on('styledata', () => {
         addMapLayers(mapObj.map);


### PR DESCRIPTION
To test: go to the priority areas form, zoom the map to some region, press the "Draw polygon" button, draw something. The map view should remain on the same place all the time.