### PR TITLE
Handle special chars in project search text

### DIFF
--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -295,9 +295,10 @@ class ProjectSearchService:
 
         if search_dto.text_search:
             # We construct an OR search, so any projects that contain or more of the search terms should be returned
-            or_search = " | ".join(
-                [x for x in search_dto.text_search.split(" ") if x != ""]
+            search_text = "".join(
+                char for char in search_dto.text_search if char.isalnum() or char == " "
             )
+            or_search = " | ".join([x for x in search_text.split(" ") if x != ""])
             opts = [
                 ProjectInfo.text_searchable.match(
                     or_search, postgresql_regconfig="english"


### PR DESCRIPTION
This PR fixes #5118 by removing special characters found on searched text as some of the special characters work as text search operators in Postgres which leads to an error  [more info](https://github.com/hotosm/tasking-manager/issues/5118#issuecomment-1120673593).