### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,22 @@
 
 The most popular tool for teams to coordinate mapping on OpenStreetMap. With this web application an area of interest can be defined and divided up into smaller tasks that can be completed rapidly. It shows which areas need to be mapped and which areas need a review for quality assurance. You can see the tool in action: log into the widely used [HOT Tasking Manager](https://tasks.hotosm.org/) and start mapping.
 
-[<img src="./docs/assets/project-view.gif" />](./docs/assets/project-view.gif)
+[<img src="./docs-old/assets/project-view.gif" />](./docs-old/assets/project-view.gif)
 
 This is Free and Open Source Software. You are welcome to use the code and set up your own instance. The Tasking Manager has been initially designed and built by and for the [Humanitarian OpenStreetMap Team](https://www.hotosm.org/), and is nowadays used by many communities and organizations.
 
 ## Get involved!
 
-* Start by reading our [Code of conduct](./docs/code_of_conduct.md)
-* Get familiar with our [contributor guidelines](./docs/contributing.md) explaining the different ways in which you can support this project! We need your help!
+* Start by reading our [Code of conduct](./docs-old/code_of_conduct.md)
+* Get familiar with our [contributor guidelines](./docs-old/contributing.md) explaining the different ways in which you can support this project! We need your help!
 * Join the Tasking Manager Collective Meet up- an opportunity to meet other Tasking Manager contributors. The meet ups take place on the first Wednesday of the month 9:00 or 15:00UTC! Register to receive a calendar invite: https://bit.ly/3s6ntmV or join directly via this link: https://meet.jit.si/TaskingManagerCollectiveMeetUp
 
 
 ## Developers
 
-* [Install TM with Docker](./docs/setup-docker.md)
-* [Setup the TM for development](./docs/setup-development.md)
-* [Learn about migrations between major versions](./docs/migration.md)
+* [Install TM with Docker](./docs-old/setup-docker.md)
+* [Setup the TM for development](./docs-old/setup-development.md)
+* [Learn about migrations between major versions](./docs-old/migration.md)
 * Help us and submit [pull requests](https://github.com/hotosm/tasking-manager/pulls)
 
 ## Instances

--- a/docs/sysadmins/ci-cd.md
+++ b/docs/sysadmins/ci-cd.md
@@ -1,6 +1,6 @@
 # CI/CD
 
-We use CircleCI to manage Continuous Integration and Continuous Deployment. 
+We use CircleCI to manage Continuous Integration and Continuous Deployment.
 
 | **Environment**     | **Branch**                              |
 |---------------------|-----------------------------------------|
@@ -10,9 +10,9 @@ We use CircleCI to manage Continuous Integration and Continuous Deployment.
 | TeachOSM            | deployment/teachosm-tasking-manager     |
 | Indonesia           | deployment/id-tasking-manager           |
 
-Each environment has its own set of environment variables which are stored as secrets in the CircleCI Organization Settings under Contexts. 
+Each environment has its own set of environment variables which are stored as secrets in the CircleCI Organization Settings under Contexts.
 
-- OPSGENIE_API	
+- OPSGENIE_API
 - TM_APP_API_URL
 - TM_APP_API_VERSION
 - TM_APP_BASE_URL
@@ -30,10 +30,13 @@ Each environment has its own set of environment variables which are stored as se
 
 ## Automated Tests
 
-For each Pull Request and branch, the CI runs a set of frontend and backend tests. We have a context in place called "tasking-manager-testing" for setting up the database with the following environment variables: 
+For each Pull Request and branch, the CI runs a set of frontend and backend tests. We have a context in place called "tasking-manager-testing" for setting up the database with the following environment variables:
 
-- POSTGRES_DB	
-- POSTGRES_ENDPOINT	
+- POSTGRES_DB
+- POSTGRES_ENDPOINT
 - POSTGRES_USER
+- TM_ORG_CODE
+- TM_ORG_NAME
 
-Note that the POSTGRES_DB variable should be for the default database (in our case `tm`) the testing script will create a database called `test_$POSTGRES_DB` during setup. 
+Note that the POSTGRES_DB variable should be for the default database (in our case `tm`) the testing script will create a database called `test_$POSTGRES_DB` during setup.
+The `TM_ORG_*` vars are required for certain tests to pass; most notably )`test_variable_replacing` in the `TestTemplateService`.


### PR DESCRIPTION
This PR does 2 things:
1. fixes the paths in the README for the new docs structure (these will need to change again once the new doc content is finalized)
2. it adds two more necessary env vars for circle tests to pass. Most notably, [`test_variable_replacing` in `TestTemplateService`](https://github.com/hotosm/tasking-manager/blob/49632fbad1633effbc6237205271576ae01a9e60/tests/backend/unit/services/messaging/test_template_service.py#L19-L20) needs the org env vars to be able to pass