### PR TITLE
Display the notification modal without being directed to the notification list(inbox) page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "react-scripts": "^4.0.3",
     "react-select": "^4.3.1",
     "react-tooltip": "^4.2.21",
-    "reactjs-popup": "^1.5.0",
+    "reactjs-popup": "^2.0.5",
     "redux": "^4.1.0",
     "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -54,11 +54,7 @@ import { ProjectStats } from './views/projectStats';
 import { ContactPage } from './views/contact';
 import { SwaggerView } from './views/swagger';
 import { ContributionsPage, ContributionsPageIndex, UserStats } from './views/contributions';
-import {
-  NotificationsPage,
-  NotificationPageIndex,
-  NotificationDetail,
-} from './views/notifications';
+import { NotificationsPage, NotificationPageIndex } from './views/notifications';
 import { Banner, ArchivalNotificationBanner } from './components/banner/index';
 import TopBanner from './components/banner/TopBanner';
 
@@ -119,7 +115,6 @@ let App = (props) => {
                   <UserDetail path="users/:username" />
                   <NotificationsPage path="inbox">
                     <NotificationPageIndex path="/" />
-                    <NotificationDetail path="message/:id" />
                   </NotificationsPage>
                   <Authorized path="authorized" />
                   <Login path="login" />

--- a/frontend/src/assets/styles/_extra.scss
+++ b/frontend/src/assets/styles/_extra.scss
@@ -493,8 +493,22 @@ a[href="https://www.mapbox.com/map-feedback/"]
   @media screen and (max-width: 60em) {
     grid-template-columns: repeat(2, 1fr);
   }
-  
+
   @media screen and (max-width: 30em) {
     grid-template-columns: repeat(1, 1fr);
   }
+}
+
+// Styles for reactjs-popup
+.popup-overlay {
+  background: rgba(44, 48, 56, 0.7);
+}
+
+.popup-content {
+  font-family: 'Archivo', 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  max-height: calc(100vh - 10em);
+  overflow-y: auto;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.105469), 0px 15px 14px rgba(0, 0, 0, 0.270041),
+    0px 34px 24px rgba(0, 0, 0, 0.37534);
+  padding: 0 !important;
 }

--- a/frontend/src/components/contributions/taskCard.js
+++ b/frontend/src/components/contributions/taskCard.js
@@ -34,89 +34,90 @@ export function TaskCard({
     new Date(+new Date(lastUpdated) + autoUnlockSeconds * 1000);
 
   return (
-    <div onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
-      <article
-        className={`db base-font bg-white w-75-l w-100 mb1 mh2 blue-dark mw8 ${
-          isHovered ? 'shadow-4' : ''
-        }`}
-      >
-        <div className="pv3 ph3 ba br1 b--grey-light cf">
-          <div className="w-third-ns w-100 fl">
-            <Link to={taskLink} className="no-underline link blue-dark dib">
-              <h4 className="mv0 fw6 f5">
-                <FormattedMessage
-                  {...messages.projectTask}
-                  values={{ task: taskId, project: projectId }}
-                />
-              </h4>
-            </Link>
-            <div className={`pt2 blue-grey f6`} title={lastUpdated}>
-              <span>
-                <FormattedMessage
-                  {...messages.lastUpdatedByUser}
-                  values={{ time: <RelativeTimeWithUnit date={lastUpdated} /> }}
-                />
-              </span>
-            </div>
-          </div>
-          <div className="w-third-ns w-100 fl">
-            <div className={lockHolder ? '' : 'pv2 mv1'}>
-              <div className="db">
-                <TaskStatus status={taskStatus} lockHolder={lockHolder} />
-              </div>
-              {lockHolder && (
-                <div
-                  className="dn dib-ns mv1 blue-grey bg-grey-light f7 pv1 ph2"
-                  title={timeToAutoUnlock}
-                >
-                  <ClockIcon className="pr2 v-mid" height="19px" width="13px" />
-                  <span className="v-mid">
-                    <FormattedMessage
-                      {...messages.unlock}
-                      values={{ time: <RelativeTimeWithUnit date={timeToAutoUnlock} /> }}
-                    />
-                  </span>
-                </div>
-              )}
-            </div>
-          </div>
-          <div className="w-third-ns w-100 fr">
-            {numberOfComments ? (
-              <span
-                className="w-auto tr fl mv1 pv2 f6 blue-grey"
-                title={intl.formatMessage(messages.commentsNumber, { number: numberOfComments })}
-              >
-                <CommentIcon className="pr2 v-mid" height="19px" width="13px" />
-                {numberOfComments}
-              </span>
-            ) : (
-              ''
-            )}
-            <Popup
-              trigger={
-                <ListIcon className="pointer fr h1 w1 mv1 pv2 v-mid pr3 blue-light hover-blue-grey" />
-              }
-              modal
-              closeOnDocumentClick
-            >
-              {(close) => (
-                <TaskActivity taskId={taskId} project={{ projectId: projectId }} close={close} />
-              )}
-            </Popup>
-            {isHovered &&
-              ['READY', 'LOCKED_FOR_MAPPING', 'LOCKED_FOR_VALIDATION', 'INVALIDATED'].includes(
-                taskStatus,
-              ) && (
-                <Link to={taskLink}>
-                  <div className={`dn dib-l link pv2 ph3 mh3 mv1 bg-red white f7 fr`}>
-                    <ResumeIcon className={`ph1 dib-l dn`} />
-                    <FormattedMessage {...messages.resumeTask} />
-                  </div>
-                </Link>
-              )}
+    <article
+      className={`db base-font bg-white w-75-l w-100 mb1 mh2 blue-dark mw8 ${
+        isHovered ? 'shadow-4' : ''
+      }`}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div className="pv3 ph3 ba br1 b--grey-light cf">
+        <div className="w-third-ns w-100 fl">
+          <Link to={taskLink} className="no-underline link blue-dark dib">
+            <h4 className="mv0 fw6 f5">
+              <FormattedMessage
+                {...messages.projectTask}
+                values={{ task: taskId, project: projectId }}
+              />
+            </h4>
+          </Link>
+          <div className={`pt2 blue-grey f6`} title={lastUpdated}>
+            <span>
+              <FormattedMessage
+                {...messages.lastUpdatedByUser}
+                values={{ time: <RelativeTimeWithUnit date={lastUpdated} /> }}
+              />
+            </span>
           </div>
         </div>
-      </article>
-    </div>
+        <div className="w-third-ns w-100 fl">
+          <div className={lockHolder ? '' : 'pv2 mv1'}>
+            <div className="db">
+              <TaskStatus status={taskStatus} lockHolder={lockHolder} />
+            </div>
+            {lockHolder && (
+              <div
+                className="dn dib-ns mv1 blue-grey bg-grey-light f7 pv1 ph2"
+                title={timeToAutoUnlock}
+              >
+                <ClockIcon className="pr2 v-mid" height="19px" width="13px" />
+                <span className="v-mid">
+                  <FormattedMessage
+                    {...messages.unlock}
+                    values={{ time: <RelativeTimeWithUnit date={timeToAutoUnlock} /> }}
+                  />
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="w-third-ns w-100 fr">
+          {numberOfComments ? (
+            <span
+              className="w-auto tr fl mv1 pv2 f6 blue-grey"
+              title={intl.formatMessage(messages.commentsNumber, { number: numberOfComments })}
+            >
+              <CommentIcon className="pr2 v-mid" height="19px" width="13px" />
+              {numberOfComments}
+            </span>
+          ) : (
+            ''
+          )}
+          <Popup
+            trigger={
+              <ListIcon className="pointer fr h1 w1 mv1 pv2 v-mid pr3 blue-light hover-blue-grey" />
+            }
+            modal
+            closeOnDocumentClick
+            nested
+          >
+            {(close) => (
+              <TaskActivity taskId={taskId} project={{ projectId: projectId }} close={close} />
+            )}
+          </Popup>
+          {isHovered &&
+            ['READY', 'LOCKED_FOR_MAPPING', 'LOCKED_FOR_VALIDATION', 'INVALIDATED'].includes(
+              taskStatus,
+            ) && (
+              <Link to={taskLink}>
+                <div className={`dn dib-l link pv2 ph3 mh3 mv1 bg-red white f7 fr`}>
+                  <ResumeIcon className={`ph1 dib-l dn`} />
+                  <FormattedMessage {...messages.resumeTask} />
+                </div>
+              </Link>
+            )}
+        </div>
+      </div>
+    </article>
   );
 }

--- a/frontend/src/components/notifications/notificationBodyCard.js
+++ b/frontend/src/components/notifications/notificationBodyCard.js
@@ -62,6 +62,8 @@ export const NotificationBodyModal = (props) => {
 
 export function NotificationBodyCard({
   loading,
+  retryFn,
+  closeModal,
   card: {
     messageId,
     name,
@@ -91,7 +93,10 @@ export function NotificationBodyCard({
   }
   const deleteNotification = (id) => {
     fetchLocalJSONAPI(`notifications/${id}/`, token, 'DELETE')
-      .then((success) => navigate(`../../${location.search}`))
+      .then(() => {
+        retryFn();
+        closeModal();
+      })
       .catch((e) => {
         console.log(e.message);
       });

--- a/frontend/src/components/notifications/notificationBodyCard.js
+++ b/frontend/src/components/notifications/notificationBodyCard.js
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { Link, useLocation, navigate } from '@reach/router';
 import ReactPlaceholder from 'react-placeholder';
 import 'react-placeholder/lib/reactPlaceholder.css';
 import { selectUnit } from '../../utils/selectUnit';
@@ -8,54 +7,62 @@ import { FormattedRelativeTime, FormattedMessage } from 'react-intl';
 
 import messages from './messages';
 import { MessageAvatar, typesThatUseSystemAvatar, rawHtmlNotification } from './notificationCard';
+import { useFetch } from '../../hooks/UseFetch';
 import { CloseIcon } from '../svgIcons';
 import { fetchLocalJSONAPI } from '../../network/genericJSONRequest';
 import { DeleteButton } from '../teamsAndOrgs/management';
 import './styles.scss';
 
 export const NotificationBodyModal = (props) => {
-  const location = useLocation();
+  const [thisNotificationError, thisNotificationLoading, thisNotification] = useFetch(
+    `notifications/${props.id}/`,
+  );
+
+  useEffect(() => {
+    // Close the mini notification popover if it's open
+    props.setPopoutFocus && props.setPopoutFocus(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div
-      onClick={() => navigate(`../${location.search}`)}
-      className="fixed top-0 left-0 right-0 bottom-0 notification-ctr"
+      className={`relative shadow-3 flex flex-column notification`}
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+
+        // Navigate to links on markdown anchor elements click
+        if (e.target.href !== undefined) {
+          window.open(e.target.href);
+        }
+      }}
     >
       <div
-        className={`relative shadow-3 flex flex-column notification`}
-        onClick={(e) => {
-          e.stopPropagation();
-          e.preventDefault();
-
-          if (e.target.href !== undefined) {
-            window.open(e.target.href);
-          }
-        }}
+        className={`di fl f125 tl pa3 w-100 fw7 bb b--tan header base-font`}
+        style={{ letterSpacing: '0.114546px' }}
       >
-        <div className={`di fl f125 tl pa3 w-100 fw7 bb b--tan header`}>
-          <FormattedMessage {...messages.message} />
-          <Link className={`fr ml4 blue-dark`} to={`../../${location.search}`}>
-            <CloseIcon className={`h1 w1 blue-dark`} />
-          </Link>
-        </div>
-        {!props.thisNotificationError && (
-          <NotificationBodyCard
-            loading={props.thisNotificationLoading}
-            card={props.thisNotification}
-          />
-        )}
-        {props.thisNotificationError && !props.thisNotificationLoading && (
-          <div>
-            <FormattedMessage
-              {...messages.errorLoadingTheX}
-              values={{
-                xWord: <FormattedMessage {...messages.message} />,
-              }}
-            />
-          </div>
-        )}
-        {props.children}
+        <FormattedMessage {...messages.message} />
+        <CloseIcon className={`fr ml4 blue-dark h1 w1 blue-dark pointer`} onClick={props.close} />
       </div>
+      {!thisNotificationError && (
+        <NotificationBodyCard
+          loading={thisNotificationLoading}
+          card={thisNotification}
+          retryFn={props.retryFn}
+          closeModal={props.close}
+        />
+      )}
+      {thisNotificationError && !thisNotificationLoading && (
+        <div>
+          <FormattedMessage
+            {...messages.errorLoadingTheX}
+            values={{
+              xWord: <FormattedMessage {...messages.message} />,
+            }}
+          />
+        </div>
+      )}
+      {props.children}
     </div>
   );
 };
@@ -76,7 +83,6 @@ export function NotificationBodyCard({
   },
 }: Object) {
   const token = useSelector((state) => state.auth.token);
-  const location = useLocation();
   const { value, unit } = selectUnit(new Date((sentDate && new Date(sentDate)) || new Date()));
   const showASendingUser =
     fromUsername || (typesThatUseSystemAvatar.indexOf(messageType) !== -1 && 'System');

--- a/frontend/src/components/notifications/notificationCard.js
+++ b/frontend/src/components/notifications/notificationCard.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { useSelector } from 'react-redux';
-import { Link, navigate, useLocation } from '@reach/router';
+import Popup from 'reactjs-popup';
 import ReactTooltip from 'react-tooltip';
 import DOMPurify from 'dompurify';
 import { FormattedMessage } from 'react-intl';
@@ -13,6 +13,9 @@ import { UserAvatar } from '../user/avatar';
 import { DeleteButton } from '../teamsAndOrgs/management';
 import { RelativeTimeWithUnit } from '../../utils/formattedRelativeTime';
 import { fetchLocalJSONAPI } from '../../network/genericJSONRequest';
+import { NotificationBodyModal } from './notificationBodyCard';
+
+import 'reactjs-popup/dist/index.css';
 
 export const rawHtmlNotification = (notificationHtml) => ({
   __html: DOMPurify.sanitize(notificationHtml),
@@ -67,11 +70,14 @@ export function NotificationCard({
   setSelected,
 }: Object) {
   const token = useSelector((state) => state.auth.token);
-  const location = useLocation();
-  const setMessageAsRead = (messageId) => {
-    fetchLocalJSONAPI(`notifications/${messageId}/`, token).then(() => {
-      retryFn();
-    });
+  const ref = useRef();
+  const replacedSubject = subject.replace('task=', 'search=');
+
+  const setMessageAsRead = () => {
+    !read &&
+      fetchLocalJSONAPI(`notifications/${messageId}/`, token).then(() => {
+        retryFn();
+      });
   };
 
   const deleteNotification = (id) => {
@@ -85,92 +91,93 @@ export function NotificationCard({
       });
   };
 
-  const replacedSubject = subject.replace('task=', 'search=');
-  const openMessage = () => {
-    setMessageAsRead(messageId);
-    navigate(`/inbox/message/${messageId}/${location.search}`);
-  };
-
   return (
-    <article
-      onClick={openMessage}
-      className="pointer db base-font w-100 mb2 mw8 bg-white blue-dark br1 shadow-1"
-    >
-      <div className={`pv3 pr3 bl bw2 br2 ${read ? 'b--white' : 'b--red'} flex items-center`}>
-        <div className="ph3 pt1">
-          <CheckBox activeItems={selected} toggleFn={setSelected} itemId={messageId} />
-        </div>
-
-        <div className="flex-grow-1">
-          <div className="flex">
-            <div className={`mr3`}>
-              <MessageAvatar
-                messageType={messageType}
-                fromUsername={fromUsername}
-                displayPictureUrl={displayPictureUrl}
-                size={'medium'}
-              />
+    <Popup
+      modal
+      ref={ref}
+      closeOnDocumentClick={false}
+      onOpen={setMessageAsRead}
+      trigger={
+        <article className="pointer db base-font w-100 mb2 mw8 bg-white blue-dark br1 shadow-1">
+          <div className={`pv3 pr3 bl bw2 br2 ${read ? 'b--white' : 'b--red'} flex items-center`}>
+            <div className="ph3 pt1">
+              <CheckBox activeItems={selected} toggleFn={setSelected} itemId={messageId} />
             </div>
-            <div>
-              <p
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  if (e.target.href === undefined) {
-                    openMessage();
-                  } else {
-                    window.open(e.target.href);
-                  }
-                }}
-                className={`messageSubjectLinks ma0 f6`}
-                dangerouslySetInnerHTML={rawHtmlNotification(replacedSubject)}
-              />
-              <div className={`pt2 blue-grey f6`}>
-                <RelativeTimeWithUnit date={sentDate} />
+            <div className="flex-grow-1">
+              <div className="flex">
+                <div className={`mr3`}>
+                  <MessageAvatar
+                    messageType={messageType}
+                    fromUsername={fromUsername}
+                    displayPictureUrl={displayPictureUrl}
+                    size={'medium'}
+                  />
+                </div>
+                <div>
+                  <p
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      // Navigate to links on markdown anchor elements click
+                      if (e.target.href !== undefined) {
+                        window.open(e.target.href);
+                      } else {
+                        ref.current.open();
+                      }
+                    }}
+                    className={`messageSubjectLinks ma0 f6`}
+                    dangerouslySetInnerHTML={rawHtmlNotification(replacedSubject)}
+                  />
+                  <div className={`pt2 blue-grey f6`}>
+                    <RelativeTimeWithUnit date={sentDate} />
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
 
-        <div
-          className={`dib w3`}
-          onClick={(e) => {
-            e.persist();
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-        >
-          {!read && (
-            <>
-              <FormattedMessage {...messages.markAsRead}>
-                {(msg) => (
-                  <EyeIcon
-                    onClick={() => setMessageAsRead(messageId)}
-                    style={{ width: '20px', height: '20px' }}
-                    className={`dn dib-ns h1 w1 pr1 nr4 mv1 pv1 hover-red blue-light ml3`}
-                    data-tip={msg}
-                  />
-                )}
-              </FormattedMessage>
-              <ReactTooltip />
-            </>
-          )}
-        </div>
-        {messageType !== null ? (
-          <div className={`di-l dn f7 truncate w4 lh-solid`} title={messageType}>
-            <FormattedMessage {...messages[messageType]} />
+            <div
+              className={`dib w3`}
+              onClick={(e) => {
+                e.persist();
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
+              {!read && (
+                <>
+                  <FormattedMessage {...messages.markAsRead}>
+                    {(msg) => (
+                      <EyeIcon
+                        onClick={() => setMessageAsRead()}
+                        style={{ width: '20px', height: '20px' }}
+                        className={`dn dib-ns h1 w1 pr1 nr4 mv1 pv1 hover-red blue-light ml3`}
+                        data-tip={msg}
+                      />
+                    )}
+                  </FormattedMessage>
+                  <ReactTooltip />
+                </>
+              )}
+            </div>
+            {messageType !== null ? (
+              <div className={`di-l dn f7 truncate w4 lh-solid`} title={messageType}>
+                <FormattedMessage {...messages[messageType]} />
+              </div>
+            ) : null}
+            <DeleteButton
+              className={`bg-transparent bw0 w2 h2 lh-copy overflow-hidden blue-light p0 mb1 hover-red`}
+              showText={false}
+              onClick={(e) => {
+                e.stopPropagation();
+                deleteNotification(messageId);
+              }}
+            />
           </div>
-        ) : null}
-        <DeleteButton
-          className={`bg-transparent bw0 w2 h2 lh-copy overflow-hidden blue-light p0 mb1 hover-red`}
-          showText={false}
-          onClick={(e) => {
-            e.stopPropagation();
-            deleteNotification(messageId);
-          }}
-        />
-      </div>
-    </article>
+        </article>
+      }
+    >
+      {(close) => <NotificationBodyModal id={messageId} close={close} retryFn={retryFn} />}
+    </Popup>
   );
 }
 
@@ -181,34 +188,49 @@ export function NotificationCardMini({
   displayPictureUrl,
   subject,
   sentDate,
+  setPopoutFocus,
+  retryFn,
 }: Object) {
   return (
-    <Link to={`/inbox/message/${messageId}`} className="no-underline hover-red">
-      <article
-        className="db base-font w-100 hover-red blue-dark"
-        style={{ marginBottom: '1.5rem', padding: '0 1.3rem' }}
-      >
-        <div className="flex" style={{ gap: '1rem' }}>
-          <div className="h2 v-top">
-            <MessageAvatar
-              messageType={messageType}
-              fromUsername={fromUsername}
-              displayPictureUrl={displayPictureUrl}
-              size={'medium'}
-            />
-          </div>
-          <div>
-            <div
-              className="f7 messageSubjectLinks"
-              style={{ lineHeight: 1.21 }}
-              dangerouslySetInnerHTML={rawHtmlNotification(subject)}
-            ></div>
-            <div className="blue-grey f7 mt2">
-              <RelativeTimeWithUnit date={sentDate} />
+    <Popup
+      modal
+      nested
+      trigger={
+        <article
+          className="db base-font w-100 hover-red blue-dark pointer"
+          style={{ marginBottom: '1.5rem', padding: '0 1.3rem' }}
+        >
+          <div className="flex" style={{ gap: '1rem' }}>
+            <div className="h2 v-top">
+              <MessageAvatar
+                messageType={messageType}
+                fromUsername={fromUsername}
+                displayPictureUrl={displayPictureUrl}
+                size={'medium'}
+              />
+            </div>
+            <div>
+              <div
+                className="f7 messageSubjectLinks"
+                style={{ lineHeight: 1.21 }}
+                dangerouslySetInnerHTML={rawHtmlNotification(subject)}
+              />
+              <div className="blue-grey f7 mt2">
+                <RelativeTimeWithUnit date={sentDate} />
+              </div>
             </div>
           </div>
-        </div>
-      </article>
-    </Link>
+        </article>
+      }
+    >
+      {(close) => (
+        <NotificationBodyModal
+          id={messageId}
+          close={close}
+          setPopoutFocus={setPopoutFocus}
+          retryFn={retryFn}
+        />
+      )}
+    </Popup>
   );
 }

--- a/frontend/src/components/notifications/notificationResults.js
+++ b/frontend/src/components/notifications/notificationResults.js
@@ -23,10 +23,12 @@ export const NotificationResults = ({
   retryFn,
   useMiniCard,
   liveUnreadCount,
+  setPopoutFocus,
 }) => {
   const stateNotifications = !useMiniCard
     ? notifications.userMessages
     : state.unreadNotificationsMini;
+
   const showRefreshButton =
     useMiniCard &&
     !state.isError &&
@@ -72,7 +74,7 @@ export const NotificationResults = ({
           </div>
         </div>
       ) : null}
-      <div className={`cf ${!useMiniCard ? 'db' : 'dib'}`}>
+      <div className={`cf`}>
         <ReactPlaceholder
           ready={!loading && stateNotifications}
           customPlaceholder={<NotificationPlaceholder />}
@@ -83,6 +85,7 @@ export const NotificationResults = ({
             pageOfCards={stateNotifications}
             useMiniCard={useMiniCard}
             retryFn={retryFn}
+            setPopoutFocus={setPopoutFocus}
           />
         </ReactPlaceholder>
       </div>
@@ -97,7 +100,7 @@ export const NotificationResults = ({
   );
 };
 
-const NotificationCards = ({ pageOfCards, useMiniCard, retryFn }) => {
+const NotificationCards = ({ pageOfCards, useMiniCard, retryFn, setPopoutFocus }) => {
   const [selected, setSelected] = useState([]);
 
   if (pageOfCards.length === 0) {
@@ -137,7 +140,16 @@ const NotificationCards = ({ pageOfCards, useMiniCard, retryFn }) => {
         </>
       )}
       {useMiniCard &&
-        pageOfCards.slice(0, 5).map((card, n) => <NotificationCardMini {...card} key={n} />)}
+        pageOfCards
+          .slice(0, 5)
+          .map((card, n) => (
+            <NotificationCardMini
+              {...card}
+              key={n}
+              setPopoutFocus={setPopoutFocus}
+              retryFn={retryFn}
+            />
+          ))}
     </>
   );
 };

--- a/frontend/src/components/notifications/styles.scss
+++ b/frontend/src/components/notifications/styles.scss
@@ -1,22 +1,4 @@
-.notification-ctr {
-  inset: 0px;
-  background: rgba(0, 0, 0, 0.5) none repeat scroll 0% 0%;
-  display: flex;
-  z-index: 999;
-
-  .notification {
-    background: rgb(255, 255, 255) none repeat scroll 0% 0%;
-    width: 55%;
-    margin: 5em auto auto;
-    border: 1px solid rgb(187, 187, 187);
-    overflow-y: auto;
-    max-height: calc(100vh - 10em);
-    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.105469), 0px 15px 14px rgba(0, 0, 0, 0.270041),
-      0px 34px 24px rgba(0, 0, 0, 0.37534);
-  }
-
-  .header {
-    padding: 1.5rem;
-    margin-bottom: 1.5rem;
-  }
+.header {
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
 }

--- a/frontend/src/views/notifications.js
+++ b/frontend/src/views/notifications.js
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { backendToQueryConversion, useInboxQueryParams } from '../hooks/UseInboxQueryAPI';
-import useForceUpdate from '../hooks/UseForceUpdate';
 import { InboxNav, InboxNavMini, InboxNavMiniBottom } from '../components/notifications/inboxNav';
 import {
   NotificationResults,
@@ -11,6 +10,7 @@ import { useSetTitleTag } from '../hooks/UseMetaTags';
 import { Login } from './login';
 import { remapParamsToAPI } from '../utils/remapParamsToAPI';
 import Paginator from '../components/notifications/paginator';
+import { fetchLocalJSONAPI } from '../network/genericJSONRequest';
 
 function serializeParams(queryState) {
   const obj = remapParamsToAPI(queryState, backendToQueryConversion);
@@ -59,6 +59,7 @@ export const NotificationPopout = (props) => {
           liveUnreadCount={props.liveUnreadCount}
           retryFn={props.forceUpdate}
           state={props.state}
+          setPopoutFocus={props.setPopoutFocus}
           className="tl"
         />
         <InboxNavMiniBottom
@@ -81,11 +82,20 @@ export const NotificationsPage = (props) => {
   useSetTitleTag('Notifications');
   const userToken = useSelector((state) => state.auth.token);
   const [inboxQuery, setInboxQuery] = useInboxQueryParams();
-  const [forceUpdated, forceUpdate] = useForceUpdate();
-  const [error, loading, notifications] = useFetch(
-    `notifications/?${serializeParams(inboxQuery)}`,
-    forceUpdated,
-  );
+  const [notifications, setNotifications] = useState([]);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchNotifications = () => {
+    return fetchLocalJSONAPI(`notifications/?${serializeParams(inboxQuery)}`, userToken)
+      .then((result) => setNotifications(result))
+      .catch((e) => setError(e));
+  };
+
+  useEffect(() => {
+    fetchNotifications().then(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inboxQuery]);
 
   if (!userToken) {
     return <Login redirectTo={window.location.pathname} />;
@@ -100,10 +110,10 @@ export const NotificationsPage = (props) => {
       <section>
         <InboxNav />
         <NotificationResults
-          retryFn={forceUpdate}
           error={error}
           loading={loading}
           notifications={notifications}
+          retryFn={fetchNotifications}
         />
         <div className="flex justify-end mw8">
           <Paginator

--- a/frontend/src/views/notifications.js
+++ b/frontend/src/views/notifications.js
@@ -7,8 +7,6 @@ import {
   NotificationResults,
   NotificationResultsMini,
 } from '../components/notifications/notificationResults';
-import { NotificationBodyModal } from '../components/notifications/notificationBodyCard';
-import { useFetch } from '../hooks/UseFetch';
 import { useSetTitleTag } from '../hooks/UseMetaTags';
 import { Login } from './login';
 import { remapParamsToAPI } from '../utils/remapParamsToAPI';
@@ -121,18 +119,4 @@ export const NotificationsPage = (props) => {
 
 export const NotificationPageIndex = () => {
   return null;
-};
-
-export const NotificationDetail = ({ id }) => {
-  const [thisNotificationError, thisNotificationLoading, thisNotification] = useFetch(
-    `notifications/${id}/`,
-  );
-
-  return (
-    <NotificationBodyModal
-      thisNotificationError={thisNotificationError}
-      thisNotificationLoading={thisNotificationLoading}
-      thisNotification={thisNotification}
-    />
-  );
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -13625,10 +13625,10 @@ react@^18.1.0:
   dependencies:
     loose-envify "^1.1.0"
 
-reactjs-popup@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/reactjs-popup/-/reactjs-popup-1.5.0.tgz"
-  integrity sha512-9uoxUAcUomnNoBtdYXBmgsF4w46llsogE3tOvLb5IkR5MMrD6UZJK20ip9kDKXCYubSxNkdfQKqSb/c95rf/qA==
+reactjs-popup@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/reactjs-popup/-/reactjs-popup-2.0.5.tgz#588a74966bb126699429d739948e3448d7771eac"
+  integrity sha512-b5hv9a6aGsHEHXFAgPO5s1Jw1eSkopueyUVxQewGdLgqk2eW0IVXZrPRpHR629YcgIpC2oxtX8OOZ8a7bQJbxA==
 
 read-pkg-up@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Resolves https://github.com/hotosm/tasking-manager/issues/5431

This PR does the following:

- Bump `reactjs-popup` dependency to its latest version 2.0.5.
- Remove URL routes for notification modal. The notification modal will be displayed without navigating to the `inbox/message/` page. Notice how the notification modal is displayed on the same page in the attached image.
![Peek 2022-12-05 15-57](https://user-images.githubusercontent.com/51614993/205612461-0d43e96d-feb9-4b60-90bf-f82325dcb1d2.gif)
- Mark notification as read without displaying the loading placeholder. Notice how the red highlight on the left side of the notification list item gets removed without showing a loading placeholder UI. Similar behavior has been implemented for deletion activity.
![read-notification](https://user-images.githubusercontent.com/51614993/205613483-1437b67a-0f06-4135-9158-79a35a1480c9.gif)
- Close mini notifications popup after clicking on a notification item.
- Fix hover actions over the tasks list; only perform hover actions when hovered over that particular list item, not outside the container.
![hover-wrapper-outside](https://user-images.githubusercontent.com/51614993/205613923-533aff57-d29c-4651-bd92-dd69ac6af878.gif)

