### PR TITLE
Display task instructions also when multiple tasks are selected

### DIFF
--- a/frontend/src/components/taskSelection/action.js
+++ b/frontend/src/components/taskSelection/action.js
@@ -334,11 +334,7 @@ export function TaskMapAction({
                           }
                           contributors={contributors}
                           historyTabSwitch={historyTabSwitch}
-                          taskInstructions={
-                            activeTasks && activeTasks.length === 1
-                              ? activeTasks[0].perTaskInstructions
-                              : null
-                          }
+                          taskInstructions={activeTasks && activeTasks[0].perTaskInstructions}
                           disabled={disabled}
                           taskComment={taskComment}
                           setTaskComment={setTaskComment}
@@ -350,11 +346,7 @@ export function TaskMapAction({
                         <CompletionTabForValidation
                           project={project}
                           tasksIds={tasksIds}
-                          taskInstructions={
-                            activeTasks && activeTasks.length === 1
-                              ? activeTasks[0].perTaskInstructions
-                              : null
-                          }
+                          taskInstructions={activeTasks && activeTasks[0].perTaskInstructions}
                           disabled={disabled}
                           contributors={contributors}
                           validationComments={validationComments}


### PR DESCRIPTION
Related to the second item from https://github.com/hotosm/tasking-manager/issues/5149

Per task instructions were shown only when a single task was selected for mapping/validation. This PR will display task instructions even when multiple tasks are selected for validation. 
![per-task-instruction](https://user-images.githubusercontent.com/51614993/204448315-97830f08-69d6-46a6-a054-5d280b3dbc32.png)
