### PR TITLE
Add spellcheck props for the markdown editor

### DIFF
--- a/frontend/src/components/comments/commentInput.js
+++ b/frontend/src/components/comments/commentInput.js
@@ -87,7 +87,7 @@ export const CommentInputField = ({
           height={200}
           value={comment}
           onChange={setComment}
-          textareaProps={getInputProps}
+          textareaProps={{ ...getInputProps(), spellCheck: 'true' }}
         />
         <input
           type="file"


### PR DESCRIPTION
Related to https://github.com/hotosm/tasking-manager/issues/5390; enable spellcheck for the markdown editor

![spellcheck](https://user-images.githubusercontent.com/51614993/205321411-47fc9a9f-e4f4-4738-842b-5c97f1b87734.png)
