### PR TITLE
Improve status filters by making them independent on manage project page

### DIFF
--- a/frontend/src/components/projects/myProjectNav.js
+++ b/frontend/src/components/projects/myProjectNav.js
@@ -143,42 +143,52 @@ export const MyProjectNav = (props) => {
               </>
             )}
             {props.management && (userDetails.role === 'ADMIN' || isOrgManager) && (
-              <>
-                <FilterButton
-                  query={fullProjectsQuery}
-                  newQueryParams={{ status: 'PUBLISHED', managedByMe: 1, createdByMe: undefined }}
-                  setQuery={setQuery}
-                  isActive={
-                    fullProjectsQuery.managedByMe && fullProjectsQuery.status === 'PUBLISHED'
-                  }
-                >
-                  <FormattedMessage {...messages.active} />
-                </FilterButton>
-                <FilterButton
-                  query={fullProjectsQuery}
-                  newQueryParams={{ status: 'DRAFT', managedByMe: 1, createdByMe: undefined }}
-                  setQuery={setQuery}
-                  isActive={isActiveButton('DRAFT', fullProjectsQuery)}
-                >
-                  <FormattedMessage {...messages.draft} />
-                </FilterButton>
-                <FilterButton
-                  query={fullProjectsQuery}
-                  newQueryParams={{ status: 'ARCHIVED', managedByMe: 1, createdByMe: undefined }}
-                  setQuery={setQuery}
-                  isActive={isActiveButton('ARCHIVED', fullProjectsQuery)}
-                >
-                  <FormattedMessage {...messages.archived} />
-                </FilterButton>
-                <FilterButton
-                  query={fullProjectsQuery}
-                  newQueryParams={{ status: undefined, managedByMe: undefined, createdByMe: 1 }}
-                  setQuery={setQuery}
-                  isActive={isActiveButton('createdByMe', fullProjectsQuery)}
-                >
-                  <FormattedMessage {...messages.created} />
-                </FilterButton>
-              </>
+              <div>
+                <div className="dib pr4">
+                  <FilterButton
+                    query={fullProjectsQuery}
+                    newQueryParams={{ status: 'PUBLISHED' }}
+                    setQuery={setQuery}
+                    isActive={isActiveButton('PUBLISHED', fullProjectsQuery)}
+                  >
+                    <FormattedMessage {...messages.active} />
+                  </FilterButton>
+                  <FilterButton
+                    query={fullProjectsQuery}
+                    newQueryParams={{ status: 'DRAFT' }}
+                    setQuery={setQuery}
+                    isActive={isActiveButton('DRAFT', fullProjectsQuery)}
+                  >
+                    <FormattedMessage {...messages.draft} />
+                  </FilterButton>
+                  <FilterButton
+                    query={fullProjectsQuery}
+                    newQueryParams={{ status: 'ARCHIVED' }}
+                    setQuery={setQuery}
+                    isActive={isActiveButton('ARCHIVED', fullProjectsQuery)}
+                  >
+                    <FormattedMessage {...messages.archived} />
+                  </FilterButton>
+                </div>
+                <div className="dib">
+                  <FilterButton
+                    query={fullProjectsQuery}
+                    newQueryParams={{ managedByMe: undefined, createdByMe: 1 }}
+                    setQuery={setQuery}
+                    isActive={isActiveButton('createdByMe', fullProjectsQuery)}
+                  >
+                    <FormattedMessage {...messages.created} />
+                  </FilterButton>
+                  <FilterButton
+                    query={fullProjectsQuery}
+                    newQueryParams={{ managedByMe: 1, createdByMe: undefined }}
+                    setQuery={setQuery}
+                    isActive={isActiveButton('managedByMe', fullProjectsQuery)}
+                  >
+                    <FormattedMessage {...messages.managed} />
+                  </FilterButton>
+                </div>
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
# Description

This PR's main goal is to solve the linked issue by creating a new status filter called "Managed by Me", so that users can select projects managed by them that have been archived. Currently, there's no way to do so because "Archived" and "Created by Me" filters are mutually exclusive.

We also improve the status filter toggling behaviour by making "Active", "Draft" & "Archived" filters separate from "Created by Me" and "Managed by Me". These filters have also been tested on mobile-sized screens to make sure they aren't awkwardly aligned.

_(Beware: Unfamiliar with business logic)_
Feel free to comment if I might have misunderstood the requirements here. I think it's easier to implement what I think should be the logic in code, and then work on this from here as a baseline.

Fixes #3829 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

* Run `yarn start` in the `./frontend` folder
* Navigate to the page `Manage > View all projects`
* Verify that filters can be toggled independently from each other
    * For projects "Created by Me", toggle each one of "Active", "Draft" & "Archived" filters
    * For projects "Managed by Me", toggle each one of "Active", "Draft" & "Archived" filters
* Run `yarn test` in the `./frontend` folder. There were no unit tests for this file, so I tested my implementation on the UI.

Here is a reference screenshot (larger screens):

![image](https://user-images.githubusercontent.com/12412031/120495933-b8cd6280-c3ef-11eb-9218-793d1d619a6e.png)

(mobile screens)

![image](https://user-images.githubusercontent.com/12412031/120496052-d39fd700-c3ef-11eb-9d89-4a0b50f032d3.png)


