### PR TITLE
Display project due date on project card

### DIFF
--- a/frontend/src/assets/styles/_typography.scss
+++ b/frontend/src/assets/styles/_typography.scss
@@ -7,9 +7,13 @@
 }
 
 .base-font {
-  font-family: "Archivo", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-family: 'Archivo', 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
 .f125 {
   font-size: 1.125rem;
+}
+
+.f8 {
+  font-size: 0.625rem;
 }

--- a/frontend/src/components/projectCard/dueDateBox.js
+++ b/frontend/src/components/projectCard/dueDateBox.js
@@ -42,20 +42,20 @@ export function DueDateBox({
     return (
       <>
         <span
-          className={`dib relative lh-solid f7 tr br1 link ph1 pv2 truncate ${
-            align === 'right' ? 'fr' : 'fl'
-          } ${
+          className={`inline-flex items-center lh-solid f8 br1 ph2 link ${
             milliDifference < 60000 * 20 && intervalMili !== undefined
-              ? 'bg-red white fw6'
-              : 'bg-grey-light blue-grey'
+              ? 'bg-red white'
+              : 'bg-tan blue-grey'
           } ${intervalMili ? '' : 'mw4'}`}
           data-tip={tooltipMsg}
+          style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}
         >
           {!isTaskStatusPage ? (
             <ClockIcon height="12px" width="12px" />
           ) : (
             <TimerIcon height="12px" width="12px" />
           )}
+          <span className="pl1">
             <FormattedMessage
               className="indent"
               {...messages['dueDateRelativeRemainingDays']}

--- a/frontend/src/components/projectCard/dueDateBox.js
+++ b/frontend/src/components/projectCard/dueDateBox.js
@@ -12,6 +12,7 @@ export function DueDateBox({
   intervalMili,
   tooltipMsg,
   isTaskStatusPage = false,
+  isProjectDetailPage = false,
 }: Object) {
   const intl = useIntl();
   const [timer, setTimer] = useState(Date.now());
@@ -69,6 +70,22 @@ export function DueDateBox({
       </>
     );
   } else {
-    return null;
+    return (
+      isProjectDetailPage && (
+        <span
+          className="inline-flex items-center lh-solid f8 br1 ph2 link bg-tan blue-grey"
+          style={{ paddingTop: '0.375rem', paddingBottom: '0.375rem' }}
+        >
+          <ClockIcon height="12px" width="12px" />
+          <span className="pl1">
+            {dueDate ? (
+              <FormattedMessage {...messages.dueDateExpired} />
+            ) : (
+              <FormattedMessage {...messages.noDueDate} />
+            )}
+          </span>
+        </span>
+      )
+    );
   }
 }

--- a/frontend/src/components/projectCard/dueDateBox.js
+++ b/frontend/src/components/projectCard/dueDateBox.js
@@ -5,8 +5,14 @@ import ReactTooltip from 'react-tooltip';
 
 import { ClockIcon } from '../svgIcons';
 import messages from './messages';
+import { TimerIcon } from '../svgIcons/timer';
 
-export function DueDateBox({ dueDate, intervalMili, align = 'right', tooltipMsg }: Object) {
+export function DueDateBox({
+  dueDate,
+  intervalMili,
+  tooltipMsg,
+  isTaskStatusPage = false,
+}: Object) {
   const intl = useIntl();
   const [timer, setTimer] = useState(Date.now());
   useEffect(() => {
@@ -45,10 +51,11 @@ export function DueDateBox({ dueDate, intervalMili, align = 'right', tooltipMsg 
           } ${intervalMili ? '' : 'mw4'}`}
           data-tip={tooltipMsg}
         >
-          <span>
-            <ClockIcon className="absolute pl1 top-0 pt1 left-0" />
-          </span>
-          <span className="pl3 ml1 v-mid">
+          {!isTaskStatusPage ? (
+            <ClockIcon height="12px" width="12px" />
+          ) : (
+            <TimerIcon height="12px" width="12px" />
+          )}
             <FormattedMessage
               className="indent"
               {...messages['dueDateRelativeRemainingDays']}

--- a/frontend/src/components/projectCard/messages.js
+++ b/frontend/src/components/projectCard/messages.js
@@ -72,4 +72,12 @@ export default defineMessages({
     id: 'project.card.project_tasks.button',
     defaultMessage: 'Tasks',
   },
+  noDueDate: {
+    id: 'project.detail.noDueDate',
+    defaultMessage: 'No due date specified',
+  },
+  dueDateExpired: {
+    id: 'project.detail.dueDateExpired',
+    defaultMessage: 'Due date expired',
+  },
 });

--- a/frontend/src/components/projectCard/projectCard.js
+++ b/frontend/src/components/projectCard/projectCard.js
@@ -9,6 +9,7 @@ import { MappingLevelMessage } from '../mappingLevel';
 import { ProjectStatusBox } from '../projectDetail/statusBox';
 import { PROJECTCARD_CONTRIBUTION_SHOWN_THRESHOLD } from '../../config/index';
 import { PriorityBox } from './priorityBox';
+import { DueDateBox } from './dueDateBox';
 
 export function ProjectTeaser({
   lastUpdated,
@@ -126,11 +127,12 @@ export function ProjectCard({
                 percentMapped={percentMapped}
                 percentValidated={percentValidated}
               />
-              <div className="cf pt2 truncate">
+              <div className="pt2 truncate flex justify-between items-center">
                 <MappingLevelMessage
                   level={mapperLevel}
                   className="fl f7 pv2 ttc fw5 blue-grey truncate"
                 />
+                <DueDateBox dueDate={dueDate} />
               </div>
             </div>
           </div>

--- a/frontend/src/components/projectCard/tests/dueDateBox.test.js
+++ b/frontend/src/components/projectCard/tests/dueDateBox.test.js
@@ -10,13 +10,11 @@ describe('test DueDate', () => {
   it('relative date formatting in English', () => {
     // six days of milliseconds plus a few seconds for the test
     const sixDaysOut = 6 * 86400 * 1000 + 10000 + Date.now();
-    const { container } = render(
+    render(
       <ReduxIntlProviders>
         <DueDateBox dueDate={sixDaysOut} />
       </ReduxIntlProviders>,
     );
-    expect(container.querySelectorAll('span')[0].className).toContain('fr');
-    expect(container.querySelectorAll('span')[0].className).not.toContain('fl');
     expect(screen.getByText('6 days left')).toBeInTheDocument();
     expect(screen.getByRole('img')).toBeInTheDocument();
   });
@@ -26,15 +24,13 @@ describe('test DueDate', () => {
     const fiveDaysOut = 5 * 86400 * 1000 + 10000 + Date.now();
     const { container } = render(
       <ReduxIntlProviders>
-        <DueDateBox dueDate={fiveDaysOut} align="left" tooltipMsg="Tooltip works" />
+        <DueDateBox dueDate={fiveDaysOut} tooltipMsg="Tooltip works" />
       </ReduxIntlProviders>,
     );
     expect(screen.queryByText('Tooltip works')).not.toBeInTheDocument();
     userEvent.hover(screen.getByText('5 days left'));
     expect(screen.getByText('Tooltip works')).toBeInTheDocument();
-    expect(container.querySelectorAll('span')[0].className).toContain('fl');
-    expect(container.querySelectorAll('span')[0].className).toContain('bg-grey-light blue-grey');
-    expect(container.querySelectorAll('span')[0].className).not.toContain('fr');
+    expect(container.querySelectorAll('span')[0].className).toContain('bg-tan blue-grey');
     expect(container.querySelectorAll('span')[0].className).not.toContain('bg-red white fw6');
   });
 
@@ -44,13 +40,40 @@ describe('test DueDate', () => {
         <DueDateBox dueDate={1000 * 540 + Date.now()} intervalMili={true} />
       </ReduxIntlProviders>,
     );
-    expect(container.querySelectorAll('span')[0].className).toContain('fr');
-    expect(container.querySelectorAll('span')[0].className).toContain('bg-red white fw6');
-    expect(container.querySelectorAll('span')[0].className).not.toContain('fl');
-    expect(container.querySelectorAll('span')[0].className).not.toContain(
-      'bg-grey-light blue-grey',
-    );
+    expect(container.querySelectorAll('span')[0].className).toContain('bg-red white');
+    expect(container.querySelectorAll('span')[0].className).not.toContain('bg-tan blue-grey');
     expect(screen.getByText('9 minutes left')).toBeInTheDocument();
     expect(screen.getByRole('img')).toBeInTheDocument();
+  });
+
+  it('renders the appropriate clock timer icon for task status page', () => {
+    render(
+      <ReduxIntlProviders>
+        <DueDateBox dueDate={1000 * 540 + Date.now()} intervalMili={true} isTaskStatusPage />
+      </ReduxIntlProviders>,
+    );
+    // A title tag has been added to the timer svg which we can access 
+    expect(
+      screen.getByRole('img', {
+        name: 'Timer',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the clock timer icon for project details', () => {
+    render(
+      <ReduxIntlProviders>
+        <DueDateBox
+          dueDate={1000 * 540 + Date.now()}
+          intervalMili={true}
+          isTaskStatusPage={false}
+        />
+      </ReduxIntlProviders>,
+    );
+    expect(
+      screen.queryByRole('img', {
+        name: 'Timer',
+      }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/projectCard/tests/dueDateBox.test.js
+++ b/frontend/src/components/projectCard/tests/dueDateBox.test.js
@@ -52,7 +52,7 @@ describe('test DueDate', () => {
         <DueDateBox dueDate={1000 * 540 + Date.now()} intervalMili={true} isTaskStatusPage />
       </ReduxIntlProviders>,
     );
-    // A title tag has been added to the timer svg which we can access 
+    // A title tag has been added to the timer svg which we can access
     expect(
       screen.getByRole('img', {
         name: 'Timer',
@@ -75,5 +75,32 @@ describe('test DueDate', () => {
         name: 'Timer',
       }),
     ).not.toBeInTheDocument();
+  });
+
+  it('should display text when no due date is specified', () => {
+    render(
+      <ReduxIntlProviders>
+        <DueDateBox dueDate={null} isProjectDetailPage />
+      </ReduxIntlProviders>,
+    );
+    expect(screen.getByText('No due date specified')).toBeInTheDocument();
+  });
+
+  it('should display due date expiration message when due date has expired', () => {
+    render(
+      <ReduxIntlProviders>
+        <DueDateBox dueDate={Date.now() - 1000} isProjectDetailPage />
+      </ReduxIntlProviders>,
+    );
+    expect(screen.getByText('Due date expired')).toBeInTheDocument();
+  });
+
+  it('should not display messages for pages other than the project detail page', () => {
+    render(
+      <ReduxIntlProviders>
+        <DueDateBox dueDate={Date.now() - 1000} isProjectDetailPage={false} />
+      </ReduxIntlProviders>,
+    );
+    expect(screen.queryByText('Due date expired')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/projectDetail/infoPanel.js
+++ b/frontend/src/components/projectDetail/infoPanel.js
@@ -69,6 +69,7 @@ export function ProjectInfoPanel({ project, tasks, contributors, type }: Object)
         <DueDateBox
           dueDate={project.dueDate}
           tooltipMsg={intl.formatMessage(messages.dueDateTooltip)}
+          isProjectDetailPage
         />
       </div>
     </ReactPlaceholder>

--- a/frontend/src/components/projectDetail/infoPanel.js
+++ b/frontend/src/components/projectDetail/infoPanel.js
@@ -64,7 +64,7 @@ export function ProjectInfoPanel({ project, tasks, contributors, type }: Object)
         percentValidated={percentValidated}
         percentBadImagery={percentBadImagery}
       />
-      <div className="cf pb1 bg-white">
+      <div className="pb1 bg-white flex justify-between items-center">
         <MappingLevelMessage level={project.mapperLevel} className="fl f5 mt1 ttc fw5 blue-dark" />
         <DueDateBox
           dueDate={project.dueDate}

--- a/frontend/src/components/svgIcons/timer.js
+++ b/frontend/src/components/svgIcons/timer.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export class TimerIcon extends React.PureComponent {
+  render() {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="10"
+        height="12"
+        fill="none"
+        viewBox="0 0 10 12"
+        role="img"
+        {...this.props}
+      >
+        <title>Timer</title>
+        <path
+          fill="#68707F"
+          fillRule="evenodd"
+          d="M5.77 1.013v.932C8.164 2.32 10 4.419 10 6.942 10 9.732 7.757 12 5 12S0 9.731 0 6.942c0-2.524 1.837-4.621 4.23-4.997v-.932h-.421a.504.504 0 01-.501-.507c0-.28.224-.506.5-.506h2.383c.277 0 .501.227.501.506 0 .28-.224.507-.5.507H5.77zm3.306 5.909a.344.344 0 00.09-.264c-.182-1.99-1.783-3.58-3.787-3.76A.344.344 0 005 3.24V6.69c0 .19.155.344.347.344H8.82c.098 0 .191-.04.257-.112z"
+          clipRule="evenodd"
+        ></path>
+      </svg>
+    );
+  }
+}

--- a/frontend/src/components/taskSelection/action.js
+++ b/frontend/src/components/taskSelection/action.js
@@ -266,7 +266,7 @@ export function TaskMapAction({ project, projectIsReady, tasks, activeTasks, act
                     ))}
                   </h3>
                   <div className="db" title={intl.formatMessage(messages.timeToUnlock)}>
-                    <DueDateBox dueDate={timer} align="left" intervalMili={60000} />
+                    <DueDateBox dueDate={timer} isTaskStatusPage intervalMili={60000} />
                   </div>
                 </div>
                 <div className="cf">

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -220,6 +220,8 @@
   "project.card.edit_project.button": "Edit",
   "project.card.project_page.button": "Project Page",
   "project.card.project_tasks.button": "Tasks",
+  "project.detail.noDueDate": "No due date specified",
+  "project.detail.dueDateExpired": "Due date expired",
   "management.projects.create.title": "Create new project",
   "management.projects.clone.message": "The new project will be a clone of the project #{id} ({name}).",
   "management.projects.create.clone": "Clone",


### PR DESCRIPTION
Closes #5236 

This PR does the following:

- Displays the due date of the project on the project card. Due dates are not displayed if they have already passed.
- Adds a timer icon - this icon is used when the component is on the task status page. And on pages where project detail is shown, the clock icon, which is already present in the project, is used.
For project details:
![project-card-due-date](https://user-images.githubusercontent.com/51614993/184528263-c4e1f592-69d5-4653-b4c2-d8ba957dd4e8.png)
For the task action page:
![task-status-due-date](https://user-images.githubusercontent.com/51614993/184528280-b1080790-8de6-48a1-b678-72bba977cc4f.png)
- Adds message when the project has no due date or the due date has expired. This message will be shown only on the project detail page.
No due date specified:
![no-due-date](https://user-images.githubusercontent.com/51614993/184530005-ff6963fa-7654-4ce8-ac33-03985dd2cd64.png)
Due date expired:
![due-date-expired](https://user-images.githubusercontent.com/51614993/184530009-8c94615e-f33b-4e53-acbb-caaa23e2c997.png)

- Some styling modifications have been made referencing the Figma design.

