### PR TITLE
Fix project header boxes to be next to project title

### DIFF
--- a/frontend/src/components/projectDetail/header.js
+++ b/frontend/src/components/projectDetail/header.js
@@ -52,16 +52,18 @@ export const ProjectHeader = ({ project, showEditLink }: Object) => {
         organisation={project.organisationName}
         showEditLink={showEditLink && userCanEditProject}
       />
-      <h3
-        className="f2 fw5 mt3 mt2-ns mb3 ttu barlow-condensed blue-dark dib"
-        lang={project.projectInfo.locale}
-      >
-        {project.projectInfo && project.projectInfo.name}
-      </h3>
-      {project.private && <ProjectVisibilityBox className={'pv2 ph3 ml3 mb3 v-mid dib'} />}
-      {['DRAFT', 'ARCHIVED'].includes(project.status) && (
-        <ProjectStatusBox status={project.status} className={'pv2 ph3 ml3 mb3 v-mid dib'} />
-      )}
+      <div>
+        <h3
+          className="f2 fw5 mt3 mt2-ns mb3 ttu barlow-condensed blue-dark dib mr3"
+          lang={project.projectInfo.locale}
+        >
+          {project.projectInfo && project.projectInfo.name}
+        </h3>
+        {project.private && <ProjectVisibilityBox className="pv2 ph3 mb3 mr3 v-mid dib" />}
+        {['DRAFT', 'ARCHIVED'].includes(project.status) && (
+          <ProjectStatusBox status={project.status} className="pv2 ph3 mb3 v-mid dib mr3" />
+        )}
+      </div>
       <TagLine
         campaigns={project.campaigns}
         countries={


### PR DESCRIPTION
Fixes styling to align project status and project visibility boxes next to the project title

_Issue:_
![incorrect](https://user-images.githubusercontent.com/51614993/215988538-4dc10c4a-6263-4100-8be6-3d82a0ef81a5.png)

_Fix:_
![correct](https://user-images.githubusercontent.com/51614993/215988540-b245052e-e8ab-4a64-9ae3-58abdd69d965.png)
