### PR TITLE
Display default contributors list on markdown editor

### DIFF
--- a/frontend/src/components/comments/commentInput.js
+++ b/frontend/src/components/comments/commentInput.js
@@ -80,19 +80,7 @@ export const CommentInputField = ({
         setComment(e.target.value);
       });
     }
-    // cleanup function
-    return () => {
-      mentionIcon.removeEventListener('mousedown', function (e) {
-        e.preventDefault();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        tribute.showMenuForCollection(textareaRef.current.textarea, 0);
-        // setComment((prev) => prev + e.target.value);
-      });
-      textareaRef.current.textarea.removeEventListener('tribute-replaced', (e) => {
-        setComment((prev) => prev + e.target.value);
-      });
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [textareaRef.current, contributors]);
 
   const handleImagePick = async (event) =>

--- a/frontend/src/components/comments/commentInput.js
+++ b/frontend/src/components/comments/commentInput.js
@@ -68,13 +68,30 @@ export const CommentInputField = ({
 
   useEffect(() => {
     // Make sure the type of contributors is not an array until the attachment happens
+    const mentionIcon = document.getElementById('tribute-trigger');
     if (textareaRef.current.textarea && !isBundle.current && Array.isArray(contributors)) {
       isBundle.current = true;
       tribute.attach(textareaRef.current.textarea);
+      mentionIcon.addEventListener('mousedown', function (e) {
+        e.preventDefault();
+        tribute.showMenuForCollection(textareaRef.current.textarea, 0);
+      });
       textareaRef.current.textarea.addEventListener('tribute-replaced', (e) => {
         setComment(e.target.value);
       });
     }
+    // cleanup function
+    return () => {
+      mentionIcon.removeEventListener('mousedown', function (e) {
+        e.preventDefault();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        tribute.showMenuForCollection(textareaRef.current.textarea, 0);
+        // setComment((prev) => prev + e.target.value);
+      });
+      textareaRef.current.textarea.removeEventListener('tribute-replaced', (e) => {
+        setComment((prev) => prev + e.target.value);
+      });
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [textareaRef.current, contributors]);
 

--- a/frontend/src/components/comments/editorIconConfig.js
+++ b/frontend/src/components/comments/editorIconConfig.js
@@ -96,13 +96,11 @@ export const iconConfig = {
       </svg>
     ),
     execute: (state, api) => {
-      const newSelectionRange = selectWord({ text: state.text, selection: state.selection });
-      const state1 = api.setSelectionRange(newSelectionRange);
-      const state2 = api.replaceSelection(`@${state1.selectedText}`);
-      api.setSelectionRange({
-        start: state2.selection.end - state1.selectedText.length,
-        end: state2.selection.end,
-      });
+      let modifyText = `@${state.selectedText}\n`;
+      if (!state.selectedText) {
+        modifyText = `@`;
+      }
+      api.replaceSelection(modifyText);
     },
   },
   upload: {

--- a/frontend/src/components/comments/editorIconConfig.js
+++ b/frontend/src/components/comments/editorIconConfig.js
@@ -79,7 +79,7 @@ export const iconConfig = {
     name: 'mention',
     keyCommand: 'mention',
     value: '@',
-    buttonProps: { 'aria-label': 'Mention user', title: 'Mention user' },
+    buttonProps: { 'aria-label': 'Mention user', title: 'Mention user', id: 'tribute-trigger' },
     icon: (
       <svg
         width={ICON_SIZE}


### PR DESCRIPTION
- Related to  #5390; Show default list when @ button is clicked on the toolbar


_Progress_:
The current solution is adapted from the [library's example](https://github.com/zurb/tribute/blob/252ec344a75b624268aef1cdbf80afc30b3cbe2b/example/index.html#L295) on how to trigger the mention functionality. Still getting inconsistent displays of the tribute menu when @ icon is clicked vs typed in. 