### PR TITLE
Fix logic to not show error on project detail page

### DIFF
--- a/frontend/src/views/project.js
+++ b/frontend/src/views/project.js
@@ -178,6 +178,8 @@ export const MoreFilters = (props) => {
 export const ProjectDetailPage = (props) => {
   const [error, loading, data] = useFetch(`projects/${props.id}/`, props.id);
 
+  console.log('error>>>', !!error);
+
   return (
     <ReactPlaceholder showLoadingAnimation={true} rows={30} delay={1000} ready={loading === false}>
       {!error && (
@@ -190,10 +192,14 @@ export const ProjectDetailPage = (props) => {
           type="detail"
         />
       )}
-      {error?.message === 'PrivateProject' ? (
-        <PrivateProjectError />
-      ) : (
-        <NotFound projectId={props.id} />
+      {error && (
+        <>
+          {error.message === 'PrivateProject' ? (
+            <PrivateProjectError />
+          ) : (
+            <NotFound projectId={props.id} />
+          )}
+        </>
       )}
     </ReactPlaceholder>
   );


### PR DESCRIPTION
The project not found error, like on the screenshot below, is being shown even when project detail loads successfully. This PR fixes it.

![error-dekhaira](https://user-images.githubusercontent.com/51614993/174007693-e8eb87c1-c18a-402e-a741-2e3816de17ca.png)
.