### PR TITLE
Update contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -36,7 +36,7 @@ Test a bug fix or new feature. Once an issue has been addressed and Pull Request
 Create pull requests (PRs) for changes that you think are needed. We would really appreciate your help! We ask that you follow our [coding contribution guidelines](https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing-guidelines.md).
 
 ## Translating
-Review or submit [language translations]( https://github.com/hotosm/tasking-manager/blob/develop/docs/contributing-translation.md)
+Review or submit [language translations](https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing-guidelines.md#translators)
 
 ## Thank you!
 Thank you very much in advance for your contributions!! Please ensure you refer to our [Code of Conduct](https://github.com/hotosm/tasking-manager/blob/develop/docs/code_of_conduct.md) when you contribute!

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,46 @@
+
+# Contributing to the Tasking Manager
+
+## Welcome
+
+:+1::tada: First off, I'm really glad you're reading this, because we need volunteer developers to help improve the Tasking Manager.! :tada::+1:
+We welcome and encourage contributors of all skill levels and we are committed to making sure your participation in our tech collective is inclusive, enjoyable and rewarding. If you have never contributed to an open source project before, we are a good place to start and will make sure you are supported every step of the way. If you have **any** questions, please ask!
+
+We are collaborating with Kathmandu Living Labs on the maintenance of the Tasking Manager - expect to hear a lot from all of us on Github :)
+
+There are many ways to contribute to the Tasking Manager Project:
+
+## Report bugs and suggest improvements:
+
+The [issue queue](https://github.com/hotosm/tasking-manager/issues) is the best way to get started. There are issue templates for BUGs and FEATURES that you can use, or you can create your own. Once you have submitted an issue, it will be assigned one label out of the following [label categories](https://github.com/hotosm/tasking-manager/labels):
+
+- **Backlog**:  Backlog=triage will first be assigned to any new issues
+- **Component**
+
+On a monthly basis, we will collaboratively triage issues from the *backlog=triage* and assign one of the below labels:
+- **Assigned**: once reviewed the issue will be assigned either to hot_tech OR tm_collective. Issues assigned to tm_collective is where we really need your help!
+- **Type**: specifying whether the issue is a bug or feature/enhancement
+- **Priority**: specifying the priority level for each issue. We want to collaboratively agree the criteria for prioritisation.
+- **Status**: specifying whether the issue is in progress or done.
+- **Experience**: we have added a beginner label for good first issues. We will work with the community to update the labels in this category and make them suitable.
+
+Note: Issues older than 6 months from the point of raising the issue with no engagement will be labelled as *archived*.
+
+## Testing
+
+Test a bug fix or new feature. Once an issue has been addressed and Pull Request (PR) change deployed to the [Tasking Manager Staging site](https://tasks-stage.hotosm.org/), you will be able to view and test the change on the staging site. A PR would then be made from develop to master branch, which would require two reviews. If you notice any issues while testing, please comment on the PR directly.
+
+
+## Code contributions
+
+Create pull requests (PRs) for changes that you think are needed. We would really appreciate your help! We ask that you follow our [coding contribution guidelines](https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing-guidelines.md).
+
+## Translating
+Review or submit [language translations]( https://github.com/hotosm/tasking-manager/blob/develop/docs/contributing-translation.md)
+
+## Thank you!
+Thank you very much in advance for your contributions!! Please ensure you refer to our [Code of Conduct](https://github.com/hotosm/tasking-manager/blob/develop/docs/code_of_conduct.md) when you contribute!
+
+If you've read the guidelines, but you are still not sure how to contribute on Github, please reach out to us via our [ HOT Tech Support page]([https://hotosm.atlassian.net/servicedesk/customer/portal/4](https://hotosm.atlassian.net/servicedesk/customer/portal/4/group/5/create/51) and we will be happy to help!
+
+


### PR DESCRIPTION
These should be the MAIN contributing guidelines. They introduce users to the different ways of contributing and refer to two more detailed pages:
- Translation contributions:   https://github.com/hotosm/tasking-manager/blob/develop/docs/contributing-translation.md  @dakotabenjamin  this links gives me an error- could check where it might be held or it is now part of code contributions below?
- Code contributions:  https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing-guidelines.md
- @dakotabenjamin  I also updated the URL for tech support https://hotosm.atlassian.net/servicedesk/customer/portal/4/group/5/create/51

@ramyaragupathy  we can also late update the labels if any changes.