### PR TITLE
Update CircleCI job names for deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,7 @@ workflows:
             ignore:
             - /^deployment\/.*/
     - backend_deploy:
-        name: staging
+        name: backend-staging
         filters:
           branches:
             only:
@@ -238,7 +238,7 @@ workflows:
         gitsha: $CIRCLE_SHA1
         context: tasking-manager-staging
     - frontend_deploy:
-        name: staging
+        name: frontend-staging
         filters:
           branches:
             only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,7 +315,7 @@ workflows:
   backend-production:
     jobs:
     - backend_deploy:
-        name: production
+        name: backend-production
         filters:
           branches:
             only:
@@ -326,7 +326,7 @@ workflows:
   frontend-production:
     jobs:
     - frontend_deploy:
-        name: production
+        name: frontend-production
         filters:
           branches:
             only:


### PR DESCRIPTION
Simple change to switch the name of the deployment jobs to be more descriptive:
**frontend** => `frontend-staging`/`frontend-production`
**backend** => `backend-staging`/`backend-production`

closes #4952 