### PR TITLE
Revise assigned teams actions permissions

### DIFF
--- a/frontend/src/components/projectEdit/messages.js
+++ b/frontend/src/components/projectEdit/messages.js
@@ -21,6 +21,11 @@ export default defineMessages({
     id: 'projects.formInputs.teams.title',
     defaultMessage: 'Teams',
   },
+  teamsPermissionNote: {
+    id: 'projects.teams.teamsPermissionNote',
+    defaultMessage:
+      'Note: Mappers have mapping permissions. Validators have mapping and validation permissions. Project managers have mapping and validation permissions as well as the access to the management sections.',
+  },
   organisation: {
     id: 'projects.formInputs.organisation.title',
     defaultMessage: 'Organization',

--- a/frontend/src/components/projectEdit/permissionsForm.js
+++ b/frontend/src/components/projectEdit/permissionsForm.js
@@ -25,6 +25,9 @@ export const PermissionsForm = () => {
           <FormattedMessage {...messages.teams} />
         </label>
         <TeamSelect />
+        <p className="f6 blue-grey w-80 mt2">
+          <FormattedMessage {...messages.teamsPermissionNote} />          
+        </p>
       </div>
       <div className={styleClasses.divClass}>
         <label className={styleClasses.labelClass}>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -357,6 +357,7 @@
   "projects.formInputs.privacy.field": "Private project",
   "projects.formInputs.privacy.description": "Private means that only the users that are project team members can access, map or validate this project. This option overrides the mapping and validation permissions.",
   "projects.formInputs.teams.title": "Teams",
+  "projects.teams.teamsPermissionNote": "Note: Mappers have mapping permissions. Validators have mapping and validation permissions. Project managers have mapping and validation permissions as well as the access to the management sections.",
   "projects.formInputs.organisation.title": "Organization",
   "projects.formInputs.campaign.title": "Campaign",
   "projects.formInputs.categories.title": "Categories",

--- a/frontend/src/views/projectEdit.js
+++ b/frontend/src/views/projectEdit.js
@@ -51,6 +51,17 @@ export const handleCheckButton = (event, arrayElement) => {
   return arrayElement;
 };
 
+const doesMappingTeamNotExist = (teams, mappingPermission) =>
+  ['TEAMS', 'TEAMS_LEVEL'].includes(mappingPermission) &&
+  teams.filter((team) => team.role === 'MAPPER').length === 0 &&
+  teams.filter((team) => team.role === 'VALIDATOR').length === 0 &&
+  teams.filter((team) => team.role === 'PROJECT_MANAGER').length === 0;
+
+const doesValidationTeamNotExist = (teams, validationPermission) =>
+  ['TEAMS', 'TEAMS_LEVEL'].includes(validationPermission) &&
+  teams.filter((team) => team.role === 'VALIDATOR').length === 0 &&
+  teams.filter((team) => team.role === 'PROJECT_MANAGER').length === 0;
+
 export default function ProjectEdit({ id }) {
   useSetTitleTag(`Edit project #${id}`);
   const [errorLanguages, loadingLanguages, languages] = useFetch('system/languages/');
@@ -142,16 +153,10 @@ export default function ProjectEdit({ id }) {
       missingFields.push({ locale: null, fields: nonLocaleMissingFields });
     }
     const { teams, mappingPermission, validationPermission } = projectInfo;
-    const doesMappingTeamNotExist =
-      ['TEAMS', 'TEAMS_LEVEL'].includes(mappingPermission) &&
-      teams.filter((team) => team.role === 'MAPPER').length === 0 &&
-      teams.filter((team) => team.role === 'VALIDATOR').length === 0 &&
-      teams.filter((team) => team.role === 'PROJECT_MANAGER').length === 0;
-    const doesValidationTeamNotExist =
-      ['TEAMS', 'TEAMS_LEVEL'].includes(validationPermission) &&
-      teams.filter((team) => team.role === 'VALIDATOR').length === 0 &&
-      teams.filter((team) => team.role === 'PROJECT_MANAGER').length === 0;
-    if (doesMappingTeamNotExist || doesValidationTeamNotExist) {
+    if (
+      doesMappingTeamNotExist(teams, mappingPermission) ||
+      doesValidationTeamNotExist(teams, validationPermission)
+    ) {
       missingFields.push({ type: 'noTeamsAssigned' });
     }
 
@@ -337,20 +342,14 @@ const ErrorTitle = ({ locale, numberOfMissingFields, type, projectInfo }) => {
   if (type === 'noTeamsAssigned') {
     // message if mapping or validation permissions is set to team only but no team has been added
     const { teams, mappingPermission, validationPermission } = projectInfo;
-    const doesMappingTeamNotExist =
-      ['TEAMS', 'TEAMS_LEVEL'].includes(mappingPermission) &&
-      teams.filter((team) => team.role === 'MAPPER').length === 0 &&
-      teams.filter((team) => team.role === 'VALIDATOR').length === 0 &&
-      teams.filter((team) => team.role === 'PROJECT_MANAGER').length === 0;
-    const doesValidationTeamNotExist =
-      ['TEAMS', 'TEAMS_LEVEL'].includes(validationPermission) &&
-      teams.filter((team) => team.role === 'VALIDATOR').length === 0 &&
-      teams.filter((team) => team.role === 'PROJECT_MANAGER').length === 0;
 
     return (
       <FormattedMessage
         {...messages.noTeamsAssigned}
-        values={{ mapping: doesMappingTeamNotExist, validation: doesValidationTeamNotExist }}
+        values={{
+          mapping: doesMappingTeamNotExist(teams, mappingPermission),
+          validation: doesValidationTeamNotExist(teams, validationPermission),
+        }}
       />
     );
   }

--- a/frontend/src/views/projectEdit.js
+++ b/frontend/src/views/projectEdit.js
@@ -141,13 +141,16 @@ export default function ProjectEdit({ id }) {
     if (nonLocaleMissingFields.length) {
       missingFields.push({ locale: null, fields: nonLocaleMissingFields });
     }
-
+    const { teams, mappingPermission, validationPermission } = projectInfo;
     const doesMappingTeamNotExist =
-      ['TEAMS', 'TEAMS_LEVEL'].includes(projectInfo.mappingPermission) &&
-      projectInfo.teams.filter((team) => team.role === 'MAPPER').length === 0;
+      ['TEAMS', 'TEAMS_LEVEL'].includes(mappingPermission) &&
+      teams.filter((team) => team.role === 'MAPPER').length === 0 &&
+      teams.filter((team) => team.role === 'VALIDATOR').length === 0 &&
+      teams.filter((team) => team.role === 'PROJECT_MANAGER').length === 0;
     const doesValidationTeamNotExist =
-      ['TEAMS', 'TEAMS_LEVEL'].includes(projectInfo.validationPermission) &&
-      projectInfo.teams.filter((team) => team.role === 'VALIDATOR').length === 0;
+      ['TEAMS', 'TEAMS_LEVEL'].includes(validationPermission) &&
+      teams.filter((team) => team.role === 'VALIDATOR').length === 0 &&
+      teams.filter((team) => team.role === 'PROJECT_MANAGER').length === 0;
     if (doesMappingTeamNotExist || doesValidationTeamNotExist) {
       missingFields.push({ type: 'noTeamsAssigned' });
     }
@@ -333,13 +336,16 @@ export default function ProjectEdit({ id }) {
 const ErrorTitle = ({ locale, numberOfMissingFields, type, projectInfo }) => {
   if (type === 'noTeamsAssigned') {
     // message if mapping or validation permissions is set to team only but no team has been added
-    const { mappingPermission, validationPermission, teams } = projectInfo;
+    const { teams, mappingPermission, validationPermission } = projectInfo;
     const doesMappingTeamNotExist =
       ['TEAMS', 'TEAMS_LEVEL'].includes(mappingPermission) &&
-      teams.filter((team) => team.role === 'MAPPER').length === 0;
+      teams.filter((team) => team.role === 'MAPPER').length === 0 &&
+      teams.filter((team) => team.role === 'VALIDATOR').length === 0 &&
+      teams.filter((team) => team.role === 'PROJECT_MANAGER').length === 0;
     const doesValidationTeamNotExist =
       ['TEAMS', 'TEAMS_LEVEL'].includes(validationPermission) &&
-      teams.filter((team) => team.role === 'VALIDATOR').length === 0;
+      teams.filter((team) => team.role === 'VALIDATOR').length === 0 &&
+      teams.filter((team) => team.role === 'PROJECT_MANAGER').length === 0;
 
     return (
       <FormattedMessage


### PR DESCRIPTION
This PR does the following:
- Revise actions permissions for assigned teams. Because validators can also map, assigning a team for validation means they have access to mapping and validation, eliminating the need to assign a separate team for mapping. This would also allow for a single team to map and validate at the same time.
- Add helpful note text - _"Note: Mappers have mapping permissions. Validators have mapping and validation permissions. Project managers have mapping and validation permissions and access to the management sections."_