### PR TITLE
Update team members list when joining or leaving

### DIFF
--- a/frontend/src/views/teams.js
+++ b/frontend/src/views/teams.js
@@ -373,7 +373,10 @@ export function TeamDetail(props) {
       JSON.stringify({ role: 'MEMBER', username: userDetails.username }),
       token,
       'POST',
-    ).then((res) => setIsMember(team.inviteOnly ? 'requested' : true));
+    ).then((res) => {
+      setIsMember(team.inviteOnly ? 'requested' : true);
+      setMembers((members) => [...members, userDetails]);
+    });
   };
 
   const leaveTeam = () => {
@@ -382,7 +385,10 @@ export function TeamDetail(props) {
       JSON.stringify({ username: userDetails.username }),
       token,
       'POST',
-    ).then((res) => setIsMember(false));
+    ).then((res) => {
+      setIsMember(false);
+      setMembers((members) => members.filter((member) => member.username !== userDetails.username));
+    });
   };
 
   if (!loading && error) {


### PR DESCRIPTION
Closes #2334 

![Peek 2022-05-08 13-47](https://user-images.githubusercontent.com/51614993/167287247-8512b724-07fd-4fb6-a8c8-32099c6bcc18.gif)

Appends logged in user details to the members' state and renders that rather than updating state with an API call.

