### PR TITLE
Remove dependency on the visibility value to enable submit button

### DIFF
--- a/frontend/src/components/formInputs.js
+++ b/frontend/src/components/formInputs.js
@@ -9,7 +9,7 @@ import { formatCountryList } from '../utils/countries';
 import { fetchLocalJSONAPI } from '../network/genericJSONRequest';
 import { CheckIcon, SearchIcon, CloseIcon } from './svgIcons';
 
-export const RadioField = ({ name, value, className }: Object) => (
+export const RadioField = ({ name, value, className, required = false }: Object) => (
   <Field
     name={name}
     component="input"
@@ -18,6 +18,7 @@ export const RadioField = ({ name, value, className }: Object) => (
     className={`radio-input input-reset pointer v-mid dib h2 w2 mr2 br-100 ba b--blue-light ${
       className || ''
     }`}
+    required={required}
   />
 );
 

--- a/frontend/src/components/teamsAndOrgs/teams.js
+++ b/frontend/src/components/teamsAndOrgs/teams.js
@@ -194,7 +194,7 @@ export function TeamInformation(props) {
         </label>
         {Object.keys(joinMethods).map((method) => (
           <div className="pv2">
-            <RadioField name="joinMethod" value={method} />
+            <RadioField name="joinMethod" value={method} required />
             <span className="f5">
               <FormattedMessage {...messages[joinMethods[method]]} />
             </span>

--- a/frontend/src/views/teams.js
+++ b/frontend/src/views/teams.js
@@ -138,9 +138,6 @@ export function CreateTeam() {
 
   const createTeam = (payload) => {
     delete payload['organisation'];
-    if (payload.joinMethod !== 'BY_INVITE') {
-      payload.visibility = 'PUBLIC';
-    }
     pushToLocalJSONAPI('teams/', JSON.stringify(payload), token, 'POST').then((result) => {
       managers
         .filter((user) => user.username !== userDetails.username)
@@ -153,7 +150,8 @@ export function CreateTeam() {
   return (
     <Form
       onSubmit={(values) => createTeam(values)}
-      render={({ handleSubmit, pristine, form, submitting, values }) => {
+      initialValues={{ visibility: 'PUBLIC' }}
+      render={({ handleSubmit, pristine, submitting, values }) => {
         return (
           <form onSubmit={handleSubmit} className="blue-grey">
             <div className="cf pb5">
@@ -200,7 +198,7 @@ export function CreateTeam() {
               </div>
               <div className="w-20-l w-40-m w-50 h-100 fr">
                 <FormSubmitButton
-                  disabled={submitting || pristine || !values.organisation_id || !values.visibility}
+                  disabled={submitting || pristine || !values.organisation_id}
                   className="w-100 h-100 bg-red white"
                   disabledClassName="bg-red o-50 white w-100 h-100"
                 >
@@ -211,7 +209,7 @@ export function CreateTeam() {
           </form>
         );
       }}
-    ></Form>
+    />
   );
 }
 


### PR DESCRIPTION
Closes #5415 

Initialize the team creation form with a value of `PUBLIC` for visibility key so that the value is also sent as a payload (the field is marked as required on the endpoint).

Also adds a tooltip for the radio button input when a value is not provided as follows.

![Screenshot from 2022-11-29 14-41-32](https://user-images.githubusercontent.com/51614993/204492747-cf090d3b-dcd2-49cd-8e3c-adc667c8ed60.png)
