### PR TITLE
Remove recommended projects from project progress emails

### DIFF
--- a/backend/services/messaging/smtp_service.py
+++ b/backend/services/messaging/smtp_service.py
@@ -87,12 +87,12 @@ class SMTPService:
             for contributor_id in contributor_ids:
                 contributor = UserService.get_user_by_id(contributor_id[0])
                 values["USERNAME"] = contributor.username
-                if email_type == EncouragingEmailType.PROJECT_COMPLETE.value:
+                if email_type == EncouragingEmailType.BEEN_SOME_TIME.value:
                     recommended_projects = UserService.get_recommended_projects(
                         contributor.username, "en"
                     ).results
                     projects = []
-                    for recommended_project in recommended_projects:
+                    for recommended_project in recommended_projects[:4]:
                         projects.append(
                             {
                                 "org_logo": recommended_project.organisation_logo,

--- a/backend/services/messaging/templates/encourage_mapper_en.html
+++ b/backend/services/messaging/templates/encourage_mapper_en.html
@@ -13,7 +13,7 @@
         ">
         Hi {{ values["USERNAME"] }}
     </h1>
-    <p style="margin-bottom: 1.714rem">
+    <p style="margin-bottom: 1.714rem; line-height: 1.5;">
       you recently participated in the mapping project - 
       <a style="color: #d73f3f; font-weight: 700" href="{{values['APP_BASE_URL']}}/projects/{{values['PROJECT_ID']}}">{{values['PROJECT_NAME']}}</a> - on the 
       <a style="color: #d73f3f; font-weight: 700" href="{{values['APP_BASE_URL']}}">{{values["ORG_CODE"]}} Tasking Manager</a>.
@@ -36,13 +36,13 @@
           ">
           Hi {{ values["USERNAME"] }}
       </h1>
-      <p style="margin-bottom: 1.714rem">
+      <p style="margin-bottom: 1.714rem; line-height: 1.5;">
         you recently participated in the mapping project - 
         <a style="color: #d73f3f; font-weight: 700" href="{{values['APP_BASE_URL']}}/projects/{{values['PROJECT_ID']}}">{{values['PROJECT_NAME']}}</a> - on the 
         <a style="color: #d73f3f; font-weight: 700" href="{{values['APP_BASE_URL']}}">{{values["ORG_CODE"]}} Tasking Manager</a>.
         We want to inform you the project has been completed. It is time to celebrate! 
         <br>
-        Do you want to continue? How about exploring this list of projects we selected for you?
+        Do you want to continue? Find the suitable project for you here: <a href="{{values['APP_BASE_URL']}}/explore">{{values['APP_BASE_URL']}}/explore</a>
       </p>
     </div>
   {% elif values["EMAIL_TYPE"]==3 %}
@@ -65,7 +65,7 @@
       </p>
     </div>
   {% endif %}
-  {% if values["EMAIL_TYPE"] !=1 %}
+  {% if values["EMAIL_TYPE"] ==3 %}
     <div>
       <!-- card starts here -->
       <table aria-label=""> <!-- Noncompliant -->
@@ -142,6 +142,7 @@
                       font-weight: 700;
                       margin-bottom: 16px;
                       color: #2c3038;
+                      overflow-y: hidden;
                     ">
                   {{ project.name }}
                 </p>
@@ -151,6 +152,7 @@
                       color: #68707f;
                       height: 65px;
                       font-weight: 500;
+                      overflow-y: hidden;
                     ">
                   {{ project.description }}
                 </p>

--- a/tests/backend/integration/services/messaging/test_smtp_service.py
+++ b/tests/backend/integration/services/messaging/test_smtp_service.py
@@ -173,7 +173,6 @@ class TestSMTPService(BaseTestCase):
         # Act/Assert
         SMTPService._send_message(to_address, subject, content, content)
 
-    @patch.object(UserService, "get_recommended_projects")
     @patch.object(SMTPService, "_send_message")
     @patch.object(UserService, "get_user_by_id")
     @patch.object(Message, "get_all_contributors")
@@ -182,7 +181,6 @@ class TestSMTPService(BaseTestCase):
         mock_get_all_contributors,
         mock_get_user_by_id,
         mock_send_message,
-        mock_recommended_projects,
     ):
         # Arrange
         mock_get_all_contributors.return_value = [(123456,)]
@@ -210,9 +208,3 @@ class TestSMTPService(BaseTestCase):
             EncouragingEmailType.PROJECT_PROGRESS.value, 1, "test", 50
         )
         mock_send_message.assert_called()
-
-        # Test Recommended projects is sent on project complete email
-        SMTPService.send_email_to_contributors_on_project_progress(
-            EncouragingEmailType.PROJECT_COMPLETE.value, 1, "test", 50
-        )
-        mock_recommended_projects.assert_called()


### PR DESCRIPTION
Recommended projects logic needs some review so removing this on project progress emails for now. Related to #5262 