### PR TITLE
Fix user tasks stats

### DIFF
--- a/backend/services/users/user_service.py
+++ b/backend/services/users/user_service.py
@@ -357,6 +357,11 @@ class UserService:
         user_tasks = (
             db.session.query(filtered_actions)
             .filter(filtered_actions.c.user_id == user.id)
+            .distinct(
+                filtered_actions.c.project_id,
+                filtered_actions.c.task_id,
+                filtered_actions.c.action_text,
+            )
             .subquery()
             .alias("user_tasks")
         )
@@ -367,6 +372,11 @@ class UserService:
             .filter(filtered_actions.c.task_id == user_tasks.c.task_id)
             .filter(filtered_actions.c.project_id == user_tasks.c.project_id)
             .filter(filtered_actions.c.action_text != TaskStatus.MAPPED.name)
+            .distinct(
+                filtered_actions.c.project_id,
+                filtered_actions.c.task_id,
+                filtered_actions.c.action_text,
+            )
             .subquery()
             .alias("others_tasks")
         )


### PR DESCRIPTION
Currently, user task stats is being calculated from the task_history table.
This PR fixes #3895 by adding a filter to count distinct rows by project_id, task_id, and action_text so that the same action on a task of the project cannot be counted more than once while calculating user tasks stats.

