### PR TITLE
Resolve console warnings on the landing page

### DIFF
--- a/frontend/src/components/banner/TopBanner.js
+++ b/frontend/src/components/banner/TopBanner.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { useFetch } from '../../hooks/UseFetch';
+import { useFetchWithAbort } from '../../hooks/UseFetch';
 import { htmlFromMarkdown } from '../../utils/htmlFromMarkdown';
 import './styles.scss';
 
 function TopBanner() {
-  const [, error, data] = useFetch(`system/banner/`);
+  const [, error, data] = useFetchWithAbort(`system/banner/`);
 
   return (
     <>

--- a/frontend/src/components/dropdown.js
+++ b/frontend/src/components/dropdown.js
@@ -175,7 +175,7 @@ export class _Dropdown extends React.PureComponent {
           onClick={this.toggleDropdown}
           className={`blue-dark ${this.props.className || ''}`}
         >
-          <p className="lh-title dib ma0 f6">{this.getActiveOrDisplay()}</p>
+          <div className="lh-title dib ma0 f6">{this.getActiveOrDisplay()}</div>
           <ChevronDownIcon style={{ width: '11px', height: '11px' }} className="pl3 v-mid pr1" />
         </CustomButton>
         {this.state.display && (

--- a/frontend/src/components/header/notificationBell.js
+++ b/frontend/src/components/header/notificationBell.js
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { TopNavLink } from './NavLink';
 import { BellIcon } from '../svgIcons';
 import { NotificationPopout } from '../../views/notifications';
-import { useFetch, useFetchIntervaled } from '../../hooks/UseFetch';
+import { useFetchWithAbort, useFetchIntervaled } from '../../hooks/UseFetch';
 import { useOnClickOutside } from '../../hooks/UseOnClickOutside';
 import useForceUpdate from '../../hooks/UseForceUpdate';
 import { useInboxQueryAPI } from '../../hooks/UseInboxQueryAPI';
@@ -27,7 +27,7 @@ export const NotificationBell = (props) => {
 
   const [isPopoutFocus, setPopoutFocus] = useState(false);
   const [unreadNotifications, setUnreadNotifications] = useState(false);
-  const [initialUnreadCountError, initialUnreadCountLoading, initialUnreadCount] = useFetch(
+  const [initialUnreadCountError, initialUnreadCountLoading, initialUnreadCount] = useFetchWithAbort(
     '/api/v2/notifications/queries/own/count-unread/',
     trigger,
   );

--- a/frontend/src/components/homepage/stats.js
+++ b/frontend/src/components/homepage/stats.js
@@ -37,23 +37,27 @@ export const StatsSection = () => {
   /* eslint-disable-next-line */
   const [tmStatsError, tmStatsLoading, tmStats] = useFetch('system/statistics/');
   const [stats, setStats] = useState({ edits: 0, buildings: 0, roads: 0 });
-  const url = HOMEPAGE_STATS_API_URL;
-  const getStats = async (url) => {
-    try {
-      const response = await axios.get(url);
-      setStats({
-        edits: response.data.edits,
-        buildings: response.data.building_count_add,
-        roads: response.data.road_km_add,
-      });
-    } catch (error) {
-      console.error(error);
-    }
-  };
 
   useEffect(() => {
-    getStats(url);
-  }, [url]);
+    // Using axios over the useFetch hook for external API endpoint
+    const abortController = new AbortController();
+    axios
+      .get(HOMEPAGE_STATS_API_URL, {
+        signal: abortController.signal,
+      })
+      .then((res) => {
+        const { edits, building_count_add: buildings, road_km_add: roads } = res.data;
+        setStats({
+          edits,
+          buildings,
+          roads,
+        });
+      })
+      .catch((err) => console.error(err));
+    return () => {
+      abortController.abort();
+    };
+  }, []);
 
   return (
     <div className="pt5 pb2 ph6-l ph4 flex justify-around flex-wrap flex-nowrap-ns stats-container">

--- a/frontend/src/components/homepage/stats.js
+++ b/frontend/src/components/homepage/stats.js
@@ -5,7 +5,7 @@ import shortNumber from 'short-number';
 
 import messages from './messages';
 import { HOMEPAGE_STATS_API_URL } from '../../config';
-import { useFetch } from '../../hooks/UseFetch';
+import { useFetchWithAbort } from '../../hooks/UseFetch';
 
 export const StatsNumber = (props) => {
   const value = shortNumber(props.value);
@@ -35,7 +35,7 @@ export const StatsColumn = ({ label, value }: Object) => {
 
 export const StatsSection = () => {
   /* eslint-disable-next-line */
-  const [tmStatsError, tmStatsLoading, tmStats] = useFetch('system/statistics/');
+  const [_tmStatsError, _tmStatsLoading, tmStats] = useFetchWithAbort('system/statistics/');
   const [stats, setStats] = useState({ edits: 0, buildings: 0, roads: 0 });
 
   useEffect(() => {

--- a/frontend/src/components/homepage/testimonials.js
+++ b/frontend/src/components/homepage/testimonials.js
@@ -27,7 +27,7 @@ export function Testimonials() {
         // </div>
       }
       {testimonials.map((person, n) => (
-        <div className="testimony relative">
+        <div className="testimony relative" key={person.name}>
           {/* <div key={n} className={`blue-dark testimonial-${person.cssCode} relative`} /> */}
           <div className="testimonial-image-parent">
             <img
@@ -39,7 +39,7 @@ export function Testimonials() {
           <div className="citation-ctr">
             <p className="bg-red white pv2 pl3 pr1 citation ma0 relative">
               <FormattedMessage {...person.citation} />
-              <p className="quotes-icon red ma0">&ldquo;</p>
+              <span className="quotes-icon red ma0">&ldquo;</span>
             </p>
             <div className="w-70-l w-50-m mh3 mh0-ns">
               <h4 className="f5 fw7 mb1 tl-m witness">{person.name},</h4>

--- a/frontend/src/network/genericJSONRequest.js
+++ b/frontend/src/network/genericJSONRequest.js
@@ -33,6 +33,32 @@ export function fetchLocalJSONAPI(endpoint, token, method = 'GET', language = 'e
     });
 }
 
+export function fetchLocalJSONAPIWithAbort(
+  endpoint,
+  token,
+  signal,
+  method = 'GET',
+  language = 'en',
+) {
+  const url = new URL(endpoint, API_URL);
+  let headers = {
+    'Content-Type': 'application/json',
+    'Accept-Language': language.replace('-', '_'),
+  };
+  if (token) {
+    headers['Authorization'] = `Token ${token}`;
+  }
+  return fetch(url, {
+    method: method,
+    headers: headers,
+    signal: signal,
+  })
+    .then(handleErrors)
+    .then((res) => {
+      return res.json();
+    });
+}
+
 export function pushToLocalJSONAPI(
   endpoint,
   payload,


### PR DESCRIPTION
This PR does the following things:

- Adds a `useFetchWithAbort` hook and replaces the `useFetch` hook with the same to abort to cancel ongoing network requests on unmounted components
- Resolves `X cannot appear as a descendant of Y` by using the proper HTML tag for ascendants