### PR TITLE
Fix active nav bar and tab indicator

### DIFF
--- a/frontend/src/components/header/index.js
+++ b/frontend/src/components/header/index.js
@@ -161,8 +161,8 @@ const PopupItems = (props) => {
 
 class Header extends React.Component {
   linkCombo = 'link mh3 barlow-condensed blue-dark f4 ttu';
-  isActive = ({ isCurrent }) => {
-    return isCurrent
+  isActive = ({ isPartiallyCurrent }) => {
+    return isPartiallyCurrent
       ? { className: `${this.linkCombo} bb b--blue-dark bw1 pv2` }
       : { className: this.linkCombo };
   };

--- a/frontend/src/components/menu.js
+++ b/frontend/src/components/menu.js
@@ -2,12 +2,14 @@ import React from 'react';
 import { TopNavLink } from './header/NavLink';
 
 export function SectionMenu({ items }: Object) {
-  const isActive = ({ isCurrent }) => {
+  const isActive = (props) => {
+    const splitHref = props.href.split('?')[0];
     const linkCombo = 'link mh2 blue-dark ttc';
-    return isCurrent
+    return splitHref === props.location.pathname
       ? { className: `${linkCombo} bb b--blue-dark bw1 pb1` }
       : { className: linkCombo };
   };
+  
   return (
     <div className="cf mb2 pb3 pt3-ns ph4 ph2-m bg-grey-light dib">
       {items.map((item, n) => (

--- a/frontend/src/components/teamsAndOrgs/menu.js
+++ b/frontend/src/components/teamsAndOrgs/menu.js
@@ -28,6 +28,10 @@ export function ManagementMenu({ isAdmin }: Object) {
     url: '/manage/stats/',
     label: <FormattedMessage {...messages.statistics} />,
   });
+  items.unshift({
+    url: '/manage',
+    label: <FormattedMessage {...messages.overview} />,
+  });
 
   return <SectionMenu items={items} />;
 }

--- a/frontend/src/components/teamsAndOrgs/messages.js
+++ b/frontend/src/components/teamsAndOrgs/messages.js
@@ -435,4 +435,8 @@ export default defineMessages({
     id: 'management.stats.title',
     defaultMessage: 'Statistics',
   },
+  overview: {
+    id: 'management.stats.overview',
+    defaultMessage: 'Overview',
+  },
 });

--- a/frontend/src/components/teamsAndOrgs/tests/menu.test.js
+++ b/frontend/src/components/teamsAndOrgs/tests/menu.test.js
@@ -12,6 +12,7 @@ describe('ManagementMenu items for', () => {
         <ManagementMenu isAdmin={true} />
       </ReduxIntlProviders>,
     );
+    expect(screen.getByText('Overview').closest('a').href).toContain('/');
     expect(screen.getByText('Statistics').closest('a').href).toContain('/stats');
     expect(screen.getByText('Users').closest('a').href).toContain('/users');
     expect(screen.getByText('Licenses').closest('a').href).toContain('/licenses');
@@ -22,12 +23,13 @@ describe('ManagementMenu items for', () => {
     expect(screen.getByText('Teams').closest('a').href).toContain('/teams');
   });
 
-  it('non ADMIN users can see only Statistics and other 3 items', () => {
+  it('non ADMIN users can see only Statistics and other 4 items', () => {
     render(
       <ReduxIntlProviders>
         <ManagementMenu isAdmin={false} />
       </ReduxIntlProviders>,
     );
+    expect(screen.getByText('Overview').closest('a').href).toContain('/');
     expect(screen.getByText('Statistics').closest('a').href).toContain('/stats');
     expect(screen.getByText('Projects').closest('a').href).toContain('/projects');
     expect(screen.getByText('Organizations').closest('a').href).toContain('/organisations');

--- a/frontend/src/components/userDetail/headerProfile.js
+++ b/frontend/src/components/userDetail/headerProfile.js
@@ -101,7 +101,7 @@ const MyContributionsNav = ({ username, authUser }) => {
   const items = [
     { url: `/contributions`, label: <FormattedMessage {...messages.myStats} /> },
     {
-      url: '/contributions/projects/?mappedByMe=1&action=any',
+      url: '/contributions/projects?mappedByMe=1&action=any',
       label: <FormattedMessage {...messages.myProjects} />,
     },
     { url: '/contributions/tasks', label: <FormattedMessage {...messages.myTasks} /> },


### PR DESCRIPTION
This PR does the following two things:
- Improves the logic to calculate if a tab route is currently active.
- Adds an 'Overview' tab to the management section for an overall consistent navigation landing experience.

**Improves the logic to calculate if a tab route is currently active.**

When you click on the 'My Contributions' navigation menu on the header, you can see that the active tab indicator (the underline thingy) below 'My Contributions' and 'My Stats' is present, which is correct.

But for other tabs, the indicators were missing. You can see that the indicator on 'My Contributions' on the navbar gets removed when you navigate to other tabs. The 'Projects' tab doesn't show any indicator at all. 
![Peek 2022-05-18 10-52](https://user-images.githubusercontent.com/51614993/168961432-94480c44-0abb-4a60-9f0d-e76f234b7da5.gif)

Fixed:
![Peek 2022-05-18 10-57](https://user-images.githubusercontent.com/51614993/168961953-a3da4374-372f-4c24-96c7-01a4732cd901.gif)


**Adds an 'Overview' tab to the management section for an overall consistent navigation landing experience.**
When you visit the 'My Contributions' page or the 'Learn' page, you'll land on a default tab - 'My Stats' for 'My Contributions' and  'Learn to map' for 'Learn'. The 'Manage' page, however, misses a default landing tab. No tab is selected as default, which feels different from the former two pages.
![manage-no-tab](https://user-images.githubusercontent.com/51614993/168963137-f6bf941d-55ad-4c21-823b-43b87c82df63.png)

An 'Overview' tab has been added, which possibly poses a consistent experience.

![overview-tab](https://user-images.githubusercontent.com/51614993/168963333-7fc35be2-7d87-44a5-a308-cd37439fd4a5.png)




