### PR TITLE
Display priority boxes for all priority options

### DIFF
--- a/frontend/src/components/projectCard/priorityBox.js
+++ b/frontend/src/components/projectCard/priorityBox.js
@@ -4,30 +4,25 @@ import { FormattedMessage } from 'react-intl';
 import messages from './messages';
 import { ClockIcon } from '../svgIcons';
 
-export function PriorityBox({ priority, extraClasses, hideMediumAndLow, showIcon }: Object) {
-  // hideMediumAndLow option will make the priority not be rendered if it's MEDIUM or LOW
+export function PriorityBox({ priority, extraClasses, showIcon }: Object) {
   let color = 'blue-grey b--blue-grey';
   if (priority === 'URGENT') color = 'red b--red';
   if (priority === 'HIGH') color = 'orange b--orange';
 
-  if (!hideMediumAndLow || ['URGENT', 'HIGH'].includes(priority)) {
-    return (
-      <FormattedMessage {...messages[`priorityDescription${priority}`]}>
-        {(msg) => (
-          <div className={`tc br1 f8 ttu ba ${color} ${extraClasses}`} title={msg}>
-            {showIcon && <ClockIcon className={`${color} v-mid mr1`} style={{ height: '13px' }} />}
-            {priority ? (
-              <span className="v-mid fw5">
-                <FormattedMessage {...messages[`projectPriority${priority}`]} />
-              </span>
-            ) : (
-              ''
-            )}
-          </div>
-        )}
-      </FormattedMessage>
-    );
-  } else {
-    return <></>;
-  }
+  return (
+    <FormattedMessage {...messages[`priorityDescription${priority}`]}>
+      {(msg) => (
+        <div className={`tc br1 f8 ttu ba ${color} ${extraClasses}`} title={msg}>
+          {showIcon && <ClockIcon className={`${color} v-mid mr1`} style={{ height: '13px' }} />}
+          {priority ? (
+            <span className="v-mid fw5">
+              <FormattedMessage {...messages[`projectPriority${priority}`]} />
+            </span>
+          ) : (
+            ''
+          )}
+        </div>
+      )}
+    </FormattedMessage>
+  );
 }

--- a/frontend/src/components/projectCard/projectCard.js
+++ b/frontend/src/components/projectCard/projectCard.js
@@ -111,8 +111,7 @@ export function ProjectCard({
                   <PriorityBox
                     priority={priority}
                     extraClasses={'pv1 ph2 dib'}
-                    hideMediumAndLow={!showBottomButtons}
-                    showIcon={priority !== 'URGENT'} // inside the cards, don't show the icon for urgent, due to the space required
+                    showIcon={!['URGENT', 'MEDIUM'].includes(priority)} // inside the cards, don't show the icon for urgent or medium, due to the space required
                   />
                 )}
               </div>

--- a/frontend/src/components/projectDetail/header.js
+++ b/frontend/src/components/projectDetail/header.js
@@ -34,7 +34,6 @@ export function HeaderLine({ author, projectId, priority, showEditLink, organisa
             <PriorityBox
               priority={priority}
               extraClasses={'pv2 ph3 mh1 mv1'}
-              hideMediumAndLow
               showIcon
             />
           </div>

--- a/frontend/src/components/projectDetail/tests/header.test.js
+++ b/frontend/src/components/projectDetail/tests/header.test.js
@@ -34,7 +34,7 @@ describe('test if HeaderLine component', () => {
     expect(screen.getByText('#1').closest('a').href).toContain('projects/1');
     expect(screen.getByText('| HOT')).toBeInTheDocument();
     expect(screen.queryByText('Edit project')).not.toBeInTheDocument();
-    expect(screen.queryByText('Low')).not.toBeInTheDocument();
+    expect(screen.queryByText('Low')).toBeInTheDocument();
   });
 });
 
@@ -109,7 +109,7 @@ describe('test if ProjectHeader component', () => {
     expect(screen.getByText('#1').closest('a').href).toContain('projects/1');
     expect(screen.getByText('| HOT')).toBeInTheDocument();
     expect(screen.queryByText('Edit project')).not.toBeInTheDocument();
-    expect(screen.queryByText('Low')).not.toBeInTheDocument(); //LOW priority tag should not be displayed
+    expect(screen.queryByText('Low')).toBeInTheDocument();
     expect(screen.queryByText('Draft')).toBeInTheDocument();
     expect(screen.getByText('La Paz Buildings')).toBeInTheDocument();
     expect(screen.getByText('La Paz Buildings').closest('h3').lang).toBe('en');

--- a/frontend/src/components/projects/list.js
+++ b/frontend/src/components/projects/list.js
@@ -69,8 +69,7 @@ export function ProjectListItem({ project }: Object) {
               <PriorityBox
                 priority={project.priority}
                 extraClasses={'pv1 ph2 dib'}
-                hideMediumAndLow={false}
-                showIcon={project.priority !== 'URGENT'} // inside the cards, don't show the icon for urgent, due to the space required
+                showIcon={!['URGENT', 'MEDIUM'].includes(project.priority)} // inside the cards, don't show the icon for urgent or medium, due to the space required
               />
             )}
           </div>


### PR DESCRIPTION
Closes #5455 

Remove hideMediumAndLow props from the PriorityBox component to eliminate the conditional not to display priority boxes for medium and low-priority projects. Also, hide the clock icon for medium-priority projects along with urgent ones.