### PR TITLE
Consistent cards heights in the mapping flow section

### DIFF
--- a/frontend/src/components/homepage/mappingFlow.js
+++ b/frontend/src/components/homepage/mappingFlow.js
@@ -6,8 +6,8 @@ import { MappingIcon, ValidationIcon, DataUseIcon } from '../svgIcons';
 
 function MappingCard({ image, title, description }: Object) {
   return (
-    <div className="w-third-l w-100 dib fl ph2-l pv3">
-      <div className="shadow-4 mh2">
+    <div className="w-100 w-third-l">
+      <div className="shadow-4 h-100">
         <div className="pa4 ph3-m">
           <div className="red dib">{image}</div>
           <h4 className="blue-dark b">
@@ -52,7 +52,7 @@ export function MappingFlow() {
       <p className="pr2 f5 f4-ns blue-dark lh-title mw7 mb4">
         <FormattedMessage {...messages.mappingFlowHeadline} />
       </p>
-      <div className="cf">
+      <div className="flex flex-column flex-row-l" style={{ gap: '2.25rem' }}>
         {cards.map((card, n) => (
           <MappingCard {...card} key={n} />
         ))}

--- a/frontend/src/components/homepage/mappingFlow.js
+++ b/frontend/src/components/homepage/mappingFlow.js
@@ -6,7 +6,7 @@ import { MappingIcon, ValidationIcon, DataUseIcon } from '../svgIcons';
 
 function MappingCard({ image, title, description }: Object) {
   return (
-    <div className="w-100 w-third-l">
+    <div className="w-100 w-third-l pv3">
       <div className="shadow-4 h-100">
         <div className="pa4 ph3-m">
           <div className="red dib">{image}</div>


### PR DESCRIPTION
This PR adds a fix to make the heights of cards in the mapping flow section consistent. It also removes the whitespace on the outer edges.

Before:
![before](https://user-images.githubusercontent.com/51614993/176938062-e81a7d51-3588-432f-8828-b26901bf56c1.png)

After:
![after](https://user-images.githubusercontent.com/51614993/176938394-2151679b-e656-4def-8155-41a892c546dc.png)


