### PR TITLE
Add icon on toolbar to upload an image for comment input

### DIFF
--- a/frontend/src/components/comments/commentInput.js
+++ b/frontend/src/components/comments/commentInput.js
@@ -7,7 +7,7 @@ import { useDropzone } from 'react-dropzone';
 
 import 'tributejs/tribute.css';
 
-import { useOnDrop } from '../../hooks/UseUploadImage';
+import { useOnDrop, useUploadImage } from '../../hooks/UseUploadImage';
 import { fetchLocalJSONAPI } from '../../network/genericJSONRequest';
 import HashtagPaste from './hashtagPaste';
 import FileRejections from './fileRejections';
@@ -37,6 +37,7 @@ export const CommentInputField = ({
     onDrop,
     ...DROPZONE_SETTINGS,
   });
+  const [fileuploadError, fileuploading, uploadImg] = useUploadImage();
 
   const tribute = new Tribute({
     trigger: '@',
@@ -72,6 +73,9 @@ export const CommentInputField = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [textareaRef.current, contributors]);
 
+  const handleImagePick = async (event) =>
+    await uploadImg(event.target.files[0], appendImgToComment, token);
+
   return (
     <div {...getRootProps()}>
       <div className={`${isShowPreview ? 'dn' : ''}`}>
@@ -84,6 +88,13 @@ export const CommentInputField = ({
           value={comment}
           onChange={setComment}
           textareaProps={getInputProps}
+        />
+        <input
+          type="file"
+          id="image_picker"
+          className="dn"
+          accept="image/*"
+          onChange={handleImagePick}
         />
         {isProjectDetailCommentSection && (
           <div className="flex justify-between ba bt-0 w-100 ph2 pv1 relative b--blue-grey textareaDetail">
@@ -125,7 +136,10 @@ export const CommentInputField = ({
           )}
         </span>
       )}
-      <DropzoneUploadStatus uploading={uploading} uploadError={uploadError} />
+      <DropzoneUploadStatus
+        uploading={uploading || fileuploading}
+        uploadError={uploadError || fileuploadError}
+      />
       <FileRejections files={fileRejections} />
     </div>
   );

--- a/frontend/src/components/comments/editorIconConfig.js
+++ b/frontend/src/components/comments/editorIconConfig.js
@@ -105,6 +105,27 @@ export const iconConfig = {
       });
     },
   },
+  upload: {
+    name: 'upload',
+    keyCommand: 'upload',
+    buttonProps: { 'aria-label': 'Upload user', title: 'Upload image' },
+    icon: (
+      <svg width={ICON_SIZE} height={ICON_SIZE} x="0" y="0" viewBox="0 0 24 24" class="">
+        <g>
+          <path
+            id="image-upload"
+            d="m21.75 11v6a3.383 3.383 0 0 1 -3.75 3.75h-12a3.383 3.383 0 0 1 -3.75-3.75v-10a3.383 3.383 0 0 1 3.75-3.75h8a.75.75 0 0 1 0 1.5h-8c-1.577 0-2.25.673-2.25 2.25v9.25l2.54-2.54a1.008 1.008 0 0 1 1.42 0l.94.94a.5.5 0 0 0 .7 0l4.94-4.94a1.008 1.008 0 0 1 1.42 0l4.54 4.54v-3.25a.75.75 0 0 1 1.5 0zm-13.757-3.25a1.253 1.253 0 1 0 .007 0zm10.537-2.72.22-.219v2.189a.75.75 0 0 0 1.5 0v-2.189l.22.219a.75.75 0 0 0 1.06-1.06l-1.5-1.5a.751.751 0 0 0 -1.06 0l-1.5 1.5a.75.75 0 0 0 1.06 1.06z"
+            fill="#000000"
+            data-original="#000000"
+            class=""
+          ></path>
+        </g>
+      </svg>
+    ),
+    execute: () => {
+      document.getElementById('image_picker').click();
+    },
+  },
   // The backend converts markdown into HTML, so youtube embed iframe works on the preview mode,
   // uncomment this when backend has support for converting our custom youtube markdown into iframes
   // youtube: {

--- a/frontend/src/components/projectDetail/tests/questionsAndComments.test.js
+++ b/frontend/src/components/projectDetail/tests/questionsAndComments.test.js
@@ -23,7 +23,7 @@ describe('test if QuestionsAndComments component', () => {
       </ReduxIntlProviders>,
     );
     const previewBtn = screen.getByRole('button', { name: /preview/i });
-    expect(screen.getAllByRole('button').length).toBe(10);
+    expect(screen.getAllByRole('button').length).toBe(11);
     expect(screen.getByRole('button', { name: /write/i })).toBeInTheDocument();
     expect(previewBtn).toBeInTheDocument();
     expect(screen.getByRole('textbox')).toBeInTheDocument();


### PR DESCRIPTION
This pull request will add an image upload icon to the toolbar of the markdown editor, allowing the user to select a local image to upload.

![upload-image](https://user-images.githubusercontent.com/51614993/202381240-50e122f0-6042-4032-8b67-cf69bda14b33.gif)

Closes one of the tasks from https://github.com/hotosm/tasking-manager/issues/5390
