### PR TITLE
fix JOSM remote control so url= is regular http(s) URL

### DIFF
--- a/client/app/project/project.controller.js
+++ b/client/app/project/project.controller.js
@@ -1678,10 +1678,11 @@
                 hasImagery = true;
             }
             if (hasImagery) {
+                const fixedUrl = imageryUrl.substr(imageryUrl.indexOf(":")+1);
                 var imageryParams = {
                     title: encodeURIComponent('Tasking Manager Imagery - #' + vm.projectData.projectId),
                     type: imageryUrl.toLowerCase().substring(0, 3),
-                    url: encodeURIComponent(imageryUrl)
+                    url: encodeURIComponent(fixedUrl)
                 };
                 editorService.sendJOSMCmd('http://127.0.0.1:8111/imagery', imageryParams)
                     .catch(function() {


### PR DESCRIPTION
Otherwise, as `imageryUrl` is (as required) in format like `tms[20]:https://tms.osm-hr.org/knin-2007/{zoom}/{x}/{-y}.png`, that value would be sent as `url` parameter to [JOSM remote control](https://josm.openstreetmap.de/wiki/Help/RemoteControlCommands#imagery) `imagery` load command, which would thus fail to load imagery (in current testing JOSM version 18583 at least)

This PR fixes it so `url=` parameter to remote control is regular http(s) URL like `https://tms.osm-hr.org/knin-2007/{zoom}/{x}/{-y}.png`, as it should be.