### PR TITLE
Update CircleCI image namespace 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /home/circleci/app
     docker:
-    - image: circleci/python:3.7-buster-node
+    - image: cimg/python:3.7-buster-node
     steps:
     - checkout
     - setup_remote_docker
@@ -81,7 +81,7 @@ jobs:
         type: string
     working_directory: /home/circleci/tasking-manager
     docker:
-    - image: circleci/python:3.7-buster-node
+    - image: cimg/python:3.7-buster-node
     steps:
     - checkout
     - setup_remote_docker
@@ -177,7 +177,7 @@ jobs:
   frontend_deploy:
     working_directory: /home/circleci/tasking-manager
     docker:
-    - image: circleci/python:3.7-buster-node
+    - image: cimg/python:3.7-buster-node
     parameters:
       stack_name:
         description: "the name of the stack for cfn-config"


### PR DESCRIPTION
The Docker images currently used for CircleCI will be deprecated on Dec 31, 2021. This simply updates the usage as stated by CircleCI

Closes #4950 