### PR TITLE
Add checkbox to redirect to previous project after unlocking task in another project

### DIFF
--- a/frontend/src/components/taskSelection/action.js
+++ b/frontend/src/components/taskSelection/action.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { navigate } from '@reach/router';
+import { navigate, useLocation } from '@reach/router';
 import ReactPlaceholder from 'react-placeholder';
 import Popup from 'reactjs-popup';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -37,6 +37,7 @@ const Editor = React.lazy(() => import('../editor'));
 const RapiDEditor = React.lazy(() => import('../rapidEditor'));
 
 export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, action, editor }) {
+  const location = useLocation();
   useSetProjectPageTitleTag(project);
   const userDetails = useSelector((state) => state.auth.get('userDetails'));
   const token = useSelector((state) => state.auth.get('token'));
@@ -131,6 +132,15 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
       }
     }
   }, [editor, project, projectIsReady, userDetails.defaultEditor, action, tasks, tasksIds]);
+
+  useEffect(() => {
+    if (location.state?.directedFrom) {
+      localStorage.setItem('lastProjectPathname', location.state.directedFrom);
+    } else {
+      localStorage.removeItem('lastProjectPathname');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const callEditor = async (arr) => {
     setIsJosmError(false);

--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -6,6 +6,7 @@ import ReactTooltip from 'react-tooltip';
 import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
+import { CheckBoxInput } from '../formInputs';
 import { Button, CustomButton } from '../button';
 import { Dropdown } from '../dropdown';
 import { CheckCircle } from '../checkCircle';
@@ -47,9 +48,11 @@ export function CompletionTabForMapping({
   const [showHelp, setShowHelp] = useState(false);
   const [showMapChangesModal, setShowMapChangesModal] = useState(false);
   const [splitTaskError, setSplitTaskError] = useState(false);
+  const [redirectToPreviousProject, setRedirectToPreviousProject] = useState(true);
   const radioInput = 'radio-input input-reset pointer v-mid dib h2 w2 mr2 br-100 ba b--blue-light';
   const fetchLockedTasks = useFetchLockedTasks();
   const clearLockedTasks = useClearLockedTasks();
+  const directedFrom = localStorage.getItem('lastProjectPathname');
 
   const splitTask = () => {
     if (!disabled) {
@@ -60,7 +63,7 @@ export function CompletionTabForMapping({
       )
         .then((r) => {
           clearLockedTasks();
-          navigate(`../tasks/`);
+          navigate((redirectToPreviousProject && directedFrom) || `../tasks/`);
         })
         .catch((e) => {
           setSplitTaskError(true);
@@ -83,7 +86,9 @@ export function CompletionTabForMapping({
         token,
       ).then((r) => {
         clearLockedTasks();
-        navigate(`/projects/${project.projectId}/tasks/`);
+        navigate(
+          (redirectToPreviousProject && directedFrom) || `/projects/${project.projectId}/tasks/`,
+        );
       });
     } else {
       return new Promise((resolve, reject) => {
@@ -111,7 +116,9 @@ export function CompletionTabForMapping({
       }
       return pushToLocalJSONAPI(url, JSON.stringify(payload), token).then((r) => {
         fetchLockedTasks();
-        navigate(`/projects/${project.projectId}/tasks/`);
+        navigate(
+          (redirectToPreviousProject && directedFrom) || `/projects/${project.projectId}/tasks/`,
+        );
       });
     }
   };
@@ -225,6 +232,22 @@ export function CompletionTabForMapping({
           />
         </p>
       </div>
+      {directedFrom && (
+        <div className="flex items-center">
+          <CheckBoxInput
+            changeState={() => setRedirectToPreviousProject(!redirectToPreviousProject)}
+            isActive={redirectToPreviousProject}
+          />
+          <label>
+            <FormattedMessage
+              {...messages.redirectToPreviousProject}
+              values={{
+                projectId: directedFrom.split('/')[2],
+              }}
+            />
+          </label>
+        </div>
+      )}
       <div className="cf mv2" data-tip>
         <Button
           className="bg-red white w-100 fl"
@@ -239,11 +262,11 @@ export function CompletionTabForMapping({
           <FormattedMessage {...messages.submitTask} />
         </Button>
       </div>
-      {disabled &&
+      {disabled && (
         <ReactTooltip place="top">
           <FormattedMessage {...messages.unsavedChangesTooltip} />
         </ReactTooltip>
-      }
+      )}
       <div className="cf pb1">
         <Button
           className="bg-blue-dark white w-50 fl"
@@ -280,8 +303,10 @@ export function CompletionTabForValidation({
 }: Object) {
   const token = useSelector((state) => state.auth.get('token'));
   const [showMapChangesModal, setShowMapChangesModal] = useState(false);
+  const [redirectToPreviousProject, setRedirectToPreviousProject] = useState(true);
   const fetchLockedTasks = useFetchLockedTasks();
   const clearLockedTasks = useClearLockedTasks();
+  const directedFrom = localStorage.getItem('lastProjectPathname');
 
   const updateStatus = (id, newStatus) =>
     setValidationStatus({ ...validationStatus, [id]: newStatus });
@@ -312,7 +337,7 @@ export function CompletionTabForValidation({
         token,
       ).then((r) => {
         clearLockedTasks();
-        navigate(`../tasks/`);
+        navigate((redirectToPreviousProject && directedFrom) || `../tasks/`);
       });
     } else {
       return new Promise((resolve, reject) => {
@@ -335,10 +360,9 @@ export function CompletionTabForValidation({
       };
       return pushToLocalJSONAPI(url, JSON.stringify(payload), token).then((r) => {
         fetchLockedTasks();
-        navigate(`../tasks/?filter=readyToValidate`);
+        navigate((redirectToPreviousProject && directedFrom) || `../tasks/?filter=readyToValidate`);
       });
-    }
-    else if (disabled) {
+    } else if (disabled) {
       return new Promise((resolve, reject) => {
         setShowMapChangesModal('unlock');
         resolve();
@@ -385,6 +409,22 @@ export function CompletionTabForValidation({
           />
         ))}
       </div>
+      {directedFrom && (
+        <div className="flex items-center">
+          <CheckBoxInput
+            changeState={() => setRedirectToPreviousProject(!redirectToPreviousProject)}
+            isActive={redirectToPreviousProject}
+          />
+          <label>
+            <FormattedMessage
+              {...messages.redirectToPreviousProject}
+              values={{
+                projectId: directedFrom.split('/')[2],
+              }}
+            />
+          </label>
+        </div>
+      )}
       <div className="cf mv3" data-tip>
         <Button
           className="bg-red white w-100 fl"
@@ -395,11 +435,11 @@ export function CompletionTabForValidation({
           <FormattedMessage {...messages[tasksIds.length > 1 ? 'submitTasks' : 'submitTask']} />
         </Button>
       </div>
-      {disabled &&
+      {disabled && (
         <ReactTooltip place="top">
           <FormattedMessage {...messages.unsavedChangesTooltip} />
         </ReactTooltip>
-      }
+      )}
       <div className="cf">
         <Button
           className="blue-dark bg-white w-100 fl"
@@ -475,8 +515,9 @@ const TaskValidationSelector = ({
             <FormattedMessage {...messages.incomplete} />
           </label>
           <CustomButton
-            className={`${showCommentInput ? 'b--red red' : 'b--grey-light blue-dark'
-              } bg-white ba br1 ml3 pv2 ph3`}
+            className={`${
+              showCommentInput ? 'b--red red' : 'b--grey-light blue-dark'
+            } bg-white ba br1 ml3 pv2 ph3`}
             onClick={() => setShowCommentInput(!showCommentInput)}
             icon={
               comment ? (
@@ -636,7 +677,9 @@ export function UnsavedMapChangesModalContent({ close, action }: Object) {
       <div className="mv4 lh-title">
         {action === 'split' && <FormattedMessage {...messages.unsavedChangesToSplit} />}
         {action === 'unlock' && <FormattedMessage {...messages.unsavedChangesToUnlock} />}
-        {action === 'reload editor' && <FormattedMessage {...messages.unsavedChangesToReloadEditor} />}
+        {action === 'reload editor' && (
+          <FormattedMessage {...messages.unsavedChangesToReloadEditor} />
+        )}
       </div>
       <Button className="bg-red white" onClick={() => close()}>
         <FormattedMessage {...messages.closeModal} />

--- a/frontend/src/components/taskSelection/lockedTasks.js
+++ b/frontend/src/components/taskSelection/lockedTasks.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link, navigate } from '@reach/router';
+import { Link, navigate, useLocation } from '@reach/router';
 import { fetchLocalJSONAPI, pushToLocalJSONAPI } from '../../network/genericJSONRequest';
 import { useSelector } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
@@ -9,6 +9,8 @@ import { Button } from '../button';
 import { useGetLockedTasks } from '../../hooks/UseLockedTasks';
 
 export function AnotherProjectLock({ projectId, lockedTasksLength, action }: Object) {
+  const location = useLocation();
+
   return (
     <>
       <h3 className="barlow-condensed f3 fw6 mv0">
@@ -32,7 +34,7 @@ export function AnotherProjectLock({ projectId, lockedTasksLength, action }: Obj
           }}
         />
       </div>
-      <Link to={`/projects/${projectId}/${action}/`}>
+      <Link to={`/projects/${projectId}/${action}/`} state={{ directedFrom: location.pathname }}>
         <Button className="bg-red white">
           <FormattedMessage {...messages.goToProject} values={{ project: projectId }} />
         </Button>

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -445,6 +445,10 @@ export default defineMessages({
     id: 'project.tasks.action.comment.title',
     defaultMessage: 'Comment',
   },
+  redirectToPreviousProject: {
+    id: 'project.tasks.action.redirectToPreviousProject',
+    defaultMessage: 'Redirect to previous project #{projectId}',
+  },
   commentPlaceholder: {
     id: 'project.tasks.action.comment.input.placeholder',
     defaultMessage: 'Write a comment on this task',

--- a/frontend/src/components/taskSelection/tests/lockedTasks.test.js
+++ b/frontend/src/components/taskSelection/tests/lockedTasks.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import { FormattedMessage } from 'react-intl';
+import { createHistory, createMemorySource } from '@reach/router';
 import '@testing-library/jest-dom/extend-expect';
 import {
   LockedTaskModalContent,
@@ -12,8 +13,17 @@ import {
 import { createComponentWithReduxAndIntl } from '../../../utils/testWithIntl';
 import { store } from '../../../store';
 
+jest.mock('@reach/router', () => ({
+  ...jest.requireActual('@reach/router'),
+  useLocation: () => ({
+    pathname: 'localhost:3000/example/path',
+  }),
+}));
+
 describe('test LockedTaskModalContent', () => {
   const { act } = TestRenderer;
+  const history = createHistory(createMemorySource('/'));
+  jest.spyOn(history, 'navigate');
   it('return SameProjectLock message', () => {
     act(() => {
       store.dispatch({ type: 'SET_PROJECT', project: 1 });


### PR DESCRIPTION
If I'm trying to map a task in Project X, but I have a task locked in Project Y, I'd have to unlock the task in Project Y first to map the task in Project X. After unlocking the task in Project Y, there wasn't an option to be redirected to Project X.

This PR adds a checkbox input field that can be toggled to be redirected to Project X after unlocking the task in Project Y.

![redirect-prev](https://user-images.githubusercontent.com/51614993/167475496-d37c9abd-c948-4fea-a186-8e18ca206fdd.png)

