### PR TITLE
Update tests for the header and its components

### DIFF
--- a/frontend/src/components/header/NavLink.js
+++ b/frontend/src/components/header/NavLink.js
@@ -1,16 +1,6 @@
 import React from 'react';
 import { Link } from '@reach/router';
 
-export const NavLink = ({ partial = true, ...props }) => (
-  <Link
-    {...props}
-    getProps={({ isCurrent, isPartiallyCurrent }) => {
-      const isActive = partial ? isPartiallyCurrent : isCurrent;
-      return { className: `${isActive && 'bg-blue-dark white'} ${props.className}` };
-    }}
-  />
-);
-
 export const TopNavLink = (props) => {
   const { isActive, ...otherProps } = props;
   return (

--- a/frontend/src/components/header/notificationBell.js
+++ b/frontend/src/components/header/notificationBell.js
@@ -11,7 +11,7 @@ import { useInboxQueryAPI } from '../../hooks/UseInboxQueryAPI';
 import { pushToLocalJSONAPI } from '../../network/genericJSONRequest';
 import { useOnResize } from '../../hooks/UseOnResize';
 
-export const NotificationBell = (props) => {
+export const NotificationBell = () => {
   const token = useSelector((state) => state.auth.token);
   const trigger = token !== null;
   const [forceUpdated, forceUpdate] = useForceUpdate();
@@ -27,10 +27,8 @@ export const NotificationBell = (props) => {
 
   const [isPopoutFocus, setPopoutFocus] = useState(false);
   const [unreadNotifications, setUnreadNotifications] = useState(false);
-  const [initialUnreadCountError, initialUnreadCountLoading, initialUnreadCount] = useFetchWithAbort(
-    '/api/v2/notifications/queries/own/count-unread/',
-    trigger,
-  );
+  const [initialUnreadCountError, initialUnreadCountLoading, initialUnreadCount] =
+    useFetchWithAbort('/api/v2/notifications/queries/own/count-unread/', trigger);
   const [unreadCountError, unreadCount] = useFetchIntervaled(
     '/api/v2/notifications/queries/own/count-unread/',
     30000,
@@ -39,11 +37,8 @@ export const NotificationBell = (props) => {
 
   useEffect(() => {
     // unreadCount will receive a value only after 30 seconds,
-    //so while it's undefined, we rely on initialUnreadCount
-    if (
-      (!unreadCount && initialUnreadCount && initialUnreadCount.newMessages) ||
-      (unreadCount && unreadCount.newMessages)
-    ) {
+    // so while it's undefined, we rely on initialUnreadCount
+    if ((!unreadCount && initialUnreadCount?.newMessages) || unreadCount?.newMessages) {
       setUnreadNotifications(true);
     } else {
       setUnreadNotifications(false);
@@ -78,11 +73,8 @@ export const NotificationBell = (props) => {
   };
 
   const liveUnreadCount =
-    (!unreadCountError && unreadCount && unreadCount.unread) ||
-    (!initialUnreadCountLoading &&
-      !initialUnreadCountError &&
-      initialUnreadCount &&
-      initialUnreadCount.unread);
+    (!unreadCountError && unreadCount?.unread) ||
+    (!initialUnreadCountLoading && !initialUnreadCountError && initialUnreadCount?.unread);
 
   return (
     <span ref={notificationBellRef}>

--- a/frontend/src/components/header/signUp.js
+++ b/frontend/src/components/header/signUp.js
@@ -171,16 +171,18 @@ const SignupForm = ({ data, setData, step, setStep }) => {
           {step.errMessage}
         </p>
       </div>
-      <p className="mb0 f6">
-        <a
-          className="link pointer red fw5"
-          target="_blank"
-          rel="noopener noreferrer"
-          href={`http://${ORG_PRIVACY_POLICY_URL}`}
-        >
-          <FormattedMessage {...messages.privacyPolicy} />
-        </a>
-      </p>
+      {ORG_PRIVACY_POLICY_URL && (
+        <p className="mb0 f6">
+          <a
+            className="link pointer red fw5"
+            target="_blank"
+            rel="noopener noreferrer"
+            href={`http://${ORG_PRIVACY_POLICY_URL}`}
+          >
+            <FormattedMessage {...messages.privacyPolicy} />
+          </a>
+        </p>
+      )}
       <div className="mt3 tr">
         <Button
           className="bg-red white"

--- a/frontend/src/components/header/signUp.js
+++ b/frontend/src/components/header/signUp.js
@@ -10,7 +10,7 @@ import { createLoginWindow } from '../../utils/login';
 import { ORG_PRIVACY_POLICY_URL, OSM_REGISTER_URL } from '../../config';
 import * as safeStorage from '../../utils/safe_storage';
 
-const LoginModal = ({ step, login }) => {
+export const LoginModal = ({ step, login }) => {
   return (
     <div>
       <h1 className="pb2 ma0 barlow-condensed blue-dark">
@@ -41,7 +41,7 @@ const LoginModal = ({ step, login }) => {
   );
 };
 
-const ProceedOSM = ({ data, step, setStep, login }) => {
+export const ProceedOSM = ({ data, step, setStep, login }) => {
   const NextStep = (setStep) => {
     window.open(OSM_REGISTER_URL, '_blank');
     setStep((s) => {
@@ -88,11 +88,6 @@ const SignupForm = ({ data, setData, step, setStep }) => {
   };
 
   const checkFields = () => {
-    if (data.name === '') {
-      setStep({ ...step, errMessage: <FormattedMessage {...messages.invalidName} /> });
-      return;
-    }
-
     const re =
       // eslint-disable-next-line no-useless-escape
       /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
@@ -212,21 +207,19 @@ export const SignUp = ({ closeModal }) => {
 
   const getStep = (step) => {
     switch (step.number) {
-      case 1:
-        return <SignupForm data={data} setData={setData} step={step} setStep={setStep} />;
       case 2:
         return <ProceedOSM data={data} step={step} setStep={setStep} login={login} />;
       case 3:
         return <LoginModal step={step} login={login} />;
       default:
-        return null;
+        return <SignupForm data={data} setData={setData} step={step} setStep={setStep} />;
     }
   };
 
   return (
     <div className="tl pa4 bg-white">
       <span className="fr relative blue-light pt1 link pointer" onClick={() => closeModal()}>
-        <CloseIcon style={{ height: '18px', width: '18px' }} />
+        <CloseIcon aria-label="Close popup" style={{ height: '18px', width: '18px' }} />
       </span>
       {getStep(step)}
     </div>

--- a/frontend/src/components/header/tests/index.test.js
+++ b/frontend/src/components/header/tests/index.test.js
@@ -1,0 +1,348 @@
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { globalHistory } from '@reach/router';
+import { screen, fireEvent, act, within, waitFor, render } from '@testing-library/react';
+
+import '../../../utils/mockMatchMedia';
+import { IntlProviders, ReduxIntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
+import { ORG_URL, ORG_LOGO, SERVICE_DESK } from '../../../config';
+import { AuthButtons, getMenuItemsForUser, Header, PopupItems } from '..';
+import messages from '../messages';
+import { store } from '../../../store';
+
+describe('Header', () => {
+  const setup = () => {
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <Header location={globalHistory.location} />
+      </ReduxIntlProviders>,
+      {
+        route: '/explore',
+      },
+    );
+  };
+
+  it('should render component details', () => {
+    setup();
+    expect(screen.getByText(messages.slogan.defaultMessage)).toBeInTheDocument();
+    if (ORG_URL) {
+      expect(screen.getByText(ORG_URL)).toBeInTheDocument();
+      expect(screen.getByText(ORG_URL).closest('a')).toHaveAttribute('href', `http://${ORG_URL}`);
+    }
+    expect(screen.getByTitle('externalLink')).toBeInTheDocument();
+    const orgLogo = screen.getByRole('img');
+    if (ORG_LOGO) {
+      expect(orgLogo).toHaveAttribute('src', ORG_LOGO);
+    } else {
+      expect(orgLogo).toHaveAttribute('src', 'main-logo.svg');
+    }
+    expect(screen.getByText(/Tasking Manager/i)).toBeInTheDocument();
+    ['Explore projects', 'Learn', 'About'].forEach((menuItem) =>
+      expect(
+        screen.getByRole('link', {
+          name: menuItem,
+        }),
+      ).toBeInTheDocument(),
+    );
+    if (SERVICE_DESK) {
+      expect(
+        screen.getByRole('link', {
+          name: 'Support',
+        }),
+      ).toBeInTheDocument();
+    } else {
+      expect(
+        screen.queryByRole('link', {
+          name: 'Support',
+        }),
+      ).not.toBeInTheDocument();
+    }
+  });
+
+  // TODO:
+  // it('should use local logo image if no org logo is present', () => {
+  //   const { rerender } = renderWithRouter(
+  //     <ReduxIntlProviders>
+  //       <Header location={globalHistory.location} />
+  //     </ReduxIntlProviders>,
+  //   );
+
+  //   const orgLogo = screen.getByAltText(`${ORG_NAME} logo`);
+  //   expect(orgLogo).toHaveAttribute('src', 'main-logo.svg');
+  // });
+
+  it('should render fallback logo if the environment logo fails to load', () => {
+    setup();
+    const orgLogo = screen.getByRole('img');
+    if (ORG_LOGO) {
+      expect(orgLogo).toHaveAttribute('src', ORG_LOGO);
+      fireEvent.error(orgLogo);
+      expect(orgLogo).toHaveAttribute('src', 'main-logo.svg');
+    }
+  });
+
+  it('should display menu when burger menu icon is clicked', async () => {
+    setup();
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /menu/i,
+      }),
+    );
+    const popup = screen.getByRole('dialog');
+    const someMenuFromDialog = within(popup).getByRole('link', {
+      name: /about/i,
+    });
+    expect(someMenuFromDialog).toBeInTheDocument();
+  });
+
+  it('should display active classes on active page', async () => {
+    setup();
+    expect(
+      screen.getByRole('link', {
+        name: /explore projects/i,
+      }),
+    ).toHaveClass('bb b--blue-dark bw1 pv2');
+    expect(
+      screen.getByRole('link', {
+        name: /about/i,
+      }),
+    ).not.toHaveClass('bb b--blue-dark bw1 pv2');
+  });
+});
+
+describe('Right side action items', () => {
+  const setup = () => {
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <Header location={globalHistory.location} />
+      </ReduxIntlProviders>,
+    );
+  };
+  test('when the user is logged in', () => {
+    act(() => {
+      store.dispatch({
+        type: 'SET_USER_DETAILS',
+        userDetails: { username: 'somebody' },
+      });
+    });
+    setup();
+    expect(screen.getByLabelText('Notifications')).toBeInTheDocument();
+    expect(screen.getByLabelText('Sample avatar')).toBeInTheDocument();
+  });
+
+  test("when the user isn't logged in", () => {
+    act(() => {
+      store.dispatch({
+        type: 'SET_USER_DETAILS',
+        userDetails: {},
+      });
+    });
+    setup();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByText('English')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /log in/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /sign up/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /menu/i,
+      }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('Dropdown menu of logged in user', () => {
+  const setup = () =>
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <Header location={globalHistory.location} />
+      </ReduxIntlProviders>,
+    );
+
+  it('should render dropdown menu when clicked', async () => {
+    act(() => {
+      store.dispatch({
+        type: 'SET_USER_DETAILS',
+        userDetails: { username: 'somebody' },
+      });
+    });
+    setup();
+    await userEvent.click(screen.getByText('somebody'));
+  });
+
+  it('should log the user out', async () => {
+    act(() => {
+      store.dispatch({
+        type: 'SET_USER_DETAILS',
+        userDetails: { username: 'somebody' },
+      });
+    });
+    setup();
+    await userEvent.click(screen.getByText('somebody'));
+    // screen.getByRole('')
+    await userEvent.click(screen.getByText(/Logout/i));
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /log in/i,
+        }),
+      ).toBeInTheDocument(),
+    );
+  });
+});
+
+describe('AuthButtons Component', () => {
+  it('should render component details', async () => {
+    render(
+      <IntlProviders>
+        <AuthButtons />
+      </IntlProviders>,
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: messages.logIn.defaultMessage,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: messages.signUp.defaultMessage,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: messages.createAccount.defaultMessage,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should display alterntive sign up text', async () => {
+    render(
+      <IntlProviders>
+        <AuthButtons alternativeSignUpText />
+      </IntlProviders>,
+    );
+    expect(
+      screen.getByRole('button', {
+        name: messages.createAccount.defaultMessage,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: messages.signUp.defaultMessage,
+      }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('PopupItems Component', () => {
+  test('when user is logged in', async () => {
+    render(
+      <ReduxIntlProviders>
+        <PopupItems
+          menuItems={getMenuItemsForUser({ username: 'somebody', role: 'ADMIN' })}
+          userDetails={{ username: 'somebody', emailAddress: undefined }}
+        />
+      </ReduxIntlProviders>,
+    );
+    expect(
+      screen.getByRole('link', {
+        name: /manage/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {
+        name: /settings/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /logout/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('when user is not logged in', async () => {
+    render(
+      <ReduxIntlProviders>
+        <PopupItems
+          menuItems={getMenuItemsForUser({ username: 'somebody', role: 'ADMIN' })}
+          userDetails={{}}
+          location={{ pathname: '/somewhere' }}
+        />
+      </ReduxIntlProviders>,
+    );
+    expect(
+      screen.queryByRole('link', {
+        name: /manage/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {
+        name: /settings/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: /logout/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /log in/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should log the user out', async () => {
+    const { rerender } = renderWithRouter(
+      <ReduxIntlProviders>
+        <PopupItems
+          menuItems={getMenuItemsForUser({ username: 'somebody', role: 'ADMIN' })}
+          userDetails={{ username: 'somebody', emailAddress: undefined }}
+        />
+      </ReduxIntlProviders>,
+    );
+    const logoutBtn = screen.getByRole('button', {
+      name: /logout/i,
+    });
+    const user = userEvent.setup();
+    await user.click(logoutBtn);
+    rerender(
+      <ReduxIntlProviders>
+        <PopupItems
+          menuItems={getMenuItemsForUser({ username: 'somebody', role: 'ADMIN' })}
+          userDetails={{}}
+          location={{ pathname: '/somewhere' }}
+        />
+      </ReduxIntlProviders>,
+    );
+    await waitFor(() => expect(logoutBtn).not.toBeInTheDocument());
+  });
+});
+
+test('users should be prompted to update their email', () => {
+  act(() => {
+    store.dispatch({
+      type: 'SET_USER_DETAILS',
+      userDetails: { username: 'somebody', emailAddress: undefined },
+    });
+  });
+  renderWithRouter(
+    <ReduxIntlProviders>
+      <Header location={globalHistory.location} />
+    </ReduxIntlProviders>,
+  );
+  expect(
+    screen.getByRole('heading', {
+      name: /update your email/i,
+    }),
+  ).toBeInTheDocument();
+});

--- a/frontend/src/components/header/tests/notificationBell.test.js
+++ b/frontend/src/components/header/tests/notificationBell.test.js
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import '../../../utils/mockMatchMedia';
+import { store } from '../../../store';
+import { ReduxIntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
+import { NotificationBell } from '../notificationBell';
+
+describe('Notification Bell', () => {
+  it('should render component details', async () => {
+    act(() => {
+      store.dispatch({ type: 'SET_TOKEN', token: 'validToken' });
+    });
+    const { container } = renderWithRouter(
+      <ReduxIntlProviders>
+        <NotificationBell />
+      </ReduxIntlProviders>,
+      {
+        route: '/inbox',
+      },
+    );
+    const inboxLink = screen.getAllByRole('link')[0];
+    expect(within(inboxLink).getByLabelText(/notifications/i)).toBeInTheDocument();
+    expect(await screen.findByText(/You have been added to team/i)).toBeInTheDocument();
+    expect(screen.getAllByRole('article').length).toBe(4);
+    await waitFor(() => {
+      expect(container.getElementsByClassName('redicon')[0]).toBeInTheDocument();
+    });
+    expect(inboxLink).toHaveClass('bb b--blue-dark bw1 pv2');
+  });
+
+  it('should clear unread notification count when bell icon is clicked', async () => {
+    const { container } = render(
+      <ReduxIntlProviders>
+        <NotificationBell />
+      </ReduxIntlProviders>,
+    );
+    expect(screen.getAllByRole('link')[0]).not.toHaveClass('bb b--blue-dark bw1 pv2');
+    expect(await screen.findByText(/You have been added to team/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(container.getElementsByClassName('redicon')[0]).toBeInTheDocument();
+    });
+    await userEvent.click(within(screen.getAllByRole('link')[0]).getByLabelText(/notifications/i));
+    await waitFor(() => {
+      expect(container.querySelector('redicon')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/header/tests/signUp.test.js
+++ b/frontend/src/components/header/tests/signUp.test.js
@@ -1,0 +1,217 @@
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+
+import messages from '../messages';
+import { LoginModal, ProceedOSM, SignUp } from '../signUp';
+import { IntlProviders } from '../../../utils/testWithIntl';
+import { ORG_PRIVACY_POLICY_URL } from '../../../config';
+
+describe('Sign Up Form', () => {
+  it('should close the sign up popup when close icon is clicked', async () => {
+    const closeModalMock = jest.fn();
+    render(
+      <IntlProviders>
+        <SignUp closeModal={closeModalMock} />
+      </IntlProviders>,
+    );
+    await userEvent.click(screen.getByLabelText(/close popup/i));
+    expect(closeModalMock).toHaveBeenCalled();
+  });
+
+  it('should render component details', () => {
+    const { container } = render(
+      <IntlProviders>
+        <SignUp />
+      </IntlProviders>,
+    );
+    expect(
+      screen.getByRole('heading', {
+        name: '1. Sign up',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(messages.signUpQuestion.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.signupLabelName.defaultMessage)).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(messages.namePlaceHolder.defaultMessage),
+    ).toBeInTheDocument();
+    expect(screen.getByText(messages.signupLabelEmail.defaultMessage)).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(messages.emailPlaceholder.defaultMessage),
+    ).toBeInTheDocument();
+    if (ORG_PRIVACY_POLICY_URL) {
+      expect(
+        screen.getByRole('link', {
+          name: messages.privacyPolicy.defaultMessage,
+        }),
+      ).toBeInTheDocument();
+    } else {
+      expect(
+        screen.queryByRole('link', {
+          name: messages.privacyPolicy.defaultMessage,
+        }),
+      ).not.toBeInTheDocument();
+    }
+    expect(container.getElementsByClassName('h2 white f6 pa2 tc')[0]).not.toHaveClass('bg-red');
+    expect(
+      screen.getByRole('button', {
+        name: /next/i,
+      }),
+    ).toBeDisabled();
+    expect(screen.getByLabelText(/close popup/i)).toBeInTheDocument();
+  });
+
+  it('should proceed to step two when expected inputs are fulfilled', async () => {
+    render(
+      <IntlProviders>
+        <SignUp />
+      </IntlProviders>,
+    );
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByPlaceholderText(messages.namePlaceHolder.defaultMessage),
+      'My Name',
+    );
+    expect(
+      screen.getByRole('button', {
+        name: /next/i,
+      }),
+    ).toBeDisabled();
+    await user.type(
+      screen.getByPlaceholderText(messages.emailPlaceholder.defaultMessage),
+      'invalidemail',
+    );
+    expect(
+      screen.getByRole('button', {
+        name: /next/i,
+      }),
+    ).toBeEnabled();
+    await user.click(
+      screen.getByRole('button', {
+        name: /next/i,
+      }),
+    );
+    expect(screen.getByText(messages.invalidEmail.defaultMessage)).toBeInTheDocument();
+    await user.type(
+      screen.getByPlaceholderText(messages.emailPlaceholder.defaultMessage),
+      'valid@email.com',
+    );
+    await user.click(
+      screen.getByRole('button', {
+        name: /next/i,
+      }),
+    );
+    expect(await screen.findByText('Do you have an OpenStreetMap account?')).toBeInTheDocument();
+  });
+});
+
+describe('Proceed OSM form', () => {
+  const setup = async () => {
+    render(
+      <IntlProviders>
+        <SignUp />
+      </IntlProviders>,
+    );
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByPlaceholderText(messages.namePlaceHolder.defaultMessage),
+      'My Name',
+    );
+    await user.type(
+      screen.getByPlaceholderText(messages.emailPlaceholder.defaultMessage),
+      'valid@email.com',
+    );
+    await user.click(
+      screen.getByRole('button', {
+        name: /next/i,
+      }),
+    );
+    expect(await screen.findByText('Do you have an OpenStreetMap account?')).toBeInTheDocument();
+  };
+
+  it('should render component details', async () => {
+    await setup();
+    expect(
+      screen.getByRole('heading', {
+        name: `2. ${messages.proceedOSMTitle.defaultMessage}`,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(messages.proceedOSMPart1.defaultMessage)).toBeInTheDocument();
+    expect(screen.getByText(messages.proceedOSMPart2.defaultMessage)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: messages.submitProceedOSM.defaultMessage,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(messages.proceedOSMLogin.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('should open OSM login window', async () => {
+    global.open = jest.fn();
+    await setup();
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: messages.submitProceedOSM.defaultMessage,
+      }),
+    );
+    expect(global.open).toHaveBeenCalled();
+  });
+
+  it('should execute login prop when user already has an account', async () => {
+    const setStepMock = jest.fn();
+    const loginMock = jest.fn();
+    render(
+      <IntlProviders>
+        <ProceedOSM
+          data={{ name: 'somebody', email: 'somebody@hot.org' }}
+          step={2}
+          setStep={setStepMock}
+          login={loginMock}
+        />
+      </IntlProviders>,
+    );
+    await userEvent.click(screen.getByText(messages.proceedOSMLogin.defaultMessage));
+    expect(loginMock).toHaveBeenCalled();
+  });
+});
+
+describe('LoginModal component', () => {
+  const loginMock = jest.fn();
+  it('should render component details', () => {
+    render(
+      <IntlProviders>
+        <LoginModal step={{ number: 3 }} login={loginMock} />
+      </IntlProviders>,
+    );
+    expect(
+      screen.getByRole('heading', {
+        name: `3. ${messages.AuthorizeTitle.defaultMessage}`,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(messages.AuthorizeMessage.defaultMessage)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /log in/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {
+        name: messages.osmRegisterCheck.defaultMessage,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should execute the login prop', async () => {
+    render(
+      <IntlProviders>
+        <LoginModal step={{ number: 3 }} login={loginMock} />
+      </IntlProviders>,
+    );
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /log in/i,
+      }),
+    );
+    expect(loginMock).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/header/tests/topBar.test.js
+++ b/frontend/src/components/header/tests/topBar.test.js
@@ -1,0 +1,12 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { TopBar } from '../topBar';
+
+it('should display the header string passed as props', () => {
+  render(<TopBar pageName="Dhamaka" />);
+  expect(
+    screen.getByRole('heading', {
+      name: 'Dhamaka',
+    }),
+  ).toBeInTheDocument();
+});

--- a/frontend/src/components/header/tests/updateDialog.test.js
+++ b/frontend/src/components/header/tests/updateDialog.test.js
@@ -1,0 +1,94 @@
+import '@testing-library/jest-dom';
+import { screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import messages from '../messages';
+import { UpdateDialog } from '../updateDialog';
+import { IntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
+
+describe('Update Dialog', () => {
+  const originalWindowContext = window.location;
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload: jest.fn() },
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(window, 'location', { configurable: true, value: originalWindowContext });
+  });
+
+  it('should not render prompt for mapping page', () => {
+    const { container } = renderWithRouter(
+      <IntlProviders>
+        <UpdateDialog />
+      </IntlProviders>,
+      {
+        route: '/projects/map/',
+      },
+    );
+    fireEvent(
+      document,
+      new CustomEvent('onNewServiceWorker', { detail: { registration: 'hello' } }),
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should not render prompt for validation page', () => {
+    const { container } = renderWithRouter(
+      <IntlProviders>
+        <UpdateDialog />
+      </IntlProviders>,
+      {
+        route: '/projects/validate/',
+      },
+    );
+    fireEvent(
+      document,
+      new CustomEvent('onNewServiceWorker', { detail: { registration: 'hello' } }),
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should render prompt for other pages', () => {
+    renderWithRouter(
+      <IntlProviders>
+        <UpdateDialog />
+      </IntlProviders>,
+    );
+    fireEvent(
+      document,
+      new CustomEvent('onNewServiceWorker', { detail: { registration: { waiting: true } } }),
+    );
+    expect(screen.getByText(messages.newVersionAvailable.defaultMessage)).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.newVersionAvailableLineTwo.defaultMessage),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument();
+  });
+
+  it('should update the service worker', async () => {
+    renderWithRouter(
+      <IntlProviders>
+        <UpdateDialog />
+      </IntlProviders>,
+    );
+    const postMessageMock = jest.fn();
+    fireEvent(
+      document,
+      new CustomEvent('onNewServiceWorker', {
+        detail: { registration: { waiting: { postMessage: postMessageMock } } },
+      }),
+    );
+
+    Object.defineProperty(global.navigator, 'serviceWorker', {
+      value: {
+        addEventListener: jest.fn(),
+      },
+    });
+    await userEvent.click(screen.getByRole('button', { name: /refresh/i }));
+    expect(postMessageMock).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/header/tests/updateEmail.test.js
+++ b/frontend/src/components/header/tests/updateEmail.test.js
@@ -1,0 +1,75 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ReduxIntlProviders } from '../../../utils/testWithIntl';
+import messages from '../messages';
+import { UpdateEmail } from '../updateEmail';
+import { ORG_PRIVACY_POLICY_URL } from '../../../config';
+
+describe('Update Email Dialog', () => {
+  const closeModalMock = jest.fn();
+  const setup = () => {
+    render(
+      <ReduxIntlProviders>
+        <UpdateEmail closeModal={closeModalMock} />
+      </ReduxIntlProviders>,
+    );
+  };
+  it('should render component details', () => {
+    setup();
+    expect(
+      screen.getByRole('heading', {
+        name: messages.emailUpdateTitle.defaultMessage,
+      }),
+    ).toBeInTheDocument();
+    [messages.emailUpdateTextPart1, messages.emailUpdateTextPart2].forEach((message) =>
+      expect(screen.getByText(message.defaultMessage)).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByPlaceholderText(messages.emailPlaceholder.defaultMessage),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /update/i,
+      }),
+    ).toBeInTheDocument();
+    if (ORG_PRIVACY_POLICY_URL) {
+      expect(
+        screen.getByRole('link', {
+          name: messages.privacyPolicy.defaultMessage,
+        }),
+      ).toBeInTheDocument();
+    } else {
+      expect(
+        screen.queryByRole('link', {
+          name: messages.privacyPolicy.defaultMessage,
+        }),
+      ).not.toBeInTheDocument();
+    }
+  });
+
+  it('should update user email', async () => {
+    setup();
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /update/i,
+      }),
+    );
+    await waitFor(() => {
+      expect(closeModalMock).toHaveBeenCalled();
+    });
+  });
+
+  it('should update email text', async () => {
+    setup();
+
+    await userEvent.type(
+      screen.getByPlaceholderText(messages.emailPlaceholder.defaultMessage),
+      'meow',
+    );
+    expect(screen.getByPlaceholderText(messages.emailPlaceholder.defaultMessage)).toHaveValue(
+      'meow',
+    );
+  });
+});

--- a/frontend/src/components/header/updateDialog.js
+++ b/frontend/src/components/header/updateDialog.js
@@ -23,7 +23,6 @@ const updateServiceWorker = (registration) => {
 export const UpdateDialog = () => {
   const location = useLocation();
   const [registration, setRegistration] = useState(null);
-  const close = useState(false);
 
   const isMapOrValidationPage =
     location.pathname.startsWith('/projects/') &&
@@ -34,9 +33,10 @@ export const UpdateDialog = () => {
     document.addEventListener('onNewServiceWorker', handleServiceWorkerEvent);
     return () => document.removeEventListener('onNewServiceWorker', handleServiceWorkerEvent);
   }, []);
+
   return (
     <>
-      {!isMapOrValidationPage && !close && registration !== null && (
+      {!isMapOrValidationPage && registration !== null && (
         <div className="fixed left-1 bottom-1 shadow-2 ph3 pt2 pb3 br1 bg-white z-5 blue-dark fw6 ba b--grey-light">
           <p className="mb3 mt2">
             <FormattedMessage {...messages.newVersionAvailable} />

--- a/frontend/src/components/header/updateEmail.js
+++ b/frontend/src/components/header/updateEmail.js
@@ -64,7 +64,7 @@ class UpdateEmail extends Component {
           </p>
           <Button className="bg-red white" type="submit">
             <FormattedMessage {...messages.emailUpdateButton} />
-          </Button>
+        {ORG_PRIVACY_POLICY_URL && (
           <p className="mb0">
             <a
               className="link pointer red fw5"
@@ -75,17 +75,7 @@ class UpdateEmail extends Component {
               <FormattedMessage {...messages.privacyPolicy} />
             </a>
           </p>
-          <p className={this.state.details ? 'dib mb0' : 'dn'}>{this.state.details}</p>
-        </form>
-      </div>
-    );
-  }
-}
-
-const mapStateToProps = (state) => ({
-  userDetails: state.auth.userDetails,
-  token: state.auth.token,
-});
+        )}
 
 UpdateEmail.propTypes = {
   updateUserEmail: PropTypes.func.isRequired,

--- a/frontend/src/components/header/updateEmail.js
+++ b/frontend/src/components/header/updateEmail.js
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
@@ -9,61 +9,61 @@ import { PROFILE_RELEVANT_FIELDS } from '../user/forms/personalInformation';
 import { ORG_PRIVACY_POLICY_URL } from '../../config';
 import { Button } from '../button';
 
-class UpdateEmail extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { email: '', success: false, details: '' };
-    this.onChange = this.onChange.bind(this);
-    this.onSubmit = this.onSubmit.bind(this);
-  }
+export const UpdateEmail = ({ closeModal }) => {
+  const dispatch = useDispatch();
 
-  onChange(e) {
-    this.setState({ [e.target.name]: e.target.value });
-  }
+  const userDetails = useSelector((state) => state.auth.userDetails);
+  const token = useSelector((state) => state.auth.token);
+  const [userState, setUserState] = useState({ email: '', success: false, details: '' });
 
-  onSubmit = (e) => {
+  const onChange = (e) => {
+    setUserState({ ...userState, [e.target.name]: e.target.value });
+  };
+
+  const onSubmit = (e) => {
     e.preventDefault();
-    let userData = this.props.userDetails;
-    userData.emailAddress = this.state.email;
-    this.props.updateUserEmail(userData, this.props.token, PROFILE_RELEVANT_FIELDS.concat(['id']));
-    this.setState({
+    let userData = userDetails;
+    userData.emailAddress = userState.email;
+    dispatch(updateUserEmail(userData, token, PROFILE_RELEVANT_FIELDS.concat(['id'])));
+    setUserState({
+      ...userState,
       success: true,
       details: <FormattedMessage {...messages.emailUpdateSuccess} />,
     });
-    this.props.closeModal();
+    closeModal();
   };
 
-  render() {
-    return (
-      <div className="tl pa4 bg-white">
-        <h1 className="pb2 ma0 barlow-condensed blue-dark">
-          <FormattedMessage {...messages.emailUpdateTitle} />
-        </h1>
-        <p className="blue-dark lh-copy">
-          <FormattedMessage {...messages.emailUpdateTextPart1} />
+  return (
+    <div className="tl pa4 bg-white">
+      <h1 className="pb2 ma0 barlow-condensed blue-dark">
+        <FormattedMessage {...messages.emailUpdateTitle} />
+      </h1>
+      <p className="blue-dark lh-copy">
+        <FormattedMessage {...messages.emailUpdateTextPart1} />
+      </p>
+      <p className="blue-dark lh-copy">
+        <FormattedMessage {...messages.emailUpdateTextPart2} />
+      </p>
+      <form onSubmit={onSubmit}>
+        <p>
+          <FormattedMessage {...messages.emailPlaceholder}>
+            {(msg) => {
+              return (
+                <input
+                  className="pa2 w-60-l w-100"
+                  type="email"
+                  name="email"
+                  placeholder={msg}
+                  onChange={onChange}
+                  value={userState.email}
+                />
+              );
+            }}
+          </FormattedMessage>
         </p>
-        <p className="blue-dark lh-copy">
-          <FormattedMessage {...messages.emailUpdateTextPart2} />
-        </p>
-        <form onSubmit={this.onSubmit}>
-          <p>
-            <FormattedMessage {...messages.emailPlaceholder}>
-              {(msg) => {
-                return (
-                  <input
-                    className="pa2 w-60-l w-100"
-                    type="email"
-                    name="email"
-                    placeholder={msg}
-                    onChange={this.onChange}
-                    value={this.state.email}
-                  />
-                );
-              }}
-            </FormattedMessage>
-          </p>
-          <Button className="bg-red white" type="submit">
-            <FormattedMessage {...messages.emailUpdateButton} />
+        <Button className="bg-red white" type="submit">
+          <FormattedMessage {...messages.emailUpdateButton} />
+        </Button>
         {ORG_PRIVACY_POLICY_URL && (
           <p className="mb0">
             <a
@@ -76,12 +76,12 @@ class UpdateEmail extends Component {
             </a>
           </p>
         )}
-
-UpdateEmail.propTypes = {
-  updateUserEmail: PropTypes.func.isRequired,
-  closeModal: PropTypes.func.isRequired,
+        <p className={userState.details ? 'dib mb0' : 'dn'}>{userState.details}</p>
+      </form>
+    </div>
+  );
 };
 
-UpdateEmail = connect(mapStateToProps, { updateUserEmail })(UpdateEmail);
-
-export { UpdateEmail };
+UpdateEmail.propTypes = {
+  closeModal: PropTypes.func.isRequired,
+};

--- a/frontend/src/components/user/avatar.js
+++ b/frontend/src/components/user/avatar.js
@@ -18,7 +18,7 @@ export const CurrentUserAvatar = (props) => {
       />
     );
   }
-  return <ProfilePictureIcon {...props} />;
+  return <ProfilePictureIcon {...props} aria-label="Sample avatar" />;
 };
 
 export const UserAvatar = ({

--- a/frontend/src/network/tests/mockData/auth.js
+++ b/frontend/src/network/tests/mockData/auth.js
@@ -1,0 +1,16 @@
+export const authLogin = {
+  auth_url:
+    'https://www.openstreetmap.org/oauth2/authorize?response_type=code&client_id=zOCFokst2ZlvH17YoCBKMudz3t_H0xijcfx4DXcfPLM&redirect_uri=http%3A%2F%2F127.0.0.1%3A3000%2Fauthorized&scope=read_prefs+write_api&state=SNAFQxrXd0AlcL0X0UHL6dZPNGnwFN5M2asTiyIGkDJ0Zo_l',
+  state: 'SNAFQxrXd0AlcL0X0UHL6dZPNGnwFN5M2asTiyIGkDJ0Zo_l',
+};
+
+export const userRegister = {
+  id: 3,
+  email: 'somebody@hot.org',
+  success: true,
+  details: 'User created successfully',
+};
+
+export const setUser = {
+  verificationEmailSent: false,
+};

--- a/frontend/src/network/tests/mockData/notifications.js
+++ b/frontend/src/network/tests/mockData/notifications.js
@@ -1,0 +1,81 @@
+export const ownCountUnread = {
+  newMessages: true,
+  unread: 2,
+};
+
+export const notifications = {
+  pagination: {
+    hasNext: true,
+    hasPrev: false,
+    nextNum: 2,
+    page: 1,
+    pages: 21,
+    prevNum: null,
+    perPage: 10,
+    total: 208,
+  },
+  userMessages: [
+    {
+      messageId: 759710,
+      subject:
+        '<a href="https://tasks-stage.hotosm.org/users/Hel Nershing Thapa">Hel Nershing Thapa</a> requested to join <a href="https://tasks-stage.hotosm.org/manage/teams/19/">asdsa</a>',
+      message:
+        '<a href="https://tasks-stage.hotosm.org/users/Hel Nershing Thapa">Hel Nershing Thapa</a> has requested to join the <a href="https://tasks-stage.hotosm.org/manage/teams/19/">asdsa</a> team.            Access the team management page to accept or reject that request.',
+      fromUsername: 'Hel Nershing Thapa',
+      displayPictureUrl:
+        'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBeFJheFE9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--a765e2377a288bccae85da6604300251d9de6d39/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2RkhKbGMybDZaVjkwYjE5c2FXMXBkRnNIYVdscGFRPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--1d22b8d446683a272d1a9ff04340453ca7c374b4/bitmoji.jpg',
+      projectId: null,
+      projectTitle: null,
+      taskId: null,
+      messageType: 'REQUEST_TEAM_NOTIFICATION',
+      sentDate: '2023-01-09T16:42:16.168030Z',
+      read: true,
+    },
+    {
+      messageId: 759703,
+      subject:
+        'You have been added to team <a href="https://tasks-stage.hotosm.org/teams/9/membership/">Notification Test</a>',
+      message:
+        'You have been added  to the team <a href="https://tasks-stage.hotosm.org/teams/9/membership/">Notification Test</a> as MEMBER by <a href="https://tasks-stage.hotosm.org/users/helnershingthapa">helnershingthapa</a>.            Access the <a href="https://tasks-stage.hotosm.org/teams/9/membership/">Notification Test</a>\'s page to view more info about this team.',
+      fromUsername: 'helnershingthapa',
+      displayPictureUrl:
+        'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXQ2Q3c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fe41f1b2a5d6cf492a7133f15c81f105dec06ff7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBPZ2h3Ym1jNkZISmxjMmw2WlY5MGIxOXNhVzFwZEZzSGFXbHBhUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--058ac785867b32287d598a314311e2253bd879a3/unnamed.webp',
+      projectId: null,
+      projectTitle: null,
+      taskId: null,
+      messageType: 'INVITATION_NOTIFICATION',
+      sentDate: '2023-01-02T07:59:27.129271Z',
+      read: true,
+    },
+    {
+      messageId: 759606,
+      subject: 'Test',
+      message:
+        'A message from <a href="https://tasks-stage.hotosm.org/users/Aadesh Baral">Aadesh Baral</a>, manager of <a href="https://tasks-stage.hotosm.org/teams/9/membership/">Notification Test</a> team:<br/><br/><p>Hello</p>',
+      fromUsername: 'Aadesh Baral',
+      displayPictureUrl:
+        'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXFHQ1E9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--aed68fa4deb4e4eeba02e233b68881c4c9d84ab8/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2RkhKbGMybDZaVjkwYjE5c2FXMXBkRnNIYVdscGFRPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--1d22b8d446683a272d1a9ff04340453ca7c374b4/89986176_1424302844399685_1705928282320404480_n.jpg',
+      projectId: null,
+      projectTitle: null,
+      taskId: null,
+      messageType: 'TEAM_BROADCAST',
+      sentDate: '2022-12-02T09:53:52.231791Z',
+      read: true,
+    },
+    {
+      messageId: 759600,
+      subject: 'Test',
+      message:
+        'A message from <a href="https://tasks-stage.hotosm.org/users/Aadesh Baral">Aadesh Baral</a>, manager of <a href="https://tasks-stage.hotosm.org/teams/9/membership/">Notification Test</a> team:<br/><br/><p>Hello</p>',
+      fromUsername: 'Aadesh Baral',
+      displayPictureUrl:
+        'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXFHQ1E9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--aed68fa4deb4e4eeba02e233b68881c4c9d84ab8/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBTU0lJYW5CbkJqb0dSVlE2RkhKbGMybDZaVjkwYjE5c2FXMXBkRnNIYVdscGFRPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--1d22b8d446683a272d1a9ff04340453ca7c374b4/89986176_1424302844399685_1705928282320404480_n.jpg',
+      projectId: null,
+      projectTitle: null,
+      taskId: null,
+      messageType: 'TEAM_BROADCAST',
+      sentDate: '2022-12-02T09:53:51.664913Z',
+      read: true,
+    },
+  ],
+};

--- a/frontend/src/network/tests/server-handlers.js
+++ b/frontend/src/network/tests/server-handlers.js
@@ -48,6 +48,8 @@ import { homepageStats } from './mockData/homepageStats';
 import { countries } from './mockData/miscellaneous';
 import tasksGeojson from '../../utils/tests/snippets/tasksGeometry';
 import { API_URL } from '../../config';
+import { notifications, ownCountUnread } from './mockData/notifications';
+import { authLogin, setUser, userRegister } from './mockData/auth';
 
 const handlers = [
   rest.get(API_URL + 'projects/:id/queries/summary/', async (req, res, ctx) => {
@@ -76,8 +78,28 @@ const handlers = [
   rest.get(API_URL + 'projects/queries/:username/touched', async (req, res, ctx) => {
     return res(ctx.json(userTouchedProjects));
   }),
+  // AUTHENTICATION
+  rest.get(API_URL + 'system/authentication/login/', async (req, res, ctx) => {
+    return res(ctx.json(authLogin));
+  }),
+  rest.post(API_URL + 'users/actions/register/', async (req, res, ctx) => {
+    return res(ctx.json(userRegister));
+  }),
+  rest.patch(API_URL + 'users/me/actions/set-user/', async (req, res, ctx) => {
+    return res(ctx.json(setUser));
+  }),
+  // NOTIFICATIONS
+  rest.get(API_URL + 'notifications', async (req, res, ctx) => {
+    return res(ctx.json(notifications));
+  }),
+  rest.get(API_URL + 'notifications/queries/own/count-unread/', async (req, res, ctx) => {
+    return res(ctx.json(ownCountUnread));
+  }),
   rest.delete(API_URL + 'notifications/delete-multiple/', async (req, res, ctx) => {
     return res(ctx.json({ Success: 'Message deleted' }));
+  }),
+  rest.post(API_URL + 'notifications/queries/own/post-unread/', async (req, res, ctx) => {
+    return res(ctx.json(null));
   }),
   // USER
   rest.get(API_URL + 'users/statistics/', async (req, res, ctx) => {

--- a/frontend/src/utils/mockMatchMedia.js
+++ b/frontend/src/utils/mockMatchMedia.js
@@ -1,0 +1,14 @@
+// Imported from https://jestjs.io/docs/26.x/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});

--- a/frontend/src/views/notifications.js
+++ b/frontend/src/views/notifications.js
@@ -28,7 +28,7 @@ function serializeParams(queryState) {
 
 export const NotificationPopout = (props) => {
   // Small screen size, as defined by tachyons
-  let smallScreenSize = !window.matchMedia('(min-width: 30em)').matches;
+  let smallScreenSize = !window.matchMedia('(min-width: 30em)')?.matches;
   // Notification popout position and margin. The popout is anchored outside of the screen and centered on small screens.
   const popoutPosition = {
     left: `${smallScreenSize ? '-2rem' : Math.max(0, props.position - 320).toString() + 'px'}`,


### PR DESCRIPTION
This PR does the following:

- Updates tests for the header and its components.
- Not display privacy policy link text if the `ORG_PRIVACY_POLICY_URL` is absent as an environment variable.
- Converts Header and UpdateEmail dialog from class components to functional components.
- Removes redundant NavLink component and a couple of other dead codes.
- Adds mock request handlers to mock API endpoints in the header section.

The coverage report is below, with the greens considered adequate for merging to develop 😏😕

![coverage-header](https://user-images.githubusercontent.com/51614993/215701551-537ba04e-bf4a-4fe9-8dbf-801571015aca.png)
