### PR TITLE
Filter by archived projects, add hint for archived projects

### DIFF
--- a/frontend/src/components/projects/projectsActionFilter.js
+++ b/frontend/src/components/projects/projectsActionFilter.js
@@ -37,14 +37,24 @@ export const ProjectsActionFilter = ({ setQuery, fullProjectsQuery }) => {
             'pushIn',
           );
         }
-        dispatch({ type: 'SET_ACTION', action: value });
+        // 'Archived' is a special case, as it is not a valid action
+        dispatch({ type: 'SET_ACTION', action: value === 'ARCHIVED' ? 'any' : value });
+        setQuery(
+          {
+            ...fullProjectsQuery,
+            page: undefined,
+            status: value !== 'ARCHIVED' ? undefined : 'ARCHIVED',
+          },
+          'pushIn',
+        );
       }}
       // use the action query param, in case someone loads the page with /explore?action=*
-      value={fullProjectsQuery.action || action || 'any'}
+      value={fullProjectsQuery.status || fullProjectsQuery.action || action || 'any'}
       options={[
         { label: <FormattedMessage {...messages.projectsToMap} />, value: 'map' },
         { label: <FormattedMessage {...messages.projectsToValidate} />, value: 'validate' },
         { label: <FormattedMessage {...messages.anyProject} />, value: 'any' },
+        { label: <FormattedMessage {...messages.archived} />, value: 'ARCHIVED' },
       ]}
       display={'Action'}
       className={'ba b--grey-light bg-white mr1 f6 v-mid dn dib-ns pv2'}

--- a/frontend/src/components/projects/tests/projectsActionFilter.test.js
+++ b/frontend/src/components/projects/tests/projectsActionFilter.test.js
@@ -17,10 +17,12 @@ describe('ProjectsActionFilter', () => {
     expect(screen.queryByText('Projects to map')).toBeInTheDocument();
     expect(screen.queryByText('Projects to validate')).not.toBeInTheDocument();
     expect(screen.queryByText('Any project')).not.toBeInTheDocument();
+    expect(screen.queryByText('Archived')).not.toBeInTheDocument();
     // open dropdown
     fireEvent.click(screen.queryByText('Projects to map'));
     expect(screen.queryByText('Projects to validate')).toBeInTheDocument();
     expect(screen.queryByText('Any project')).toBeInTheDocument();
+    expect(screen.queryByText('Archived')).toBeInTheDocument();
     // select Projects to validate
     fireEvent.click(screen.queryByText('Projects to validate'));
     expect(store.getState()['preferences']['action']).toBe('validate');
@@ -32,7 +34,12 @@ describe('ProjectsActionFilter', () => {
     fireEvent.click(screen.queryByText('Any project'));
     fireEvent.click(screen.queryByText('Projects to map'));
     expect(store.getState()['preferences']['action']).toBe('map');
+    // select Projects to archived, action set to any for this special case
+    fireEvent.click(screen.queryByText('Projects to map'));
+    fireEvent.click(screen.queryByText(/archived/i));
+    expect(store.getState()['preferences']['action']).toBe('any');
   });
+
   it('initialize it with validate action set', () => {
     render(
       <ReduxIntlProviders>
@@ -43,8 +50,9 @@ describe('ProjectsActionFilter', () => {
     fireEvent.click(screen.queryByText('Projects to validate'));
     fireEvent.click(screen.queryByText('Any project'));
     expect(store.getState()['preferences']['action']).toBe('any');
-    expect(myMock).toHaveBeenCalledTimes(1);
+    expect(myMock).toHaveBeenCalledTimes(2);
   });
+
   it('with an advanced user, the action is set as any', () => {
     act(() => {
       store.dispatch({

--- a/frontend/src/components/taskSelection/footer.js
+++ b/frontend/src/components/taskSelection/footer.js
@@ -58,7 +58,10 @@ const TaskSelectionFooter = ({ defaultUserEditor, project, tasks, taskAction, se
 
   const lockTasks = async () => {
     // if user can not map or validate the project, lead him to the explore projects page
-    if (['selectAnotherProject', 'mappingIsComplete', 'projectIsComplete'].includes(taskAction)) {
+    if (
+      ['selectAnotherProject', 'mappingIsComplete', 'projectIsComplete'].includes(taskAction) ||
+      project.status === 'ARCHIVED'
+    ) {
       navigate(`/explore/`);
     }
     // then pass to the JOSM check and validate/map checks
@@ -219,7 +222,7 @@ const TaskSelectionFooter = ({ defaultUserEditor, project, tasks, taskAction, se
           <Button className="white bg-red" onClick={() => lockTasks()} loading={isPending}>
             {['selectAnotherProject', 'mappingIsComplete', 'projectIsComplete'].includes(
               taskAction,
-            ) ? (
+            ) || project.status === 'ARCHIVED' ? (
               <FormattedMessage {...messages.selectAnotherProject} />
             ) : (
               <FormattedMessage

--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -323,6 +323,7 @@ export function TaskSelection({ project, type, loading }: Object) {
                     <>
                       <ProjectInstructions
                         instructions={project.projectInfo && project.projectInfo.instructions}
+                        isProjectArchived={project.status === 'ARCHIVED'}
                       />
                       <ChangesetCommentTags tags={project.changesetComment} />
                     </>

--- a/frontend/src/components/taskSelection/instructions.js
+++ b/frontend/src/components/taskSelection/instructions.js
@@ -1,13 +1,24 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 
 import { htmlFromMarkdown } from '../../utils/htmlFromMarkdown';
+import { Alert } from '../alert';
+import messages from './messages';
 
-export function ProjectInstructions({ instructions }: Object) {
+export function ProjectInstructions({ instructions, isProjectArchived }: Object) {
   const htmlInstructions = instructions ? htmlFromMarkdown(instructions) : { __html: '' };
+
   return (
-    <div
-      className="markdown-content base-font blue-dark"
-      dangerouslySetInnerHTML={htmlInstructions}
-    />
+    <>
+      {isProjectArchived && (
+        <Alert type="warning" compact={false}>
+          <FormattedMessage {...messages.projectIsArchived}/>
+        </Alert>
+      )}
+      <div
+        className="markdown-content base-font blue-dark"
+        dangerouslySetInnerHTML={htmlInstructions}
+      />
+    </>
   );
 }

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -212,6 +212,11 @@ export default defineMessages({
     id: 'project.instructions',
     defaultMessage: 'Instructions',
   },
+  projectIsArchived: {
+    id: 'project.isArchived',
+    defaultMessage:
+      'This project is archived and read-only. You can view the project, but you cannot update tasks.',
+  },
   changesetComment: {
     id: 'project.changesetComment',
     defaultMessage: 'Changeset comment',

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -628,6 +628,7 @@
   "project.tasks": "Tasks",
   "project.taskId": "Task #{id}",
   "project.instructions": "Instructions",
+  "project.isArchived": "This project is archived and read-only. You can view the project, but you cannot update tasks.",
   "project.changesetComment": "Changeset comment",
   "project.contributions": "contributions",
   "project.contributions.registered": "Registered on",


### PR DESCRIPTION
Closes #5128 

An option has been added to the dropdown. 
![archived-dropdown](https://user-images.githubusercontent.com/51614993/185049167-bcfb6502-ab5b-4021-82cb-9f7f138981e4.png)


The following hint is shown under the 'Instructions' tab on the task selection page.
![hint-instructions](https://user-images.githubusercontent.com/51614993/185048908-ae160677-7495-4959-8d12-31555f3b6892.png)

'Select another project' will be used as the right bottom button, directing the user to the 'explore' page.


