### PR TITLE
Only show SERVICE_DESK link if variable is configured

### DIFF
--- a/frontend/src/components/header/index.js
+++ b/frontend/src/components/header/index.js
@@ -33,8 +33,11 @@ function getMenuItensForUser(userDetails, organisations) {
     { label: messages.manage, link: 'manage', authenticated: true, manager: true },
     { label: messages.learn, link: 'learn', showAlways: true },
     { label: messages.about, link: 'about', showAlways: true },
-    { label: messages.support, link: SERVICE_DESK, showAlways: true, serviceDesk: true },
   ];
+  if (SERVICE_DESK) {
+    menuItems.push({ label: messages.support, link: SERVICE_DESK, showAlways: true, serviceDesk: true });
+  }
+
   let filteredMenuItems;
   if (userDetails.username) {
     filteredMenuItems = menuItems.filter((item) => item.authenticated === true || item.showAlways);

--- a/frontend/src/components/header/tests/menuItens.test.js
+++ b/frontend/src/components/header/tests/menuItens.test.js
@@ -3,24 +3,28 @@ import { SERVICE_DESK } from '../../../config';
 
 it('test menuItems for unlogged user', () => {
   const userDetails = {};
-  const menuItems = getMenuItensForUser(userDetails, []).map((i) => i.link);
-  expect(menuItems).toEqual(['explore', 'learn', 'about', SERVICE_DESK]);
+  const menuItems = ['explore', 'learn', 'about'];
+  if (SERVICE_DESK) menuItems.push(SERVICE_DESK);
+  expect(getMenuItensForUser(userDetails, []).map((i) => i.link)).toEqual(menuItems);
 });
 
 it('test menuItems for logged non admin user', () => {
   const userDetails = { username: 'test', role: 'MAPPER' };
-  const menuItems = getMenuItensForUser(userDetails, []).map((i) => i.link);
-  expect(menuItems).toEqual(['explore', 'contributions', 'learn', 'about', SERVICE_DESK]);
+  const menuItems = ['explore', 'contributions', 'learn', 'about'];
+  if (SERVICE_DESK) menuItems.push(SERVICE_DESK);
+  expect(getMenuItensForUser(userDetails, []).map((i) => i.link)).toEqual(menuItems);
 });
 
 it('test menuItems for logged non admin user, but org manager', () => {
   const userDetails = { username: 'test', role: 'MAPPER' };
-  const menuItems = getMenuItensForUser(userDetails, [1, 3, 4]).map((i) => i.link);
-  expect(menuItems).toEqual(['explore', 'contributions', 'manage', 'learn', 'about', SERVICE_DESK]);
+  const menuItems = ['explore', 'contributions', 'manage', 'learn', 'about'];
+  if (SERVICE_DESK) menuItems.push(SERVICE_DESK);
+  expect(getMenuItensForUser(userDetails, [1, 3, 4]).map((i) => i.link)).toEqual(menuItems);
 });
 
 it('test menuItems for logged admin user', () => {
   const userDetails = { username: 'test', role: 'ADMIN' };
-  const menuItems = getMenuItensForUser(userDetails, []).map((i) => i.link);
-  expect(menuItems).toEqual(['explore', 'contributions', 'manage', 'learn', 'about', SERVICE_DESK]);
+  const menuItems = ['explore', 'contributions', 'manage', 'learn', 'about'];
+  if (SERVICE_DESK) menuItems.push(SERVICE_DESK);
+  expect(getMenuItensForUser(userDetails, []).map((i) => i.link)).toEqual(menuItems);
 });


### PR DESCRIPTION
If the SERVICE_DESK env var wasn't configured, it was generating a wrong link. This PR makes that navigation link optional to each instance.