### PR TITLE
Update internal links in Dropdowns to allow clicking on the entire span

### DIFF
--- a/frontend/src/components/dropdown.js
+++ b/frontend/src/components/dropdown.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from '@reach/router';
+import { navigate } from '@reach/router';
 import onClickOutside from 'react-click-outside';
 
 import { ChevronDownIcon, CheckIcon } from './svgIcons';
@@ -18,7 +18,13 @@ class DropdownContent extends React.PureComponent {
   handleClick = (data: Object) => {
     if (data) {
       var label = data.label;
-      if (!label || !this.props.value || !this.props.onChange) return;
+      if (!this.props.value || !this.props.onChange) {
+        if (!label) return;
+        if (data.href && data.internalLink) {
+          navigate(data.href)
+        }
+        return
+      }
       const value = this.props.value;
       let ourObj = data;
       if (!ourObj) return;
@@ -71,10 +77,10 @@ class DropdownContent extends React.PureComponent {
             )}
             {i.href ? (
               i.internalLink ? (
-                <Link to={i.href} className="link blue-grey">
+                <>
                   {i.label}
                   {this.isActive(i) && <CheckIcon className="red pl4" />}
-                </Link>
+                </>
               ) : (
                 <a
                   target={'_blank'}


### PR DESCRIPTION
This PR updates any internal link within a Dropdown component to use `@react/router`'s `navigate` instead of a `Link`. Instead of having to click on the text of the link, a user can just click the "box" that it lives in

## Current behavior:
![tm-dropdown_before](https://user-images.githubusercontent.com/9849118/123324737-65cd6380-d4f4-11eb-8d5f-70f1f8ee5e92.gif)
(must click the text)

## New behavior:
![tm-dropdown_after](https://user-images.githubusercontent.com/9849118/123324752-6c5bdb00-d4f4-11eb-9fee-24cb3cb925ea.gif)
(can click the surrounding area)

Closes #4781 