### PR TITLE
Fix for failing test/Unblock CircleCI

### DIFF
--- a/frontend/src/components/teamsAndOrgs/tests/orgUsageLevel.test.js
+++ b/frontend/src/components/teamsAndOrgs/tests/orgUsageLevel.test.js
@@ -99,7 +99,7 @@ describe('OrganisationTier', () => {
     expect(within(container.querySelector('h1')).getByText('Low')).toBeTruthy();
     expect(screen.getAllByRole('progressbar')[1].style.width).toBe('10%');
     expect(screen.getByText('Subscribed tier')).toBeInTheDocument();
-    expect(screen.getAllByText('Low').length).toBe(2);
+    expect(screen.getAllByText(/Low/).length).toBe(2);
     expect(screen.getByText('9,000')).toBeInTheDocument();
     expect(screen.getByText('Actions remaining on the Low tier')).toBeInTheDocument();
   });


### PR DESCRIPTION
CircleCi was failing due to a failed JS test. I'm not sure exactly why this particular test started failing all of a sudden but it seems the reason is because the specific check was using `getAllByText()` which gets all elements whose **entire** content is "Low". As the second element with "Low" in it had full content of "Actions remaining on the Low tier" it wasn't being caught by the function. 

Assuming the purpose of this check is to find the "Low"'s circled in this image, this fix should work:
![Screen Shot 2022-01-31 at 4 49 38 PM](https://user-images.githubusercontent.com/9849118/151891960-8f796a68-0454-49cc-ac52-07499625a956.png)