### PR TITLE
Add second banner for summit

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -57,7 +57,7 @@ import {
   NotificationPageIndex,
   NotificationDetail,
 } from './views/notifications';
-import { Banner } from './components/banner/index';
+import { Banner, DonationBanner } from './components/banner/index';
 
 const ProjectEdit = React.lazy(() =>
   import('./views/projectEdit' /* webpackChunkName: "projectEdit" */),
@@ -147,6 +147,7 @@ let App = (props) => {
               </QueryParamProvider>
             </Suspense>
           </main>
+          <DonationBanner />
           {MATOMO_ID && <Banner />}
           <Router primary={false}>
             <Footer path="/*" />

--- a/frontend/src/components/banner/index.js
+++ b/frontend/src/components/banner/index.js
@@ -75,3 +75,47 @@ export function Banner() {
     </div>
   );
 }
+
+export function DonationBanner() {
+  const form = document.getElementById('donation-form');
+
+  if (typeof form !== 'undefined' && form != null) {
+    if (!localStorage.getItem('donation-closed')) {
+      form.style.display = 'grid';
+    }
+    document.getElementById('donation-close').onclick = function() {
+      closeForm();
+    };
+  }
+
+  function closeForm() {
+    form.style.display = 'none';
+    localStorage.setItem('donation-closed', 'true');
+  }
+
+  return (
+    <div
+      id="donation-form"
+      className="fixed bottom-0 left-0 cf f5 w-100 tc ph6-l ph4-m ph2 pb2 bg-blue-dark white z-5 dn"
+    >
+      <div id="donation-contents">
+        <p>
+          <a
+            id="privlink"
+            className="red link f4 fw6"
+            href={`https://www.hotosm.org/donate/`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Donate text, though not internationalized.
+          </a>
+        </p>
+        <div id="donation-buttons">
+          <div className="white bg-red pv2 ph3 mh1 br1 dib fw6 pointer" id="donation-close">
+            Close
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/banner/index.js
+++ b/frontend/src/components/banner/index.js
@@ -103,12 +103,15 @@ export function DonationBanner() {
           <a
             id="privlink"
             className="red link f4 fw6"
-            href={`https://www.hotosm.org/donate/`}
+            href={`http://bit.ly/HOTSummit2021`}
             target="_blank"
             rel="noopener noreferrer"
           >
-            Donate text, though not internationalized.
+              2021 HOT Summit
           </a>
+        </p>
+        <p>
+              Join the virtual HOT Summit 2021 on November 22! All are invited; RSVP for free.
         </p>
         <div id="donation-buttons">
           <div className="white bg-red pv2 ph3 mh1 br1 dib fw6 pointer" id="donation-close">


### PR DESCRIPTION
Per Russ, I've created a banner for the HOT Summit to add to the tasking manager. I'm not sure if this should be merged upstream or if there is a separate deployment for the HOT-specific TM. 

First time a user visits the site:
<img width="1320" alt="Screen Shot 2021-11-04 at 8 54 35 PM" src="https://user-images.githubusercontent.com/8998918/140445396-37dcd069-0c67-4e36-9c9c-1ba682cbb076.png">

Hiding behind that first banner is information about the summit:
<img width="1319" alt="Screen Shot 2021-11-04 at 8 54 43 PM" src="https://user-images.githubusercontent.com/8998918/140445413-8f884efb-4979-4f0f-9c81-4e1cd04eb0ff.png">

In the past, we've had issues with temporary banners not retaining user's close preference and getting annoying; based on brief testing, the browser seems to hold the preferences since I mimicked the tracking banner's browser storage.

I originally wanted to do a broader solution based on a database table for announcements, but wasn't able to get that finished up in time. That may come down the road.