### PR TITLE
Add textfield to search for team members on the team detail page

### DIFF
--- a/frontend/src/components/teamsAndOrgs/messages.js
+++ b/frontend/src/components/teamsAndOrgs/messages.js
@@ -409,6 +409,10 @@ export default defineMessages({
     id: 'management.placeholder.search_users',
     defaultMessage: 'Search for Tasking Manager users',
   },
+  searchMembers: {
+    id: 'management.placeholder.search_members',
+    defaultMessage: 'Search team members...',
+  },
   save: {
     id: 'management.button.save',
     defaultMessage: 'Save',

--- a/frontend/src/components/teamsAndOrgs/teams.js
+++ b/frontend/src/components/teamsAndOrgs/teams.js
@@ -303,6 +303,14 @@ export function TeamForm(props) {
 
 export function TeamSideBar({ team, members, managers, requestedToJoin }: Object) {
   const [isUserTeamManager] = useEditTeamAllowed(team);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const searchMembers = () =>
+    searchQuery !== ''
+      ? members.filter((member) => {
+          return member.username.toLowerCase().includes(searchQuery.toLowerCase());
+        })
+      : members;
 
   return (
     <ReactPlaceholder
@@ -360,9 +368,9 @@ export function TeamSideBar({ team, members, managers, requestedToJoin }: Object
             </span>
           ) : (
             <div className="cf db mt3">
-              {managers.map((user, n) => (
+              {managers.map((user) => (
                 <UserAvatar
-                  key={n}
+                  key={user.username}
                   username={user.username}
                   picture={user.pictureUrl}
                   size="large"
@@ -379,16 +387,26 @@ export function TeamSideBar({ team, members, managers, requestedToJoin }: Object
               <FormattedMessage {...messages.noMembers} />
             </span>
           ) : (
-            <div className="cf db mt3">
-              {members.map((user, n) => (
-                <UserAvatar
-                  key={n}
-                  username={user.username}
-                  picture={user.pictureUrl}
-                  colorClasses="white bg-blue-grey mv1"
-                />
-              ))}
-            </div>
+            <>
+              <div className="cf db mt3">
+                <div className="mb3 w5">
+                  <TextField
+                    value={searchQuery}
+                    placeholderMsg={messages.searchMembers}
+                    onChange={({ target: { value } }) => setSearchQuery(value)}
+                    onCloseIconClick={() => setSearchQuery('')}
+                  />
+                </div>
+                {searchMembers().map((user) => (
+                  <UserAvatar
+                    key={user.username}
+                    username={user.username}
+                    picture={user.pictureUrl}
+                    colorClasses="white bg-blue-grey mv1"
+                  />
+                ))}
+              </div>
+            </>
           )}
           <div className="cf db mt3">
             {requestedToJoin && (

--- a/frontend/src/components/teamsAndOrgs/tests/teams.test.js
+++ b/frontend/src/components/teamsAndOrgs/tests/teams.test.js
@@ -10,9 +10,9 @@ import {
   IntlProviders,
   renderWithRouter,
 } from '../../../utils/testWithIntl';
-import { TeamBox, TeamsBoxList, TeamsManagement, Teams, TeamCard } from '../teams';
+import { TeamBox, TeamsBoxList, TeamsManagement, Teams, TeamCard, TeamSideBar } from '../teams';
 import { store } from '../../../store';
-import { teams } from '../../../network/tests/mockData/teams';
+import { teams, team } from '../../../network/tests/mockData/teams';
 
 const dummyTeams = [
   {
@@ -396,5 +396,28 @@ describe('Team Card', () => {
       }),
     ).toBeInTheDocument();
     ['Private', 'By invite'].forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
+  });
+});
+
+describe('TeamSideBar component', () => {
+  it('should search for users by search query', async () => {
+    render(
+      <ReduxIntlProviders>
+        <TeamSideBar team={team} managers={[]} members={team.members} />
+      </ReduxIntlProviders>,
+    );
+    const inputField = screen.getByRole('textbox');
+    expect(inputField).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {
+        name: team.members[0].username,
+      }),
+    ).toBeInTheDocument();
+    await userEvent.type(inputField, 'not_sample_user');
+    expect(
+      screen.queryByRole('link', {
+        name: team.members[0].username,
+      }),
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Resolves the first task from #3115 

![search-members](https://user-images.githubusercontent.com/51614993/215962505-82d6bb33-9868-49f6-ae19-c3eefaecbc3c.gif)
