### PR TITLE
Use useMatch to conditionally render footer

### DIFF
--- a/frontend/src/components/footer/index.js
+++ b/frontend/src/components/footer/index.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { useSelector } from 'react-redux';
-import { Link, useMatch } from '@reach/router';
+import { Link, useMatch as matchPath } from '@reach/router';
 import { FormattedMessage } from 'react-intl';
 import {
   TwitterIcon,
@@ -48,8 +48,7 @@ export function Footer() {
   ];
   let isFooterEnabled = true;
   footerDisabledPaths.forEach((path) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const match = useMatch(path);
+    const match = matchPath(path);
     if (match !== null) {
       isFooterEnabled = false;
     }

--- a/frontend/src/components/footer/index.js
+++ b/frontend/src/components/footer/index.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { useSelector } from 'react-redux';
-import { Link } from '@reach/router';
+import { Link, useMatch } from '@reach/router';
 import { FormattedMessage } from 'react-intl';
 import {
   TwitterIcon,
@@ -30,17 +30,33 @@ const socialNetworks = [
   { link: ORG_GITHUB, icon: <GithubIcon style={{ height: '20px', width: '20px' }} /> },
 ];
 
-export function Footer({ location }: Object) {
+export function Footer() {
   const userDetails = useSelector((state) => state.auth.get('userDetails'));
 
-  const noFooterViews = ['tasks', 'map', 'validate', 'new', 'membership', 'api-docs'];
-  const activeView = location.pathname
-    .split('/')
-    .filter((i) => i !== '')
-    .splice(-1)[0];
+  const footerDisabledPaths = [
+    'projects/:id/tasks',
+    'projects/:id/map',
+    'projects/:id/validate',
+    'manage/organisations/new/',
+    'manage/teams/new',
+    'manage/campaigns/new',
+    'manage/projects/new',
+    'manage/categories/new',
+    'manage/licenses/new',
+    'teams/:id/membership',
+    '/api-docs/',
+  ];
+  let isFooterEnabled = true;
+  footerDisabledPaths.forEach((path) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const match = useMatch(path);
+    if (match !== null) {
+      isFooterEnabled = false;
+    }
+  });
 
-  if (noFooterViews.includes(activeView)) {
-    return <></>;
+  if (!isFooterEnabled) {
+    return null;
   } else {
     return (
       <footer className="ph3 ph6-l pb4 white bg-blue-dark">


### PR DESCRIPTION
This PR implements `useMatch` from `@reach/router` to check for conditions to enable/disable the footer. This way, we can directly use app routes to render the footer conditionally.