### PR TITLE
Apply sticky position to some components

### DIFF
--- a/frontend/src/assets/styles/_extra.scss
+++ b/frontend/src/assets/styles/_extra.scss
@@ -334,3 +334,8 @@ div.messageBodyLinks {
     }
   }
 }
+
+.sticky-top {
+  position: sticky !important;
+  top: 0;
+}

--- a/frontend/src/views/project.js
+++ b/frontend/src/views/project.js
@@ -70,7 +70,7 @@ export const ProjectsPage = (props) => {
             state={state}
             fullProjectsQuery={fullProjectsQuery}
             setQuery={setProjectQuery}
-            className={`dib w-40-l w-100 fl`}
+            className={`dib w-40-l w-100 fl sticky-top`}
           />
         )}
       </section>
@@ -142,7 +142,7 @@ export const UserProjectsPage = (props) => {
             state={state}
             fullProjectsQuery={fullProjectsQuery}
             setQuery={setProjectQuery}
-            className={`dib w-40-l w-100 fl`}
+            className={`dib w-40-l w-100 fl sticky-top`}
           />
         )}
       </section>

--- a/frontend/src/views/projectEdit.js
+++ b/frontend/src/views/projectEdit.js
@@ -259,7 +259,7 @@ export default function ProjectEdit({ id }) {
       <h2 className="pb2 f2 fw6 mt2 mb3 ttu barlow-condensed blue-dark">
         <FormattedMessage {...messages.editProject} />
       </h2>
-      <div className="fl w-30-l w-100 ph0-ns ph4-m ph2 pb4">
+      <div className="fl w-30-l w-100 ph0-ns ph4-m ph2 pb4 sticky-top">
         <ReactPlaceholder
           showLoadingAnimation={true}
           rows={8}


### PR DESCRIPTION
Namely map on the 'explore projects' page, map on the user's projects section on the contributions page and categories on the project edit page.

Notice how the left section, i.e. the categories on the image below, stays fixed on its position while the area on the right scrolls.
![project-edit](https://user-images.githubusercontent.com/51614993/179673695-97d3b115-98e7-41e6-bf79-55fdce7b2bfb.gif)

Similarly, on the 'Explore projects' section and the 'My projects' tab on 'My Contributions' page- the map stays fixed until users scroll to the end of the projects list.
![sticky-map](https://user-images.githubusercontent.com/51614993/179673710-01090c96-67e4-43cd-8a91-28dc24f27c23.gif)
