### PR TITLE
Enable OpsGenie webhook by fixing yaml syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,4 +333,4 @@ workflows:
         context: tasking-manager-tm4-production
 notify:
   webhooks:
-    -url: https://api.opsgenie.com/v1/json/circleci?apiKey=$OPSGENIE_API
+    - url: https://api.opsgenie.com/v1/json/circleci?apiKey=$OPSGENIE_API


### PR DESCRIPTION
![image (10)](https://user-images.githubusercontent.com/1847818/160012675-754879bf-52d1-46d6-a6fb-4cc17e98719e.png)

We were not getting OpsGenie integration working, so this should fix it. 