### PR TITLE
Handle switching editors with unsaved edits

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@turf/transform-scale": "^6.4.0",
     "@turf/truncate": "^6.4.0",
     "@webscopeio/react-textarea-autocomplete": "^4.7.3",
+    "RapiD": "facebookincubator/rapid#rapid-v1.1.8-tm.1",
     "axios": "^0.21.1",
     "chart.js": "^3.3.2",
     "date-fns": "^2.28.0",
@@ -78,8 +79,8 @@
   },
   "scripts": {
     "build-locales": "combine-messages -i './src/**/messages.js' -o './src/locales/en.json'",
-    "copy-static": "bash -c \"mkdir -p public/static/id; mkdir -p public/static/rapid; if ! (test -a public/static/id/index.js); then cp -R node_modules/@hotosm/id/dist/* public/static/id; elif ! (test -a public/static/rapid/index.js); then  cp -R node_modules/RapiD/dist/* public/static/rapid; fi\"",
-    "update-static": "bash -c \"mkdir -p public/static/id; mkdir -p public/static/rapid; cp -R node_modules/@hotosm/id/dist/* public/static/id;  cp -R node_modules/RapiD/dist/* public/static/rapid;\"",
+    "copy-static": "bash -c \"mkdir -p public/static/id; mkdir -p public/static/rapid; if ! (test -a public/static/id/index.js); then cp -R node_modules/@hotosm/id/dist/* public/static/id; fi; if ! (test -a public/static/rapid/index.js); then if ! (test -a node_modules/RapiD/dist/RapiD.css) then mv node_modules/RapiD/dist/iD.css node_modules/RapiD/dist/RapiD.css; fi; cp -R node_modules/RapiD/dist/* public/static/rapid; fi\"",
+    "update-static": "bash -c \"mkdir -p public/static/id; mkdir -p public/static/rapid; cp -R node_modules/@hotosm/id/dist/* public/static/id; if ! (test -a node_modules/RapiD/dist/RapiD.css) then mv node_modules/RapiD/dist/iD.css node_modules/RapiD/dist/RapiD.css; fi; cp -R node_modules/RapiD/dist/* public/static/rapid;\"",
     "preparation": "bash -c \"if (test -a ../tasking-manager.env); then grep -hs ^ ../tasking-manager.env .env.expand > .env; else cp .env.expand .env; fi\"",
     "start": "npm run preparation && npm run copy-static && react-scripts start",
     "build": "npm run preparation && npm run update-static && react-scripts build",

--- a/frontend/src/components/rapidEditor.js
+++ b/frontend/src/components/rapidEditor.js
@@ -1,119 +1,115 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import * as RapiD from 'RapiD/dist/iD.legacy';
-import 'RapiD/dist/iD.css';
+import 'RapiD/dist/RapiD.css';
 
 import { OSM_CONSUMER_KEY, OSM_CONSUMER_SECRET, OSM_SERVER_URL } from '../config';
 
 export default function RapidEditor({ setDisable, comment, presets, imagery, gpxUrl, powerUser = false }) {
   const dispatch = useDispatch();
   const session = useSelector((state) => state.auth.get('session'));
-  const iDContext = useSelector((state) => state.editor.context);
+  const RapiDContext = useSelector((state) => state.editor.rapidContext);
   const locale = useSelector((state) => state.preferences.locale);
   const [customImageryIsSet, setCustomImageryIsSet] = useState(false);
   const windowInit = typeof window !== undefined;
   const customSource =
-  iDContext && iDContext.background() && iDContext.background().findSource('custom');
+    RapiDContext && RapiDContext.background() && RapiDContext.background().findSource('custom');
 
-    useEffect(() => {
-      if (!customImageryIsSet && imagery && customSource) {
-        if (imagery.startsWith('http')) {
-          iDContext.background().baseLayerSource(customSource.template(imagery));
-          setCustomImageryIsSet(true);
-          // this line is needed to update the value on the custom background dialog
-          window.iD.prefs('background-custom-template', imagery);
+  useEffect(() => {
+    if (!customImageryIsSet && imagery && customSource) {
+      if (imagery.startsWith('http')) {
+        RapiDContext.background().baseLayerSource(customSource.template(imagery));
+        setCustomImageryIsSet(true);
+        // this line is needed to update the value on the custom background dialog
+        window.iD.prefs('background-custom-template', imagery);
+      } else {
+        const imagerySource = RapiDContext.background().findSource(imagery);
+        if (imagerySource) {
+          RapiDContext.background().baseLayerSource(imagerySource);
+        }
+      }
+    }
+  }, [customImageryIsSet, imagery, RapiDContext, customSource]);
+
+  useEffect(() => {
+    return () => {
+      dispatch({ type: 'SET_VISIBILITY', isVisible: true });
+    };
+    // eslint-disable-next-line
+  }, []);
+
+  useEffect(() => {
+    if (windowInit) {
+      dispatch({ type: 'SET_VISIBILITY', isVisible: false });
+      if (RapiDContext === null) {
+        // we need to keep iD context on redux store because iD works better if
+        // the context is not restarted while running in the same browser session
+        dispatch({ type: 'SET_RAPIDEDITOR', context: window.iD.coreContext() })
+      }
+
+    }
+  }, [windowInit, RapiDContext, dispatch]);
+
+  useEffect(() => {
+    if (RapiDContext && comment) {
+      RapiDContext.defaultChangesetComment(comment);
+    }
+  }, [comment, RapiDContext]);
+
+  useEffect(() => {
+    if (session && locale && RapiD && RapiDContext) {
+      // if presets is not a populated list we need to set it as null
+      try {
+        if (presets.length) {
+          window.iD.presetManager.addablePresetIDs(presets);
         } else {
-          const imagerySource = iDContext.background().findSource(imagery);
-          if (imagerySource) {
-            iDContext.background().baseLayerSource(imagerySource);
-          }
-        }
-      }
-    }, [customImageryIsSet, imagery, iDContext, customSource]);
-
-    useEffect(() => {
-      return () => {
-        dispatch({ type: 'SET_VISIBILITY', isVisible: true });
-      };
-      // eslint-disable-next-line
-    }, []);
-
-    useEffect(() => {
-      if (windowInit) {
-        dispatch({ type: 'SET_VISIBILITY', isVisible: false });
-        if (iDContext === null) {
-          // we need to keep iD context on redux store because iD works better if
-          // the context is not restarted while running in the same browser session
-          dispatch({ type: 'SET_EDITOR', context: window.iD.coreContext()})
-      //   } else{
-      //     if (RapiDContext === null) {
-      //       dispatch({ type: 'SET_EDITOR', context: iDContext, rapidContext: window.iD.coreRapidContext(())})
-      //     }
-      // }
-        }
-      }
-    }, [windowInit, iDContext, dispatch]);
-
-    useEffect(() => {
-      if (iDContext && comment) {
-        iDContext.defaultChangesetComment(comment);
-      }
-    }, [comment, iDContext]);
-
-    useEffect(() => {
-      if (session && locale && RapiD && iDContext) {
-        // if presets is not a populated list we need to set it as null
-        try {
-          if (presets.length) {
-            window.iD.presetManager.addablePresetIDs(presets);
-          } else {
-            window.iD.presetManager.addablePresetIDs(null);
-          }
-        } catch (e) {
           window.iD.presetManager.addablePresetIDs(null);
         }
-        // setup the context
-        iDContext
-          .embed(true)
-          .assetPath('/static/rapid/')
-          .locale(locale)
-          .setsDocumentTitle(false)
-          .containerNode(document.getElementById('id-container'));
-        // init the ui or restart if it was loaded previously
-        if (iDContext.ui() !== undefined) {
-          iDContext.reset();
-          iDContext.ui().restart();
-        } else {
-          iDContext.init();
-        }
-        if (gpxUrl) {
-          iDContext.layers().layer('data').url(gpxUrl, '.gpx');
-        }
-
-        iDContext.rapidContext().showPowerUser = powerUser;
-
-        let osm = iDContext.connection();
-        const auth = {
-          urlroot: OSM_SERVER_URL,
-          oauth_consumer_key: OSM_CONSUMER_KEY,
-          oauth_secret: OSM_CONSUMER_SECRET,
-          oauth_token: session.osm_oauth_token,
-          oauth_token_secret: session.osm_oauth_token_secret,
-        };
-        osm.switch(auth);
-
-        const thereAreChanges = (changes) =>
-          changes.modified.length || changes.created.length || changes.deleted.length;
-
-          iDContext.history().on('change', () => {
-          if (thereAreChanges(iDContext.history().changes())) {
-            setDisable(true);
-          } else {
-            setDisable(false);
-          }
-        });
+      } catch (e) {
+        window.iD.presetManager.addablePresetIDs(null);
       }
-    }, [session, iDContext, setDisable, presets, locale, gpxUrl, powerUser]);
+      // setup the context
+      RapiDContext
+        .embed(true)
+        .assetPath('/static/rapid/')
+        .locale(locale)
+        .setsDocumentTitle(false)
+        .containerNode(document.getElementById('rapid-container'));
+      // init the ui or restart if it was loaded previously
+      if (RapiDContext.ui() !== undefined) {
+        RapiDContext.reset();
+        RapiDContext.ui().restart();
+      } else {
+        RapiDContext.init();
+      }
+      if (gpxUrl) {
+        RapiDContext.layers().layer('data').url(gpxUrl, '.gpx');
+      }
 
-  return <div className="w-100 vh-minus-77-ns" id="id-container"></div>;
+      RapiDContext.rapidContext().showPowerUser = powerUser;
+
+      let osm = RapiDContext.connection();
+      const auth = {
+        urlroot: OSM_SERVER_URL,
+        oauth_consumer_key: OSM_CONSUMER_KEY,
+        oauth_secret: OSM_CONSUMER_SECRET,
+        oauth_token: session.osm_oauth_token,
+        oauth_token_secret: session.osm_oauth_token_secret,
+      };
+      osm.switch(auth);
+
+      const thereAreChanges = (changes) =>
+        changes.modified.length || changes.created.length || changes.deleted.length;
+
+      RapiDContext.history().on('change', () => {
+        if (thereAreChanges(RapiDContext.history().changes())) {
+          setDisable(true);
+        } else {
+          setDisable(false);
+        }
+      });
+    }
+  }, [session, RapiDContext, setDisable, presets, locale, gpxUrl, powerUser]);
+
+  return <div className="w-100 vh-minus-77-ns" id="rapid-container"></div>;
 }

--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { navigate } from '@reach/router';
 import Popup from 'reactjs-popup';
+import ReactTooltip from 'react-tooltip';
 import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
@@ -224,7 +225,7 @@ export function CompletionTabForMapping({
           />
         </p>
       </div>
-      <div className="cf mv2">
+      <div className="cf mv2" data-tip>
         <Button
           className="bg-red white w-100 fl"
           onClick={() => submitTaskAsync.execute()}
@@ -238,6 +239,11 @@ export function CompletionTabForMapping({
           <FormattedMessage {...messages.submitTask} />
         </Button>
       </div>
+      {disabled &&
+        <ReactTooltip place="top">
+          <FormattedMessage {...messages.unsavedChangesTooltip} />
+        </ReactTooltip>
+      }
       <div className="cf pb1">
         <Button
           className="bg-blue-dark white w-50 fl"
@@ -332,6 +338,12 @@ export function CompletionTabForValidation({
         navigate(`../tasks/?filter=readyToValidate`);
       });
     }
+    else if (disabled) {
+      return new Promise((resolve, reject) => {
+        setShowMapChangesModal('unlock');
+        resolve();
+      });
+    }
   };
   const submitTaskAsync = useAsync(submitTask);
 
@@ -373,7 +385,7 @@ export function CompletionTabForValidation({
           />
         ))}
       </div>
-      <div className="cf mv3">
+      <div className="cf mv3" data-tip>
         <Button
           className="bg-red white w-100 fl"
           onClick={() => submitTaskAsync.execute()}
@@ -383,6 +395,11 @@ export function CompletionTabForValidation({
           <FormattedMessage {...messages[tasksIds.length > 1 ? 'submitTasks' : 'submitTask']} />
         </Button>
       </div>
+      {disabled &&
+        <ReactTooltip place="top">
+          <FormattedMessage {...messages.unsavedChangesTooltip} />
+        </ReactTooltip>
+      }
       <div className="cf">
         <Button
           className="blue-dark bg-white w-100 fl"
@@ -458,9 +475,8 @@ const TaskValidationSelector = ({
             <FormattedMessage {...messages.incomplete} />
           </label>
           <CustomButton
-            className={`${
-              showCommentInput ? 'b--red red' : 'b--grey-light blue-dark'
-            } bg-white ba br1 ml3 pv2 ph3`}
+            className={`${showCommentInput ? 'b--red red' : 'b--grey-light blue-dark'
+              } bg-white ba br1 ml3 pv2 ph3`}
             onClick={() => setShowCommentInput(!showCommentInput)}
             icon={
               comment ? (
@@ -608,7 +624,7 @@ export function SidebarToggle({ setShowSidebar }: Object) {
   );
 }
 
-function UnsavedMapChangesModalContent({ close, action }: Object) {
+export function UnsavedMapChangesModalContent({ close, action }: Object) {
   return (
     <div className="blue-dark bg-white pv2 pv4-ns ph2 ph4-ns tc">
       <div className="cf tc red pb3">
@@ -620,6 +636,7 @@ function UnsavedMapChangesModalContent({ close, action }: Object) {
       <div className="mv4 lh-title">
         {action === 'split' && <FormattedMessage {...messages.unsavedChangesToSplit} />}
         {action === 'unlock' && <FormattedMessage {...messages.unsavedChangesToUnlock} />}
+        {action === 'reload editor' && <FormattedMessage {...messages.unsavedChangesToReloadEditor} />}
       </div>
       <Button className="bg-red white" onClick={() => close()}>
         <FormattedMessage {...messages.closeModal} />

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -16,6 +16,14 @@ export default defineMessages({
     id: 'project.tasks.unsaved_map_changes.unlock',
     defaultMessage: 'Save or undo it to be able to select another task',
   },
+  unsavedChangesToReloadEditor: {
+    id: 'project.tasks.unsaved_map_changes.reload_editor',
+    defaultMessage: 'Save or undo it to be able to switch editors',
+  },
+  unsavedChangesTooltip: {
+    id: 'project.tasks.unsaved_map_changes.tooltip',
+    defaultMessage: 'You have unsaved edits. Save or undo them to submit this task.'
+  },
   closeModal: {
     id: 'project.tasks.unsaved_map_changes.actions.close_modal',
     defaultMessage: 'Close',

--- a/frontend/src/store/actions/editor.js
+++ b/frontend/src/store/actions/editor.js
@@ -1,3 +1,4 @@
 export const types = {
   SET_EDITOR: 'SET_EDITOR',
+  SET_RAPIDEDITOR: 'SET_RAPIDEDITOR',
 };

--- a/frontend/src/store/reducers/editor.js
+++ b/frontend/src/store/reducers/editor.js
@@ -2,6 +2,7 @@ import { types } from '../actions/editor';
 
 const initialState = {
   context: null,
+  rapidContext: null,
 };
 
 export function editorReducer(state = initialState, action) {
@@ -10,6 +11,12 @@ export function editorReducer(state = initialState, action) {
       return {
         ...state,
         context: action.context,
+      };
+    }
+    case types.SET_RAPIDEDITOR: {
+      return {
+        ...state,
+        rapidContext: action.context,
       };
     }
     default:

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4266,10 +4266,9 @@ JSONStream@0.8.0:
     jsonparse "0.0.5"
     through "~2.2.7"
 
-RapiD@facebookincubator/rapid#rapid-v1.1.8_tm:
-  version "1.1.8"
-  uid "6771b3ad6d353c63368cebf94d9d8d6a91d7fa34"
-  resolved "https://codeload.github.com/facebookincubator/rapid/tar.gz/6771b3ad6d353c63368cebf94d9d8d6a91d7fa34"
+RapiD@facebookincubator/rapid#rapid-v1.1.8-tm.1:
+  version "1.1.8-tm.1"
+  resolved "https://codeload.github.com/facebookincubator/rapid/tar.gz/dcd0f97a7e569e237e75aa3650987f39966d9f13"
   dependencies:
     "@id-sdk/math" "~3.0.0-pre.10"
     "@id-sdk/util" "~3.0.0-pre.10"


### PR DESCRIPTION
There was a problem reported with the RapiD integration when a user would attempt to switch editors from RapiD to iD when the user still had unsaved edits (#5025)

This PR does 3 main things to solve this issue:
1. Uses the `UnsavedMapChangesModalContent` component to show an alert if a user still has unsaved edits and tries to switch editors
![tm-rapid_unsaved_edits](https://user-images.githubusercontent.com/9849118/163267010-e4957b55-b268-4454-8d4f-c0183b653787.gif)
2. To make the actual component switch more performant, I changed how the editor switch is handled. Before, if you switched between RapiD and iD, it would reload the entire page; now it will only reload the single editor components.
3. To allow (2) to happen, I had to add a RAPIDCONTEXT to the redux store so the contexts don't get confused during the switch since they have slightly different values in their contexts.

Closes #5025