### PR TITLE
Remove Organization Managers from notifications triggered by #managers

### DIFF
--- a/backend/services/messaging/message_service.py
+++ b/backend/services/messaging/message_service.py
@@ -536,11 +536,6 @@ class MessageService:
         team_members = [item for sublist in team_members for item in sublist]
         project_managers.extend(team_members)
 
-        # Add organization managers.
-        if project.organisation is not None:
-            org_usernames = [u.username for u in project.organisation.managers]
-            project_managers.extend(org_usernames)
-
         return project_managers
 
     @staticmethod


### PR DESCRIPTION
Resolves #3902

With that change, the `#managers` hashtag will notify the project author and the members of the teams with Project Management permission on the project. The organization managers will not receive that notification any more.