### PR TITLE
Opt out of dark mode from the markdown editor

### DIFF
--- a/frontend/src/components/comments/commentInput.js
+++ b/frontend/src/components/comments/commentInput.js
@@ -78,7 +78,7 @@ export const CommentInputField = ({
 
   return (
     <div {...getRootProps()}>
-      <div className={`${isShowPreview ? 'dn' : ''}`}>
+      <div className={`${isShowPreview ? 'dn' : ''}`} data-color-mode="light">
         <MDEditor
           ref={textareaRef}
           preview="edit"


### PR DESCRIPTION
Related to #5390; wrap the markdown editor component with light color mode.

Before:
![dark-mode](https://user-images.githubusercontent.com/51614993/205322597-93cbf91e-bacf-48e4-9aec-2b2945984003.png)

Now:
![light-mode](https://user-images.githubusercontent.com/51614993/205322604-68cddbc0-af16-40c7-9b16-936cf6422553.png)
