### PR TITLE
Limit space available to usernames on the header

### DIFF
--- a/frontend/src/components/header/index.js
+++ b/frontend/src/components/header/index.js
@@ -53,7 +53,7 @@ const UserDisplay = ({ username }) => {
   return (
     <span>
       <CurrentUserAvatar className="br-100 v-mid red h2 w2 dib" />
-      <span className="pl2">{username}</span>
+      <span className="pl2 mw5 dib v-mid truncate">{username}</span>
     </span>
   );
 };


### PR DESCRIPTION
OSM allows up to 255 characters in the username. It's better to limit the space and avoid the style from breaking

### Before:
![image](https://user-images.githubusercontent.com/666291/122451845-fb11aa80-cf7e-11eb-88f6-267a710f164e.png)

### With the PR:
![image](https://user-images.githubusercontent.com/666291/122451761-e46b5380-cf7e-11eb-8063-204747ab3ab7.png)
