### PR TITLE
Display message when project's mapping/validation permissions are set to team only but no team is added

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1123,6 +1123,7 @@
   "pages.edit_project.actions.update.error": "Saving the project failed because of a Server Error. Please try again later or contact the administrator if problem persists.",
   "pages.edit_project.actions.missing_fields": "{number, plural, one {One required field is missing:} other {Some required fields are missing:}}",
   "pages.edit_project.actions.missing_fields_for_locale": "Missing information in the project's default language ({locale}):",
+  "pages.edit_project.actions.missing_fields_for_teams": "{mapping, select, true {Mapping} other {{validation, select, true {Validation} other {}}}} {mapping, select, true {{validation, select, true {and validation} other {}}} other {}} permissions have been set only to team members but no team has been added.",
   "pages.edit_project.sections.description": "Description",
   "pages.edit_project.sections.instructions": "Instructions",
   "pages.edit_project.sections.metadata": "Metadata",

--- a/frontend/src/views/messages.js
+++ b/frontend/src/views/messages.js
@@ -660,6 +660,11 @@ export default defineMessages({
     id: 'pages.edit_project.actions.missing_fields_for_locale',
     defaultMessage: "Missing information in the project's default language ({locale}):",
   },
+  noTeamsAssigned: {
+    id: 'pages.edit_project.actions.missing_fields_for_teams',
+    defaultMessage:
+      '{mapping, select, true {Mapping} other {{validation, select, true {Validation} other {}}}} {mapping, select, true {{validation, select, true {and validation} other {}}} other {}} permissions have been set only to team members but no team has been added.',
+  },
   projectEditSection_description: {
     id: 'pages.edit_project.sections.description',
     defaultMessage: 'Description',


### PR DESCRIPTION
Closes https://github.com/hotosm/tasking-manager/issues/3143

![permissions-msg](https://user-images.githubusercontent.com/51614993/173624593-1662e1ec-14b5-4989-9430-b3582100a4a2.png)

The message is shown on the left bottom side of the screenshot above. Users won't be able to save the project until a team is assigned.

