### PR TITLE
Resize map canvas on map load

### DIFF
--- a/frontend/src/components/taskSelection/map.js
+++ b/frontend/src/components/taskSelection/map.js
@@ -129,6 +129,9 @@ export const TasksMap = ({
     };
 
     const mapboxLayerDefn = () => {
+      map.once('load', () => {
+        map.resize();
+      });
       if (map.getSource('tasks') === undefined) {
         map.addImage('lock', lockIcon, { width: 17, height: 20, data: lockIcon });
         map.addImage('redlock', redlockIcon, { width: 30, height: 30, data: redlockIcon });


### PR DESCRIPTION
Closes #3512 

Canvas size has been fixed but seems to still have issues with the project boundary not being zoomed as expected occasionally though. The previously small map canvas would look like the below.

![small](https://user-images.githubusercontent.com/51614993/172044283-6d7f293a-2a9d-4f41-b23c-763da15e6cfa.png)

But it should have looked like this
![not-small](https://user-images.githubusercontent.com/51614993/172044316-ef4a202c-ecac-405d-86e2-373cf0a4c968.png)

Seems to be a known [issue](https://github.com/mapbox/mapbox-gl-js/issues/3265) in mapbox-gl-js


