### PR TITLE
Circleci update resource class and limit cache for frontend deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,82 +3,84 @@ jobs:
   build:
     working_directory: /home/circleci/app
     docker:
-    - image: cimg/python:3.7.14-node
-      environment:
-        SQLALCHEMY_DATABASE_URI: postgresql://taskingmanager@localhost/test_tm
-    - image: cimg/postgres:14.2-postgis
-      environment:
-        POSTGRES_USER: taskingmanager
-        POSTGRES_DB: test_tm
+      - image: cimg/python:3.7.14-node
+        environment:
+          SQLALCHEMY_DATABASE_URI: postgresql://taskingmanager@localhost/test_tm
+      - image: cimg/postgres:14.2-postgis
+        environment:
+          POSTGRES_USER: taskingmanager
+          POSTGRES_DB: test_tm
     steps:
-    - checkout
-    - setup_remote_docker
-    - run:
-        name: Install modules
-        command: |
-          sudo apt-get update
-          sudo apt-get install -y libgeos-dev # Required for shapely
-          sudo yarn global add @mapbox/cfn-config @mapbox/cloudfriend
-          pip install awscli --upgrade
-    - run:
-        name: Configure Postgresql Test database
-        command: |
-          sudo apt-get install postgresql-client
-          psql -h localhost -U $POSTGRES_USER test_$POSTGRES_DB -c "CREATE EXTENSION postgis;"
-    - run:
-        name: Set folder permissions
-        command: |
-          chown -R circleci:circleci ${CIRCLE_WORKING_DIRECTORY}
-          chmod -R 755 ${CIRCLE_WORKING_DIRECTORY}
-    - restore_cache:
-        keys:
-        - node-v1-{{ .Branch }}-{{ checksum "frontend/yarn.lock" }}
-        - node-v1-{{ .Branch }}-
-        - node-v1-
-    - run:
-        name: Install requirements
-        command: |
-          # Install NPM packages and build frontend
-          cd ${CIRCLE_WORKING_DIRECTORY}/frontend
-          yarn
-          cd ${CIRCLE_WORKING_DIRECTORY}
-          # Install Python dependencies
-          pip install --upgrade pip
-          pip install -r requirements.txt
-    - run:
-        name: Run backend code checks
-        command: |
-          cd ${CIRCLE_WORKING_DIRECTORY}
-          mkdir ${CIRCLE_WORKING_DIRECTORY}/tests/backend/lint
-          black --check manage.py backend tests migrations
-          flake8 manage.py backend tests migrations
-    - run:
-        name: Run frontend tests
-        command: |
-          # JS Unit Tests
-          cd ${CIRCLE_WORKING_DIRECTORY}/frontend
-          CI=true yarn test -w 1
-          CI=true GENERATE_SOURCEMAP=false yarn build
-    - run:
-        name: Run backend tests
-        command: |
-          # Run Python tests
-          cd ${CIRCLE_WORKING_DIRECTORY}
-          mkdir ${CIRCLE_WORKING_DIRECTORY}/tests/backend/results
-          find ./tests/backend -name "test*.py" -exec chmod -x {} \;
-          nosetests ./tests/backend --with-xunit \
-            --xunit-file ${CIRCLE_WORKING_DIRECTORY}/tests/backend/results/unitresults.xml \
-            --with-coverage --cover-erase --cover-package=./backend
-          coverage xml -o ${CIRCLE_WORKING_DIRECTORY}/tests/backend/results/coverage.xml
-    - store_test_results:
-        path: tests/backend/results
-    - store_artifacts:
-        path: tests/backend/results
-    - save_cache:
-        key: node-v1-{{ .Branch }}-{{ checksum "frontend/yarn.lock" }}
-        paths:
-        - frontend/node_modules
-        - env
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Install modules
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y libgeos-dev # Required for shapely
+            sudo yarn global add @mapbox/cfn-config @mapbox/cloudfriend
+            pip install awscli --upgrade
+      - run:
+          name: Configure Postgresql Test database
+          command: |
+            sudo apt-get install postgresql-client
+            psql -h localhost -U $POSTGRES_USER test_$POSTGRES_DB -c "CREATE EXTENSION postgis;"
+      - run:
+          name: Set folder permissions
+          command: |
+            chown -R circleci:circleci ${CIRCLE_WORKING_DIRECTORY}
+            chmod -R 755 ${CIRCLE_WORKING_DIRECTORY}
+      - restore_cache:
+          keys:
+            - node-v1-{{ .Branch }}-{{ checksum "frontend/yarn.lock" }}
+            - node-v1-{{ .Branch }}-
+            - node-v1-
+      - run:
+          name: Install requirements
+          command: |
+            # Install NPM packages and build frontend
+            cd ${CIRCLE_WORKING_DIRECTORY}/frontend
+            yarn
+            cd ${CIRCLE_WORKING_DIRECTORY}
+            # Install Python dependencies
+            pip install --upgrade pip
+            pip install -r requirements.txt
+      - run:
+          name: Run backend code checks
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}
+            mkdir ${CIRCLE_WORKING_DIRECTORY}/tests/backend/lint
+            black --check manage.py backend tests migrations
+            flake8 manage.py backend tests migrations
+      - run:
+          name: Run frontend tests
+          command: |
+            # JS Unit Tests
+            cd ${CIRCLE_WORKING_DIRECTORY}/frontend
+            CI=true yarn test -w 1
+            CI=true GENERATE_SOURCEMAP=false yarn build
+      - run:
+          name: Run backend tests
+          command: |
+            # Run Python tests
+            cd ${CIRCLE_WORKING_DIRECTORY}
+            mkdir ${CIRCLE_WORKING_DIRECTORY}/tests/backend/results
+            find ./tests/backend -name "test*.py" -exec chmod -x {} \;
+            nosetests ./tests/backend --with-xunit \
+              --xunit-file ${CIRCLE_WORKING_DIRECTORY}/tests/backend/results/unitresults.xml \
+              --with-coverage --cover-erase --cover-package=./backend
+            coverage xml -o ${CIRCLE_WORKING_DIRECTORY}/tests/backend/results/coverage.xml
+      - store_test_results:
+          path: tests/backend/results
+      - store_artifacts:
+          path: tests/backend/results
+      - save_cache:
+          key: node-v1-{{ .Branch }}-{{ checksum "frontend/yarn.lock" }}
+          paths:
+            - frontend/node_modules
+            - env
+    # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
+    resource_class: large
   backend_deploy:
     parameters:
       stack_name:
@@ -89,261 +91,261 @@ jobs:
         type: string
     working_directory: /home/circleci/tasking-manager
     docker:
-    - image: cimg/python:3.7.14-node
+      - image: cimg/python:3.7.14-node
     steps:
-    - checkout
-    - setup_remote_docker
-    - run:
-        name: Install modules
-        command: |
-          sudo apt-get update
-          sudo apt-get install -y libgeos-dev jq # Required for shapely
-          sudo yarn global add @mapbox/cfn-config @mapbox/cloudfriend
-          pip install awscli --upgrade
-    - run:
-        name: Configure AWS Access Key ID
-        command: |
-          aws configure set aws_access_key_id \
-          $AWS_ACCESS_KEY_ID \
-          --profile default
-    - run:
-        name: Configure AWS Secret Access Key
-        command: |
-          aws configure set aws_secret_access_key \
-          $AWS_SECRET_ACCESS_KEY \
-          --profile default
-    - run:
-        name: Configure AWS default region
-        command: |
-          aws configure set region $AWS_REGION \
-          --profile default
-    - run:
-        name: Get RDS Instance ID
-        command: |
-          chmod +x .circleci/rdsid.sh
-          RDS_ID=$(./.circleci/rdsid.sh '{"aws:cloudformation:stack-name": "tasking-manager-<< parameters.stack_name >>"}')
-          echo "export RDS_ID=$RDS_ID" >> $BASH_ENV
-    - run:
-        name: Remove last snapshot and backup database
-        no_output_timeout: 15m
-        command: |
-          DESCRIBE_SNAPSHOT=$(aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest --db-instance-identifier $RDS_ID --output text)
-          NONCE=$(openssl rand -hex 4)
-          echo "export NONCE=$NONCE" >> $BASH_ENV
-          # Copy old snapshot to temporary
-          if [ -z "$DESCRIBE_SNAPSHOT" ]
-          then
-              echo "Snapshot does not exist, creating one now."
-          else
-              aws rds copy-db-snapshot \
-                      --source-db-snapshot tm3-<< parameters.stack_name >>-${RDS_ID}-latest \
-                      --target-db-snapshot tm3-<< parameters.stack_name >>-${RDS_ID}-${NONCE}
-              aws rds delete-db-snapshot \
-                      --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-latest
-          fi
-          # create new aws rds snapshot
-          aws rds create-db-snapshot \
-                      --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-latest \
-                      --db-instance-identifier ${RDS_ID}
-          aws rds wait db-snapshot-completed \
-                      --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-latest \
-                      --db-instance-identifier ${RDS_ID}
-          if [[ $? -eq 255 ]]; then
-            echo "Production snapshot creation failed. Exiting with exit-code 125"
-            exit 125
-          fi
-    - run:
-        name: Download config file
-        command: |
-          export GITSHA=<< parameters.gitsha >>
-          aws s3 cp s3://hot-cfn-config/tasking-manager/tasking-manager-<< parameters.stack_name >>-${AWS_REGION}.cfn.json - | jq -c --arg GITSHA "$GITSHA" '.GitSha = $GITSHA' > $CIRCLE_WORKING_DIRECTORY/cfn-config-<< parameters.stack_name >>.json
-    - deploy:
-        name: Deploy to << parameters.stack_name >>
-        command: |
-          export NODE_PATH=/usr/local/share/.config/yarn/global/node_modules/
-          validate-template $CIRCLE_WORKING_DIRECTORY/scripts/aws/cloudformation/tasking-manager.template.js
-          export JSON_CONFIG="$(cat $CIRCLE_WORKING_DIRECTORY/cfn-config-<< parameters.stack_name >>.json)"
-          cfn-config update << parameters.stack_name >> $CIRCLE_WORKING_DIRECTORY/scripts/aws/cloudformation/tasking-manager.template.js -f -c hot-cfn-config -t hot-cfn-config -r $AWS_REGION -p "$JSON_CONFIG"
-    - run:
-        name: Cleanup
-        when: always
-        command: |
-          DESCRIBE_SNAPSHOT=$(aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-${NONCE} --db-instance-identifier ${RDS_ID} --output text)
-          # Copy old snapshot to temporary
-          if [ -z "$DESCRIBE_SNAPSHOT" ]
-          then
-            echo "temporary snapshot doesn't exist, nothing to cleanup."
-          else
-            aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-${NONCE}
-          fi
-          # Delete manual snapshot if database ID changed
-          RDS_ID_NEW=$(./.circleci/rdsid.sh '{"aws:cloudformation:stack-name": "tasking-manager-<< parameters.stack_name >>"}')
-          if [ "$RDS_ID" != "$RDS_ID_NEW" ]
-          then
-            aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-latest
-          fi
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Install modules
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y libgeos-dev jq # Required for shapely
+            sudo yarn global add @mapbox/cfn-config @mapbox/cloudfriend
+            pip install awscli --upgrade
+      - run:
+          name: Configure AWS Access Key ID
+          command: |
+            aws configure set aws_access_key_id \
+            $AWS_ACCESS_KEY_ID \
+            --profile default
+      - run:
+          name: Configure AWS Secret Access Key
+          command: |
+            aws configure set aws_secret_access_key \
+            $AWS_SECRET_ACCESS_KEY \
+            --profile default
+      - run:
+          name: Configure AWS default region
+          command: |
+            aws configure set region $AWS_REGION \
+            --profile default
+      - run:
+          name: Get RDS Instance ID
+          command: |
+            chmod +x .circleci/rdsid.sh
+            RDS_ID=$(./.circleci/rdsid.sh '{"aws:cloudformation:stack-name": "tasking-manager-<< parameters.stack_name >>"}')
+            echo "export RDS_ID=$RDS_ID" >> $BASH_ENV
+      - run:
+          name: Remove last snapshot and backup database
+          no_output_timeout: 15m
+          command: |
+            DESCRIBE_SNAPSHOT=$(aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-$RDS_ID-latest --db-instance-identifier $RDS_ID --output text)
+            NONCE=$(openssl rand -hex 4)
+            echo "export NONCE=$NONCE" >> $BASH_ENV
+            # Copy old snapshot to temporary
+            if [ -z "$DESCRIBE_SNAPSHOT" ]
+            then
+                echo "Snapshot does not exist, creating one now."
+            else
+                aws rds copy-db-snapshot \
+                        --source-db-snapshot tm3-<< parameters.stack_name >>-${RDS_ID}-latest \
+                        --target-db-snapshot tm3-<< parameters.stack_name >>-${RDS_ID}-${NONCE}
+                aws rds delete-db-snapshot \
+                        --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-latest
+            fi
+            # create new aws rds snapshot
+            aws rds create-db-snapshot \
+                        --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-latest \
+                        --db-instance-identifier ${RDS_ID}
+            aws rds wait db-snapshot-completed \
+                        --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-latest \
+                        --db-instance-identifier ${RDS_ID}
+            if [[ $? -eq 255 ]]; then
+              echo "Production snapshot creation failed. Exiting with exit-code 125"
+              exit 125
+            fi
+      - run:
+          name: Download config file
+          command: |
+            export GITSHA=<< parameters.gitsha >>
+            aws s3 cp s3://hot-cfn-config/tasking-manager/tasking-manager-<< parameters.stack_name >>-${AWS_REGION}.cfn.json - | jq -c --arg GITSHA "$GITSHA" '.GitSha = $GITSHA' > $CIRCLE_WORKING_DIRECTORY/cfn-config-<< parameters.stack_name >>.json
+      - deploy:
+          name: Deploy to << parameters.stack_name >>
+          command: |
+            export NODE_PATH=/usr/local/share/.config/yarn/global/node_modules/
+            validate-template $CIRCLE_WORKING_DIRECTORY/scripts/aws/cloudformation/tasking-manager.template.js
+            export JSON_CONFIG="$(cat $CIRCLE_WORKING_DIRECTORY/cfn-config-<< parameters.stack_name >>.json)"
+            cfn-config update << parameters.stack_name >> $CIRCLE_WORKING_DIRECTORY/scripts/aws/cloudformation/tasking-manager.template.js -f -c hot-cfn-config -t hot-cfn-config -r $AWS_REGION -p "$JSON_CONFIG"
+      - run:
+          name: Cleanup
+          when: always
+          command: |
+            DESCRIBE_SNAPSHOT=$(aws rds describe-db-snapshots --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-${NONCE} --db-instance-identifier ${RDS_ID} --output text)
+            # Copy old snapshot to temporary
+            if [ -z "$DESCRIBE_SNAPSHOT" ]
+            then
+              echo "temporary snapshot doesn't exist, nothing to cleanup."
+            else
+              aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-${NONCE}
+            fi
+            # Delete manual snapshot if database ID changed
+            RDS_ID_NEW=$(./.circleci/rdsid.sh '{"aws:cloudformation:stack-name": "tasking-manager-<< parameters.stack_name >>"}')
+            if [ "$RDS_ID" != "$RDS_ID_NEW" ]
+            then
+              aws rds delete-db-snapshot --db-snapshot-identifier tm3-<< parameters.stack_name >>-${RDS_ID}-latest
+            fi
   frontend_deploy:
     working_directory: /home/circleci/tasking-manager
     docker:
-    - image: cimg/python:3.7.14-node
+      - image: cimg/python:3.7.14-node
     parameters:
       stack_name:
         description: "the name of the stack for cfn-config"
         type: string
     steps:
-    - checkout
-    - setup_remote_docker
-    - run:
-        name: Install modules
-        command: |
-          pip install awscli --upgrade
-    - run:
-        name: Configure AWS Access Key ID
-        command: |
-          aws configure set aws_access_key_id \
-          $AWS_ACCESS_KEY_ID \
-          --profile default
-    - run:
-        name: Configure AWS Secret Access Key
-        command: |
-          aws configure set aws_secret_access_key \
-          $AWS_SECRET_ACCESS_KEY \
-          --profile default
-    - run:
-        name: Configure AWS default region
-        command: |
-          aws configure set region $AWS_REGION \
-          --profile default
-    - run:
-        name: Deploy Frontend to S3
-        command: |
-          cd ${CIRCLE_WORKING_DIRECTORY}/frontend/
-          export TM_ENVIRONMENT=<< parameters.stack_name >>
-          yarn
-          CI=true GENERATE_SOURCEMAP=false yarn build
-          aws s3 sync build/ s3://tasking-manager-<< parameters.stack_name >>-react-app --delete --cache-control max-age=31536000
-          aws s3 cp s3://tasking-manager-<< parameters.stack_name >>-react-app s3://tasking-manager-<< parameters.stack_name >>-react-app --recursive --exclude "*" --include "*.html" --metadata-directive REPLACE --cache-control no-cache --content-type text/html
-          export DISTRIBUTION_ID=`aws cloudformation list-exports --output=text --query "Exports[?Name=='tasking-manager-<< parameters.stack_name >>-cloudfront-id-${AWS_REGION}'].Value"`
-          aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths "/*"
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Install modules
+          command: |
+            pip install awscli --upgrade
+      - run:
+          name: Configure AWS Access Key ID
+          command: |
+            aws configure set aws_access_key_id \
+            $AWS_ACCESS_KEY_ID \
+            --profile default
+      - run:
+          name: Configure AWS Secret Access Key
+          command: |
+            aws configure set aws_secret_access_key \
+            $AWS_SECRET_ACCESS_KEY \
+            --profile default
+      - run:
+          name: Configure AWS default region
+          command: |
+            aws configure set region $AWS_REGION \
+            --profile default
+      - run:
+          name: Deploy Frontend to S3
+          command: |
+            cd ${CIRCLE_WORKING_DIRECTORY}/frontend/
+            export TM_ENVIRONMENT=<< parameters.stack_name >>
+            yarn
+            CI=true GENERATE_SOURCEMAP=false yarn build
+            aws s3 sync build/ s3://tasking-manager-<< parameters.stack_name >>-react-app --delete --cache-control max-age=31536000
+            aws s3 cp s3://tasking-manager-<< parameters.stack_name >>-react-app s3://tasking-manager-<< parameters.stack_name >>-react-app --recursive --exclude "*" --include "*.html" --metadata-directive REPLACE --cache-control no-cache --content-type text/html
+            export DISTRIBUTION_ID=`aws cloudformation list-exports --output=text --query "Exports[?Name=='tasking-manager-<< parameters.stack_name >>-cloudfront-id-${AWS_REGION}'].Value"`
+            aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths "/*"
 workflows:
   version: 2
   build-deploy:
     jobs:
-    - build:
-        context: tasking-manager-testing
-        filters:
-          branches:
-            ignore:
-            - /^deployment\/.*/
-    - backend_deploy:
-        name: backend-staging
-        filters:
-          branches:
-            only:
-            - develop
-            - staging-test
-        requires:
-          - build
-        stack_name: "staging"
-        gitsha: $CIRCLE_SHA1
-        context: tasking-manager-staging
-    - frontend_deploy:
-        name: frontend-staging
-        filters:
-          branches:
-            only:
-            - develop
-            - staging-test
-        requires:
-          - build
-        context: tasking-manager-staging
-        stack_name: "staging"
+      - build:
+          context: tasking-manager-testing
+          filters:
+            branches:
+              ignore:
+                - /^deployment\/.*/
+      - backend_deploy:
+          name: backend-staging
+          filters:
+            branches:
+              only:
+                - develop
+                - staging-test
+          requires:
+            - build
+          stack_name: "staging"
+          gitsha: $CIRCLE_SHA1
+          context: tasking-manager-staging
+      - frontend_deploy:
+          name: frontend-staging
+          filters:
+            branches:
+              only:
+                - develop
+                - staging-test
+          requires:
+            - build
+          context: tasking-manager-staging
+          stack_name: "staging"
 
-    - backend_deploy:
-        name: test
-        filters:
-          branches:
-            only:
-            - fix/cfn-init-codedeploy
-        requires:
-          - build
-        stack_name: "test"
-        gitsha: $CIRCLE_SHA1
-        context: tasking-manager-staging
-    - frontend_deploy:
-        name: test
-        filters:
-          branches:
-            only:
-            - fix/cfn-init-codedeploy
-        requires:
-          - build
-        context: tasking-manager-staging
-        stack_name: "test"
-    - backend_deploy:
-        name: teachosm
-        filters:
-          branches:
-            only:
-              - deployment/teachosm-tasking-manager
-        requires:
-          - build
-        stack_name: "teachosm"
-        gitsha: $CIRCLE_SHA1
-        context: tasking-manager-teachosm
-    - frontend_deploy:
-        name: teachosm
-        filters:
-          branches:
-            only:
-              - deployment/teachosm-tasking-manager
-        requires:
-          - build
-        context: tasking-manager-teachosm
-        stack_name: "teachosm"
-    - backend_deploy:
-        name: assisted
-        filters:
-          branches:
-            only:
-              - deployment/assisted-tasking-manager
-        requires:
-          - build
-        stack_name: "assisted"
-        gitsha: $CIRCLE_SHA1
-        context: tasking-manager-assisted
-    - frontend_deploy:
-        name: assisted
-        filters:
-          branches:
-            only:
-              - deployment/assisted-tasking-manager
-        requires:
-          - build
-        stack_name: "assisted"
-        context: tasking-manager-assisted
+      - backend_deploy:
+          name: test
+          filters:
+            branches:
+              only:
+                - fix/cfn-init-codedeploy
+          requires:
+            - build
+          stack_name: "test"
+          gitsha: $CIRCLE_SHA1
+          context: tasking-manager-staging
+      - frontend_deploy:
+          name: test
+          filters:
+            branches:
+              only:
+                - fix/cfn-init-codedeploy
+          requires:
+            - build
+          context: tasking-manager-staging
+          stack_name: "test"
+      - backend_deploy:
+          name: teachosm
+          filters:
+            branches:
+              only:
+                - deployment/teachosm-tasking-manager
+          requires:
+            - build
+          stack_name: "teachosm"
+          gitsha: $CIRCLE_SHA1
+          context: tasking-manager-teachosm
+      - frontend_deploy:
+          name: teachosm
+          filters:
+            branches:
+              only:
+                - deployment/teachosm-tasking-manager
+          requires:
+            - build
+          context: tasking-manager-teachosm
+          stack_name: "teachosm"
+      - backend_deploy:
+          name: assisted
+          filters:
+            branches:
+              only:
+                - deployment/assisted-tasking-manager
+          requires:
+            - build
+          stack_name: "assisted"
+          gitsha: $CIRCLE_SHA1
+          context: tasking-manager-assisted
+      - frontend_deploy:
+          name: assisted
+          filters:
+            branches:
+              only:
+                - deployment/assisted-tasking-manager
+          requires:
+            - build
+          stack_name: "assisted"
+          context: tasking-manager-assisted
   backend-production:
     jobs:
-    - backend_deploy:
-        name: backend-production
-        filters:
-          branches:
-            only:
-              - deployment/hot-tasking-manager
-        stack_name: "tm4-production"
-        gitsha: $CIRCLE_SHA1
-        context: tasking-manager-tm4-production
+      - backend_deploy:
+          name: backend-production
+          filters:
+            branches:
+              only:
+                - deployment/hot-tasking-manager
+          stack_name: "tm4-production"
+          gitsha: $CIRCLE_SHA1
+          context: tasking-manager-tm4-production
   frontend-production:
     jobs:
-    - frontend_deploy:
-        name: frontend-production
-        filters:
-          branches:
-            only:
-              - deployment/hot-tasking-manager-frontend
-              - deployment/hot-tasking-manager
-        stack_name: "tm4-production"
-        context: tasking-manager-tm4-production
+      - frontend_deploy:
+          name: frontend-production
+          filters:
+            branches:
+              only:
+                - deployment/hot-tasking-manager-frontend
+                - deployment/hot-tasking-manager
+          stack_name: "tm4-production"
+          context: tasking-manager-tm4-production
 notify:
   webhooks:
     - url: https://api.opsgenie.com/v1/json/circleci?apiKey=$OPSGENIE_API

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ jobs:
         description: "The 40 char hash of the git commit"
         type: string
     working_directory: /home/circleci/tasking-manager
+    resource_class: medium
     docker:
       - image: cimg/python:3.7.14-node
     steps:
@@ -186,6 +187,7 @@ jobs:
             fi
   frontend_deploy:
     working_directory: /home/circleci/tasking-manager
+    resource_class: large
     docker:
       - image: cimg/python:3.7.14-node
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs:
           keys:
             - node-v1-{{ .Branch }}-{{ checksum "frontend/yarn.lock" }}
             - node-v1-{{ .Branch }}-
-            - node-v1-
       - run:
           name: Install requirements
           command: |


### PR DESCRIPTION
Two separate issues were preventing CircleCI builds from running properly. 
1. The CI container was running out of memory. To resolve, we increased the resource class for the container (4 -> 8 GB memory) 
2. The node-modules folder was being cached from a hotfix branch that didn't have the proper updates. We were too liberal in the caching rules, so we removed one of the keys for checking whether the pull from the cache. 