### PR TITLE
Remove "missingMapsProfile" & "osmProfile" User DTO fields

### DIFF
--- a/backend/models/dtos/user_dto.py
+++ b/backend/models/dtos/user_dto.py
@@ -77,8 +77,6 @@ class UserDTO(Model):
     teams_notifications = BooleanType(serialized_name="teamsNotifications")
 
     # these are read only
-    missing_maps_profile = StringType(serialized_name="missingMapsProfile")
-    osm_profile = StringType(serialized_name="osmProfile")
     gender = StringType(
         serialized_name="gender",
         choices=("MALE", "FEMALE", "SELF_DESCRIBE", "PREFER_NOT"),

--- a/backend/models/postgis/user.py
+++ b/backend/models/postgis/user.py
@@ -68,14 +68,6 @@ class User(db.Model):
     accepted_licenses = db.relationship("License", secondary=user_licenses_table)
     interests = db.relationship(Interest, secondary=user_interests, backref="users")
 
-    @property
-    def missing_maps_profile_url(self):
-        return f"http://www.missingmaps.org/users/#/{self.username}"
-
-    @property
-    def osm_profile_url(self):
-        return f"{current_app.config['OSM_SERVER_URL']}/user/{self.username}"
-
     def create(self):
         """ Creates and saves the current model to the DB """
         db.session.add(self)
@@ -364,8 +356,6 @@ class User(db.Model):
         user_dto.country = self.country
         user_dto.name = self.name
         user_dto.picture_url = self.picture_url
-        user_dto.osm_profile = self.osm_profile_url
-        user_dto.missing_maps_profile = self.missing_maps_profile_url
         user_dto.default_editor = self.default_editor
         user_dto.mentions_notifications = self.mentions_notifications
         user_dto.projects_notifications = self.projects_notifications


### PR DESCRIPTION
# Description

This is a minor cleanup PR that removes the "missingMapsProfile" & "osmProfile" fields from the User DTO object as they're no longer

Resolves #4378 

## Type of change

- [x] Clean up (non-breaking change / improvement)

