### PR TITLE
Do not cache html files in the browser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
           yarn
           CI=true GENERATE_SOURCEMAP=false yarn build
           aws s3 sync build/ s3://tasking-manager-<< parameters.stack_name >>-react-app --delete --cache-control max-age=31536000
-          aws s3 cp s3://tasking-manager-<< parameters.stack_name >>-react-app s3://tasking-manager-<< parameters.stack_name >>-react-app --recursive --exclude "*" --include "*.html" --metadata-directive REPLACE --cache-control max-age:no-cache --content-type text/html
+          aws s3 cp s3://tasking-manager-<< parameters.stack_name >>-react-app s3://tasking-manager-<< parameters.stack_name >>-react-app --recursive --exclude "*" --include "*.html" --metadata-directive REPLACE --cache-control no-cache --content-type text/html
           export DISTRIBUTION_ID=`aws cloudformation list-exports --output=text --query "Exports[?Name=='tasking-manager-<< parameters.stack_name >>-cloudfront-id-${AWS_REGION}'].Value"`
           aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths "/*"
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,8 @@ jobs:
           export TM_ENVIRONMENT=<< parameters.stack_name >>
           yarn
           CI=true GENERATE_SOURCEMAP=false yarn build
-          aws s3 sync build/ s3://tasking-manager-<< parameters.stack_name >>-react-app --delete
+          aws s3 sync build/ s3://tasking-manager-<< parameters.stack_name >>-react-app --delete --cache-control max-age=31536000
+          aws s3 cp s3://tasking-manager-<< parameters.stack_name >>-react-app s3://tasking-manager-<< parameters.stack_name >>-react-app --recursive --exclude "*" --include "*.html" --metadata-directive REPLACE --cache-control max-age:no-cache --content-type text/html
           export DISTRIBUTION_ID=`aws cloudformation list-exports --output=text --query "Exports[?Name=='tasking-manager-<< parameters.stack_name >>-cloudfront-id-${AWS_REGION}'].Value"`
           aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths "/*"
 workflows:


### PR DESCRIPTION
This update to the CircleCI script slightly changes how files are updated in the static aws s3 bucket that hosts the frontend. We will now be explicitly adding headers to all files for Cache-Control, according to (these docs)[https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html#expiration-individual-objects]. All files will be cached with a long max-age, except for html files which will not be cached. This should prevent the missing translation errors that were presented when we tried to deploy v4.4.13. 

I will be testing on tasks-test today and then will move this PR from WIP to ready to review. 