### PR TITLE
Add test cases for teams section under the management area

### DIFF
--- a/frontend/src/components/teamsAndOrgs/members.js
+++ b/frontend/src/components/teamsAndOrgs/members.js
@@ -107,9 +107,9 @@ export function Members({
           )}
         </div>
         <div className="cf db mt3">
-          {members.map((user, n) => (
+          {members.map((user) => (
             <UserAvatar
-              key={n}
+              key={user.username}
               username={user.username}
               picture={user.pictureUrl}
               size="large"
@@ -178,9 +178,9 @@ export function JoinRequests({
   const [isChecked, setIsChecked] = useState(false);
 
   useEffect(() => {
-    const isJoinRequestEnabled = managers.filter(
+    const isJoinRequestEnabled = managers.find(
       (manager) => manager.username === loggedInUsername,
-    )[0]?.joinRequestNotifications;
+    )?.joinRequestNotifications;
     setIsChecked(isJoinRequestEnabled);
   }, [loggedInUsername, managers]);
 
@@ -235,8 +235,8 @@ export function JoinRequests({
         </div>
       )}
       <div className="cf db mt3">
-        {requests.map((user, n) => (
-          <div className="cf db pt2" key={n}>
+        {requests.map((user) => (
+          <div className="cf db pt2" key={user.username}>
             <div className="fl pt1">
               <UserAvatar
                 username={user.username}

--- a/frontend/src/components/teamsAndOrgs/teams.js
+++ b/frontend/src/components/teamsAndOrgs/teams.js
@@ -193,7 +193,7 @@ export function TeamInformation(props) {
           <FormattedMessage {...messages.joinMethod} />
         </label>
         {Object.keys(joinMethods).map((method) => (
-          <div className="pv2">
+          <div className="pv2" key={method}>
             <RadioField name="joinMethod" value={method} required />
             <span className="f5">
               <FormattedMessage {...messages[joinMethods[method]]} />

--- a/frontend/src/components/user/avatar.js
+++ b/frontend/src/components/user/avatar.js
@@ -78,6 +78,7 @@ const Avatar = ({ username, size, colorClasses, removeFn, picture, text, editMod
     >
       {removeFn && editMode && (
         <div
+          role="button"
           className="relative top-0 z-1 fr br-100 f7 tc h1 w1 bg-red white pointer"
           style={closeIconStyle}
           onClick={() => removeFn(username)}

--- a/frontend/src/network/tests/mockData/teams.js
+++ b/frontend/src/network/tests/mockData/teams.js
@@ -1,0 +1,60 @@
+export const teams = {
+  teams: [
+    {
+      teamId: 1,
+      organisationId: 123,
+      // redundant keys above and below for responses in teams list and team detail
+      organisation_id: 123,
+      organisation: 'Organisation Name 123',
+      name: 'Team Test',
+      logo: 'https://cdn.hotosm.org/tasking-manager/uploads/1588662877801_hot-logo-png.png',
+      description: 'Dummy team test',
+      joinMethod: 'BY_INVITE',
+      visibility: 'PRIVATE',
+      members: [
+        {
+          username: 'sample_user',
+          function: 'MANAGER',
+          active: true,
+          joinRequestNotifications: false,
+          pictureUrl:
+            'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBK0FQQWc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--b385b3fad59b07a040393279c91dbc88c5f8cdf7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2RkhKbGMybDZaVjkwYjE5c2FXMXBkRnNIYVdscGFRPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--1d22b8d446683a272d1a9ff04340453ca7c374b4/14421645307_6e09d2d02a_o.jpg',
+        },
+      ],
+    },
+    {
+      teamId: 4,
+      organisationId: 6,
+      organisation: 'KLL',
+      name: 'Test KLL Team',
+      logo: 'https://cdn.hotosm.org/tasking-manager/uploads/1652896455106_main-logo.png',
+      description: null,
+      joinMethod: 'BY_REQUEST',
+      visibility: 'PUBLIC',
+      members: [
+        {
+          username: 'helnershingthapa',
+          function: 'MEMBER',
+          active: true,
+          joinRequestNotifications: false,
+          pictureUrl:
+            'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXQ2Q3c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fe41f1b2a5d6cf492a7133f15c81f105dec06ff7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBPZ2h3Ym1jNkZISmxjMmw2WlY5MGIxOXNhVzFwZEZzSGFXbHBhUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--058ac785867b32287d598a314311e2253bd879a3/unnamed.webp',
+        },
+      ],
+    },
+  ],
+};
+
+export const team = teams.teams[0];
+
+export const teamCreationSuccess = {
+  teamId: 123,
+};
+
+export const teamUpdationSuccess = {
+  Status: 'Updated',
+};
+
+export const teamDeletionSuccess = {
+  Success: 'Team deleted',
+};

--- a/frontend/src/network/tests/server-handlers.js
+++ b/frontend/src/network/tests/server-handlers.js
@@ -26,6 +26,13 @@ import {
   interestDeletionSuccess,
   licenses,
 } from './mockData/management';
+import {
+  teams,
+  team,
+  teamCreationSuccess,
+  teamUpdationSuccess,
+  teamDeletionSuccess,
+} from './mockData/teams';
 import { countries } from './mockData/miscellaneous';
 import tasksGeojson from '../../utils/tests/snippets/tasksGeometry';
 import { API_URL } from '../../config';
@@ -83,6 +90,22 @@ const handlers = [
   }),
   rest.delete(API_URL + 'organisations/:id', (req, res, ctx) => {
     return res(ctx.json(organisationDeletionSuccess));
+  }),
+  // TEAMS
+  rest.get(API_URL + 'teams', (req, res, ctx) => {
+    return res(ctx.json(teams));
+  }),
+  rest.get(API_URL + 'teams/:id/', (req, res, ctx) => {
+    return res(ctx.json(team));
+  }),
+  rest.post(API_URL + 'teams', (req, res, ctx) => {
+    return res(ctx.json(teamCreationSuccess));
+  }),
+  rest.patch(API_URL + 'teams/:id/', (req, res, ctx) => {
+    return res(ctx.json(teamUpdationSuccess));
+  }),
+  rest.delete(API_URL + 'teams/:id', (req, res, ctx) => {
+    return res(ctx.json(teamDeletionSuccess));
   }),
   rest.get(API_URL + 'licenses', (req, res, ctx) => {
     return res(ctx.json(licenses));

--- a/frontend/src/views/teams.js
+++ b/frontend/src/views/teams.js
@@ -269,8 +269,8 @@ export function EditTeam(props) {
   const updateManagers = () => {
     const { usersAdded, usersRemoved } = getMembersDiff(team.members, managers, true);
     Promise.all([
-      [...usersAdded.map((user) => joinTeamRequest(team.teamId, user, 'MANAGER', token))],
-      [...usersRemoved.map((user) => leaveTeamRequest(team.teamId, user, 'MANAGER', token))],
+      ...usersAdded.map((user) => joinTeamRequest(team.teamId, user, 'MANAGER', token)),
+      ...usersRemoved.map((user) => leaveTeamRequest(team.teamId, user, 'MANAGER', token)),
     ]).then(forceUpdate);
   };
 
@@ -291,8 +291,9 @@ export function EditTeam(props) {
     if (payload.joinMethod !== 'BY_INVITE') {
       payload.visibility = 'PUBLIC';
     }
-    pushToLocalJSONAPI(`teams/${props.id}/`, JSON.stringify(payload), token, 'PATCH');
-    forceUpdate();
+    pushToLocalJSONAPI(`teams/${props.id}/`, JSON.stringify(payload), token, 'PATCH').then(
+      forceUpdate,
+    );
   };
 
   if (team && team.teamId && !canUserEditTeam) {

--- a/frontend/src/views/teams.js
+++ b/frontend/src/views/teams.js
@@ -49,7 +49,7 @@ export function ListTeams({ managementView = false }: Object) {
   const token = useSelector((state) => state.auth.token);
   const [teams, setTeams] = useState(null);
   const [userTeamsOnly, setUserTeamsOnly] = useState(true);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {

--- a/frontend/src/views/tests/teams.test.js
+++ b/frontend/src/views/tests/teams.test.js
@@ -1,0 +1,206 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ReduxIntlProviders, renderWithRouter } from '../../utils/testWithIntl';
+import { ManageTeams, EditTeam, CreateTeam } from '../teams';
+import { store } from '../../store';
+
+describe('List Teams', () => {
+  it('should show loading placeholder when teams are being fetched', async () => {
+    const { container } = renderWithRouter(
+      <ReduxIntlProviders>
+        <ManageTeams />
+      </ReduxIntlProviders>,
+    );
+    act(() => {
+      store.dispatch({
+        type: 'SET_USER_DETAILS',
+        userDetails: { id: 122, username: 'test_user', role: 'ADMIN' },
+      });
+      store.dispatch({ type: 'SET_TOKEN', token: 'validToken' });
+    });
+    expect(container.getElementsByClassName('show-loading-animation').length).toBe(4 * 9);
+  });
+
+  it('should fetch and list teams', async () => {
+    const { container } = render(
+      <ReduxIntlProviders>
+        <ManageTeams />
+      </ReduxIntlProviders>,
+    );
+    await waitFor(() =>
+      expect(container.getElementsByClassName('show-loading-animation').length).toBe(0),
+    );
+
+    expect(screen.getByRole('heading', { name: /team test/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /test kll team/i })).toBeInTheDocument();
+  });
+
+  it('should navigate to team detail page on team article click', async () => {
+    const { history, container } = renderWithRouter(
+      <ReduxIntlProviders>
+        <ManageTeams />
+      </ReduxIntlProviders>,
+    );
+    await waitFor(() =>
+      expect(container.getElementsByClassName('show-loading-animation').length).toBe(0),
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('heading', { name: /team test/i }));
+    await waitFor(() => expect(history.location.pathname).toBe('/teams/1/membership/'));
+  });
+});
+
+describe('Create Team', () => {
+  const setup = () => {
+    const { history } = renderWithRouter(
+      <ReduxIntlProviders>
+        <CreateTeam />
+      </ReduxIntlProviders>,
+    );
+    const user = userEvent.setup();
+    const createButton = screen.getByRole('button', {
+      name: /create team/i,
+    });
+
+    return {
+      user,
+      createButton,
+      history,
+    };
+  };
+
+  it('should disable create team button by default', () => {
+    const { createButton } = setup();
+    expect(createButton).toBeDisabled();
+  });
+
+  it('should fill the default manager list by the current user', () => {
+    setup();
+    const link = screen.getByRole('link', {
+      name: /test_user/i,
+    });
+    expect(within(link).getByTitle(/test_user/i)).toBeInTheDocument();
+  });
+
+  it('should navigate to the newly created team detail page on creation success', async () => {
+    const { createButton, history, user } = setup();
+    const nameInput = screen.getAllByRole('textbox')[0];
+    const orgSelect = screen.getByRole('combobox');
+    const joinMethodOption = screen.getAllByRole('radio')[0];
+    await user.type(nameInput, 'New Team Name');
+    await user.click(orgSelect);
+    const orgOption = await screen.findByText('American Red Cross');
+    await user.click(orgOption);
+    expect(createButton).toBeEnabled();
+    await user.click(joinMethodOption);
+    await user.click(createButton);
+    await waitFor(() => expect(history.location.pathname).toBe('/manage/teams/123'));
+  });
+});
+
+describe('Edit Team', () => {
+  it('should display default details of the team before editing', async () => {
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <EditTeam id={123} />
+      </ReduxIntlProviders>,
+    );
+    const nameInput = screen.getAllByRole('textbox')[0];
+    await waitFor(() => expect(nameInput.value).toBe('Team Test'));
+    expect(screen.getAllByRole('textbox')[1].value).toBe('Dummy team test');
+
+    await waitFor(() => expect(screen.getByText('Organisation Name 123')).toBeInTheDocument());
+    expect(screen.getByRole('link', { name: 'sample_user' })).toBeInTheDocument();
+  });
+
+  it('should display save and cancel button when project details are changed', async () => {
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <EditTeam id={123} />
+      </ReduxIntlProviders>,
+    );
+    const nameInput = screen.getAllByRole('textbox')[0];
+    await waitFor(() => expect(nameInput.value).toBe('Team Test'));
+    fireEvent.change(nameInput, { target: { value: 'Changed Team Test' } });
+    const saveButton = screen.getByRole('button', {
+      name: /save/i,
+    });
+    const cancelButton = screen.getByRole('button', {
+      name: /cancel/i,
+    });
+    expect(saveButton).toBeInTheDocument();
+    expect(cancelButton).toBeInTheDocument();
+  });
+
+  it('should hide the save button on successful updation of team details', async () => {
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <EditTeam id={123} />
+      </ReduxIntlProviders>,
+    );
+    const user = userEvent.setup();
+    const nameInput = screen.getAllByRole('textbox')[0];
+    await waitFor(() => expect(nameInput.value).toBe('Team Test'));
+    fireEvent.change(nameInput, { target: { value: 'Changed Team Test' } });
+    const saveButton = screen.getByRole('button', {
+      name: /save/i,
+    });
+    await user.click(saveButton);
+    expect(saveButton).not.toBeInTheDocument();
+  });
+});
+
+describe('Delete Team', () => {
+  const setup = () => {
+    const { history } = renderWithRouter(
+      <ReduxIntlProviders>
+        <EditTeam id={123} />
+      </ReduxIntlProviders>,
+    );
+
+    const deleteButton = screen.getByRole('button', {
+      name: /delete/i,
+    });
+
+    fireEvent.click(deleteButton);
+    return {
+      history,
+      deleteButton,
+    };
+  };
+
+  it('should ask for confirmation when user tries to delete a team', async () => {
+    setup();
+    const deleteDialog = screen.getByRole('dialog');
+    expect(
+      within(deleteDialog).getByRole('heading', {
+        name: 'Are you sure you want to delete this team?',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should close the confirmation dialog when cancel is clicked', async () => {
+    setup();
+    const cancelButton = screen.getByRole('button', {
+      name: /cancel/i,
+    });
+    fireEvent.click(cancelButton);
+    expect(
+      screen.queryByText('Are you sure you want to delete this team?'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should direct to teams list page on successful deletion of a team', async () => {
+    const { history } = setup();
+    const dialog = screen.getByRole('dialog');
+    const deleteConfirmationButton = within(dialog).getByRole('button', {
+      name: /delete/i,
+    });
+    fireEvent.click(deleteConfirmationButton);
+    expect(await screen.findByText('Team deleted successfully.')).toBeInTheDocument();
+    await waitFor(() => expect(history.location.pathname).toBe('/manage/teams'));
+  });
+});


### PR DESCRIPTION
This PR does the following:
- Add tests for the teams section
- Revise implementation to handle team managers' updation. The GET request to fetch updated members was executed simultaneously with the POST request rather than after the POST request was completed, which looked like it needed correction. 