### PR TITLE
Change deploy base image tag to 3.7.14-node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /home/circleci/app
     docker:
-    - image: cimg/python:3.7-node
+    - image: cimg/python:3.7.14-node
       environment:
         SQLALCHEMY_DATABASE_URI: postgresql://taskingmanager@localhost/test_tm
     - image: cimg/postgres:14.2-postgis

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
         type: string
     working_directory: /home/circleci/tasking-manager
     docker:
-    - image: cimg/python:3.7-node
+    - image: cimg/python:3.7.14-node
     steps:
     - checkout
     - setup_remote_docker
@@ -185,7 +185,7 @@ jobs:
   frontend_deploy:
     working_directory: /home/circleci/tasking-manager
     docker:
-    - image: cimg/python:3.7-node
+    - image: cimg/python:3.7.14-node
     parameters:
       stack_name:
         description: "the name of the stack for cfn-config"

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ glob2==0.7
 greenlet==1.1.2
 gunicorn==20.0.4
 idna==2.10
+importlib-metadata==4.13.0 # See https://github.com/hotosm/tasking-manager/issues/5395
 itsdangerous==1.1.0
 Jinja2==2.11.3
 Mako==1.2.2


### PR DESCRIPTION
Currently we are using `cimg/python:3.7-node` as base image for deployment which is alias for `cimg/python:3.7.15-node`. This uses node version 18.12.0 on which our deployment fails. This PR fixes frontend deployment by using  `cimg/python:3.7.14-node`
as base image which uses node 16.17.0. Related to #5395 