### PR TITLE
Fixed conditionals for commend textarea outline

### DIFF
--- a/frontend/src/components/comments/commentInput.js
+++ b/frontend/src/components/comments/commentInput.js
@@ -91,7 +91,7 @@ export const UserFetchTextarea = ({
 
   return (
     <>
-      <div className="comment-textarea">
+      <div className={`${isProjectDetailCommentSection && 'comment-textarea'}`}>
         <ReactTextareaAutocomplete
           {...inputProps}
           value={value}
@@ -105,7 +105,7 @@ export const UserFetchTextarea = ({
             fontSize: '1rem',
             resize: 'vertical',
             borderBottom: `${isProjectDetailCommentSection && '1px dashed'}`,
-            outline: 'none',
+            outline: `${isProjectDetailCommentSection && 'none'}`,
           }}
           loadingComponent={() => <span></span>}
           rows={3}


### PR DESCRIPTION
Textarea outline for the comment textarea in validation status section is displaced. 
![Screenshot from 2022-05-26 14-57-14](https://user-images.githubusercontent.com/51614993/170457610-94ef1e64-b82e-4c37-8e73-945bb60cc0a1.png)

This PR fixes that.
![Screenshot from 2022-05-26 15-01-35](https://user-images.githubusercontent.com/51614993/170458227-562fbd85-c37c-40cb-bdd5-442a9c24de39.png)

