### PR TITLE
Remove default options to not prepopulate options without a query

### DIFF
--- a/frontend/src/components/teamsAndOrgs/members.js
+++ b/frontend/src/components/teamsAndOrgs/members.js
@@ -85,15 +85,18 @@ export function Members({
           {editMode && (
             <AsyncSelect
               classNamePrefix="react-select"
+              autoFocus
               isMulti
               cacheOptions
-              defaultOptions
               placeholder={selectPlaceHolder}
               isClearable={false}
               isOptionDisabled={(option) => doesMemberExistInTeam(option.username)}
               formatOptionLabel={(option, menu) => formatOptionLabel(option, menu)}
               getOptionLabel={(option) => option.username}
               getOptionValue={(option) => option.username}
+              noOptionsMessage={({ inputValue }) =>
+                inputValue ? <FormattedMessage {...messages.noOptions} /> : null
+              }
               loadOptions={promiseOptions}
               onChange={(values) => addMembers(values || [])}
               className="z-2"

--- a/frontend/src/components/teamsAndOrgs/messages.js
+++ b/frontend/src/components/teamsAndOrgs/messages.js
@@ -36,6 +36,10 @@ export default defineMessages({
     id: 'management.members.alreadyInTeam',
     defaultMessage: 'Already in team',
   },
+  noOptions: {
+    id: 'management.members.search.noOptions',
+    defaultMessage: 'No options',
+  },
   UserAlreadyInListError: {
     id: 'management.members.UserAlreadyInListError',
     defaultMessage: 'User is already a member of this team or has already requested to join.',

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -757,6 +757,7 @@
   "management.link.edit.team": "Edit team",
   "management.members.edit": "Edit",
   "management.members.alreadyInTeam": "Already in team",
+  "management.members.search.noOptions": "No options",
   "management.members.UserAlreadyInListError": "User is already a member of this team or has already requested to join.",
   "management.members": "Members",
   "management.members.empty": "There are no members yet.",


### PR DESCRIPTION
Closes #5257.

Also adds an `autoFocus` prop to the dropdown that would automatically focus the dropdown textfield when it mounts.