### PR TITLE
Brush up styles for project detail

### DIFF
--- a/frontend/src/components/projectDetail/favorites.js
+++ b/frontend/src/components/projectDetail/favorites.js
@@ -19,7 +19,7 @@ export const AddToFavorites = (props) => {
         onClick={() => (userToken ? dispatchToggle() : navigate('/login'))}
         className={`${
           !props.projectId ? 'dn' : ''
-        } input-reset base-font bg-white blue-dark bn pointer flex nowrap items-center ml4 mr4`}
+        } input-reset base-font bg-white blue-dark bn pointer flex nowrap items-center ml3`}
       >
         <FlagIcon
           className={`pr2 v-btm ${isLoading ? 'o-50' : ''} ${isFav ? 'red' : 'blue-grey'}`}

--- a/frontend/src/components/projectDetail/footer.js
+++ b/frontend/src/components/projectDetail/footer.js
@@ -121,7 +121,7 @@ export const ProjectDetailFooter = ({ className, projectId }) => {
           ))}
         </div>
       </div>
-      <div className="flex items-center ml-auto">
+      <div className="flex items-center ml-auto gap-1">
         <ShareButton projectId={projectId} />
         {userIsloggedIn && <AddToFavorites projectId={projectId} />}
         <Link to={`./tasks`} className="">

--- a/frontend/src/components/projectDetail/index.js
+++ b/frontend/src/components/projectDetail/index.js
@@ -90,38 +90,34 @@ export const ProjectDetailLeft = ({ project, contributors, className, type }: Ob
     project.projectInfo && htmlFromMarkdown(project.projectInfo.shortDescription);
 
   return (
-    <div className={`${className} flex flex-column justify-between`}>
-      <div className="h-100 flex flex-column">
-        <ReactPlaceholder
-          showLoadingAnimation={true}
-          rows={10}
-          delay={500}
-          ready={typeof project.projectId === 'number'}
-        >
-          <ProjectHeader project={project} showEditLink={true} />
-          <section className="lh-title h5 overflow-y-auto mt3" style={{ flexGrow: 1 }}>
-            <div
-              className="pr2 blue-dark-abbey markdown-content"
-              dangerouslySetInnerHTML={htmlShortDescription}
-            />
-            <div>
-              <a href="#description" className="link base-font bg-white f6 bn pn red pointer">
-                <span className="pr2 ttu f6 fw6">
-                  <FormattedMessage {...messages.readMore} />
-                </span>
-              </a>
-            </div>
-          </section>
-        </ReactPlaceholder>
-      </div>
-      <div className="w-100 mt3">
-        <ProjectInfoPanel
-          project={project}
-          tasks={project.tasks}
-          contributors={contributors}
-          type={type}
-        />
-      </div>
+    <div className={`${className} flex flex-column`}>
+      <ReactPlaceholder
+        showLoadingAnimation={true}
+        rows={10}
+        delay={500}
+        ready={typeof project.projectId === 'number'}
+      >
+        <ProjectHeader project={project} showEditLink={true} />
+        <section className="lh-title h5 overflow-y-auto mt3 mb3" style={{ flexGrow: 1 }}>
+          <div
+            className="pr2 blue-dark-abbey markdown-content"
+            dangerouslySetInnerHTML={htmlShortDescription}
+          />
+          <div>
+            <a href="#description" className="link base-font bg-white f6 bn pn red pointer">
+              <span className="pr2 ttu f6 fw6">
+                <FormattedMessage {...messages.readMore} />
+              </span>
+            </a>
+          </div>
+        </section>
+      </ReactPlaceholder>
+      <ProjectInfoPanel
+        project={project}
+        tasks={project.tasks}
+        contributors={contributors}
+        type={type}
+      />
     </div>
   );
 };

--- a/frontend/src/components/projectDetail/styles.scss
+++ b/frontend/src/components/projectDetail/styles.scss
@@ -7,7 +7,7 @@
 }
 
 .tasks-map-height {
-  height: calc(100vh - 4rem - 7.625rem);
+  height: calc(100vh - 11.312rem); // Subtracting height of header, nav and fixed footer
   @media screen and (max-width: 60em) {
     height: 100%;
   }

--- a/frontend/src/components/projectDetail/tests/favorites.test.js
+++ b/frontend/src/components/projectDetail/tests/favorites.test.js
@@ -16,7 +16,7 @@ describe('AddToFavorites button', () => {
       </ReduxIntlProviders>,
     );
     const button = screen.getByRole('button');
-    expect(button.className).toBe(' input-reset base-font bg-white blue-dark bn pointer flex nowrap items-center ml4 mr4');
+    expect(button.className).toBe(' input-reset base-font bg-white blue-dark bn pointer flex nowrap items-center ml3');
     expect(button.className).not.toBe('dn input-reset base-font bg-white blue-dark f6 bn pointer');
     expect(container.querySelector('svg').classList.value).toBe('pr2 v-btm o-50 blue-grey');
     expect(button.textContent).toBe('Add to Favorites');


### PR DESCRIPTION
Noticed that the description height wasn't rendered as expected, and the container was overlapping with the consecutive container with https://github.com/hotosm/tasking-manager/pull/5516; this PR fixes that. Also adds a flex gap to the end components of the fixed footer.

![overlapping-detail](https://user-images.githubusercontent.com/51614993/212283078-6718cedb-6635-4908-ad01-a84627d78d5b.png)
