### PR TITLE
Fix the relative path to navigate to when clicking outside the notification modal

### DIFF
--- a/frontend/src/components/notifications/notificationBodyCard.js
+++ b/frontend/src/components/notifications/notificationBodyCard.js
@@ -18,7 +18,7 @@ export const NotificationBodyModal = (props) => {
 
   return (
     <div
-      onClick={() => navigate(`../../${location.search}`)}
+      onClick={() => navigate(`../${location.search}`)}
       className="fixed top-0 left-0 right-0 bottom-0 notification-ctr"
     >
       <div


### PR DESCRIPTION
Resolves https://github.com/hotosm/tasking-manager/issues/5429