### PR TITLE
Fix JOSM doesn't load OSM data when attempting to map a task

### DIFF
--- a/frontend/src/components/taskSelection/footer.js
+++ b/frontend/src/components/taskSelection/footer.js
@@ -108,7 +108,9 @@ const TaskSelectionFooter = ({ defaultUserEditor, project, tasks, taskAction, se
       )
         .then((res) => {
           lockSuccess('LOCKED_FOR_MAPPING', 'map', windowObjectReference);
-          window.location.reload();
+          if (editor !== 'JOSM') {
+            window.location.reload();
+          }
         })
         .catch((e) => lockFailed(windowObjectReference, e.message));
     }


### PR DESCRIPTION
#5096 solves the issue in case of reloading the editor. i.e. when the user has already locked a task, but JOSM not loading OSM data was present while starting an editor also. i.e. while locking a task for mapping. This PR fixes the latter issue by not reloading the window if JOSM is selected as editor while locking a task for mapping.