### PR TITLE
Fix reset-all-bad-imagery API

### DIFF
--- a/backend/services/mapping_service.py
+++ b/backend/services/mapping_service.py
@@ -370,7 +370,7 @@ class MappingService:
         """ Marks all bad imagery tasks ready for mapping """
         badimagery_tasks = Task.query.filter(
             Task.task_status == TaskStatus.BADIMAGERY.value,
-            Task.project_id == project_id
+            Task.project_id == project_id,
         ).all()
 
         for task in badimagery_tasks:

--- a/backend/services/mapping_service.py
+++ b/backend/services/mapping_service.py
@@ -369,7 +369,8 @@ class MappingService:
     def reset_all_badimagery(project_id: int, user_id: int):
         """ Marks all bad imagery tasks ready for mapping """
         badimagery_tasks = Task.query.filter(
-            Task.task_status == TaskStatus.BADIMAGERY.value
+            Task.task_status == TaskStatus.BADIMAGERY.value,
+            Task.project_id == project_id
         ).all()
 
         for task in badimagery_tasks:

--- a/tests/backend/helpers/test_helpers.py
+++ b/tests/backend/helpers/test_helpers.py
@@ -89,7 +89,9 @@ def create_canned_project() -> Tuple[Project, User]:
     task_non_square_feature = geojson.loads(
         json.dumps(get_canned_json("non_square_task.json"))
     )
-    task_arbitrary_feature = geojson.loads(json.dumps(get_canned_json("splittable_task.json")))
+    task_arbitrary_feature = geojson.loads(
+        json.dumps(get_canned_json("splittable_task.json"))
+    )
     test_user = get_canned_user("Thinkwhere TEST")
     if test_user is None:
         test_user = create_canned_user()

--- a/tests/backend/helpers/test_helpers.py
+++ b/tests/backend/helpers/test_helpers.py
@@ -89,6 +89,7 @@ def create_canned_project() -> Tuple[Project, User]:
     task_non_square_feature = geojson.loads(
         json.dumps(get_canned_json("non_square_task.json"))
     )
+    task_arbitrary_feature = geojson.loads(json.dumps(get_canned_json("splittable_task.json")))
     test_user = get_canned_user("Thinkwhere TEST")
     if test_user is None:
         test_user = create_canned_user()
@@ -100,7 +101,7 @@ def create_canned_project() -> Tuple[Project, User]:
     test_project = Project()
     test_project.create_draft_project(test_project_dto)
     test_project.set_project_aoi(test_project_dto)
-    test_project.total_tasks = 2
+    test_project.total_tasks = 3
 
     # Setup test task
     test_task = Task.from_geojson_feature(1, task_feature)
@@ -112,8 +113,14 @@ def create_canned_project() -> Tuple[Project, User]:
     test_task2.task_status = TaskStatus.READY.value
     test_task2.is_square = False
 
+    test_task3 = Task.from_geojson_feature(3, task_arbitrary_feature)
+    test_task3.task_status = TaskStatus.BADIMAGERY.value
+    test_task3.mapped_by = test_user.id
+    test_task3.is_square = True
+
     test_project.tasks.append(test_task)
     test_project.tasks.append(test_task2)
+    test_project.tasks.append(test_task3)
     test_project.create()
 
     return test_project, test_user

--- a/tests/backend/integration/models/postgis/test_project.py
+++ b/tests/backend/integration/models/postgis/test_project.py
@@ -34,7 +34,7 @@ class TestProject(BaseTestCase):
             self.test_project.id, None
         )
         self.assertIsInstance(feature_collection, geojson.FeatureCollection)
-        self.assertEqual(2, len(feature_collection.features))
+        self.assertEqual(3, len(feature_collection.features))
 
     def test_project_can_be_generated_as_dto(self):
         self.test_project, self.test_user = create_canned_project()

--- a/tests/backend/integration/services/test_mapping_service.py
+++ b/tests/backend/integration/services/test_mapping_service.py
@@ -2,6 +2,7 @@ import datetime
 import hashlib
 from unittest.mock import patch
 from backend.services.mapping_service import MappingService, Task
+from backend.models.postgis.task import TaskStatus
 from tests.backend.base import BaseTestCase
 from tests.backend.helpers.test_helpers import create_canned_project
 
@@ -114,3 +115,17 @@ class TestMappingService(BaseTestCase):
         # Assert
         for task in self.test_project.tasks:
             self.assertIsNotNone(task.mapped_by)
+
+
+    def test_reset_all_bad_imagery(
+        self,
+    ):
+        if self.skip_tests:
+            return
+
+        # Act
+        MappingService.reset_all_badimagery(self.test_project.id, self.test_user.id)
+
+        # Assert
+        for task in self.test_project.tasks:
+            self.assertNotEqual(task.task_status, TaskStatus.BADIMAGERY.value)

--- a/tests/backend/integration/services/test_mapping_service.py
+++ b/tests/backend/integration/services/test_mapping_service.py
@@ -116,7 +116,6 @@ class TestMappingService(BaseTestCase):
         for task in self.test_project.tasks:
             self.assertIsNotNone(task.mapped_by)
 
-
     def test_reset_all_bad_imagery(
         self,
     ):

--- a/tests/backend/unit/services/messaging/test_template_service.py
+++ b/tests/backend/unit/services/messaging/test_template_service.py
@@ -42,7 +42,10 @@ class TestTemplateService(BaseTestCase):
         base_url = current_app.config["APP_BASE_URL"]
         self.assertEqual(
             format_username_link("try @[yo] @[us2]! [t](http://a.c)"),
-            f'try <a style="color: #d73f3f" href="{base_url}/users/yo/">@yo</a> <a style="color: #d73f3f" href="{base_url}/users/us2/">@us2</a>! [t](http://a.c)',
+            (
+                f'try <a style="color: #d73f3f" href="{base_url}/users/yo/">@yo</a>'
+                f' <a style="color: #d73f3f" href="{base_url}/users/us2/">@us2</a>! [t](http://a.c)'
+            ),
         )
         self.assertEqual(
             format_username_link(

--- a/tests/backend/unit/services/messaging/test_template_service.py
+++ b/tests/backend/unit/services/messaging/test_template_service.py
@@ -42,7 +42,7 @@ class TestTemplateService(BaseTestCase):
         base_url = current_app.config["APP_BASE_URL"]
         self.assertEqual(
             format_username_link("try @[yo] @[us2]! [t](http://a.c)"),
-            f'try <a href="{base_url}/users/yo/">@yo</a> <a href="{base_url}/users/us2/">@us2</a>! [t](http://a.c)',
+            f'try <a style="color: #d73f3f" href="{base_url}/users/yo/">@yo</a> <a style="color: #d73f3f" href="{base_url}/users/us2/">@us2</a>! [t](http://a.c)',
         )
         self.assertEqual(
             format_username_link(


### PR DESCRIPTION
The main purpose of this PR is for fixing the API itself but it also adds a test for `reset_all_bad_imagery()` and fixes a few broken tests.

As stated in issue #5011, the API was incorrectly changing  resetting all tasks for **ALL PROJECTS** in the instance. It may be worth someone on the HOT tech team to make sure there aren't any severe ramifications of this API being used.

Closes #5011 