### PR TITLE
Fix task IDs are not sorted on multiple tasks validation sidebar

### DIFF
--- a/frontend/src/components/taskSelection/action.js
+++ b/frontend/src/components/taskSelection/action.js
@@ -40,9 +40,18 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
   const [activeSection, setActiveSection] = useState('completion');
   const [activeEditor, setActiveEditor] = useState(editor);
   const [showSidebar, setShowSidebar] = useState(true);
-  const tasksIds = useMemo(() => (activeTasks ? activeTasks.map((task) => task.taskId) : []), [
-    activeTasks,
-  ]);
+  const tasksIds = useMemo(
+    () =>
+      activeTasks
+        ? activeTasks
+            .map((task) => task.taskId)
+            .sort((n1, n2) => {
+              // in ascending order
+              return n1 - n2;
+            })
+        : [],
+    [activeTasks],
+  );
   const [disabled, setDisable] = useState(false);
   const [taskComment, setTaskComment] = useState('');
   const [selectedStatus, setSelectedStatus] = useState();


### PR DESCRIPTION
## Description

This ensures that task IDs on the Validate Multiple Tasks page are sorted in ascending order for a better UX. This PR performs the sort on both the title and the `TaskValidationSelector` components, so that they are aligned.

Resolves #4689

## Implementation Details

Sorting is done on the task IDs array in `action.js` since that is the array that gets passed into all child components. I thought that placing the sort function there would make it more convenient in the future, so you don't need to worry about having to sort individual child components on their own anymore (the array is sorted, just display).

(Sidenote) Javascript's `Array.prototype.sort` does a lexicographic sort by default ([docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)). Since the `tasksIds` array is a `number[]`, I had to use a custom compare function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

* Run `yarn start` in the `./frontend` folder
* Navigate to the page `Manage > Select a project > Contribute > Tasks > Validate (n) Tasks` (use a project with multiple pending validation tasks)
* Verify that tasks with a mix of 2-digit, 3-digit and 4-digit IDs, etc, are rendered in ascending order
* Run `yarn test` in the `./frontend` folder. There were no unit tests for this file, so I tested my implementation on the UI.

Here is a reference screenshot:

![image](https://user-images.githubusercontent.com/12412031/120097998-25353100-c166-11eb-9582-72de2d0b0e71.png)