### PR TITLE
Update nav learn link to not have type param

### DIFF
--- a/frontend/src/components/header/index.js
+++ b/frontend/src/components/header/index.js
@@ -164,7 +164,7 @@ export function getMenuItemsForUser(userDetails, organisations) {
       authenticated: true,
     },
     { label: messages.manage, link: 'manage', authenticated: true, manager: true },
-    { label: messages.learn, link: 'learn/map', showAlways: true },
+    { label: messages.learn, link: 'learn', showAlways: true },
     { label: messages.about, link: 'about', showAlways: true },
   ];
 

--- a/frontend/src/components/header/tests/menuItems.test.js
+++ b/frontend/src/components/header/tests/menuItems.test.js
@@ -3,28 +3,28 @@ import { SERVICE_DESK } from '../../../config';
 
 it('test menuItems for unlogged user', () => {
   const userDetails = {};
-  const menuItems = ['explore', 'learn/map', 'about'];
+  const menuItems = ['explore', 'learn', 'about'];
   if (SERVICE_DESK) menuItems.push(SERVICE_DESK);
   expect(getMenuItemsForUser(userDetails, []).map((i) => i.link)).toEqual(menuItems);
 });
 
 it('test menuItems for logged non admin user', () => {
   const userDetails = { username: 'test', role: 'MAPPER' };
-  const menuItems = ['explore', 'contributions', 'learn/map', 'about'];
+  const menuItems = ['explore', 'contributions', 'learn', 'about'];
   if (SERVICE_DESK) menuItems.push(SERVICE_DESK);
   expect(getMenuItemsForUser(userDetails, []).map((i) => i.link)).toEqual(menuItems);
 });
 
 it('test menuItems for logged non admin user, but org manager', () => {
   const userDetails = { username: 'test', role: 'MAPPER' };
-  const menuItems = ['explore', 'contributions', 'manage', 'learn/map', 'about'];
+  const menuItems = ['explore', 'contributions', 'manage', 'learn', 'about'];
   if (SERVICE_DESK) menuItems.push(SERVICE_DESK);
   expect(getMenuItemsForUser(userDetails, [1, 3, 4]).map((i) => i.link)).toEqual(menuItems);
 });
 
 it('test menuItems for logged admin user', () => {
   const userDetails = { username: 'test', role: 'ADMIN' };
-  const menuItems = ['explore', 'contributions', 'manage', 'learn/map', 'about'];
+  const menuItems = ['explore', 'contributions', 'manage', 'learn', 'about'];
   if (SERVICE_DESK) menuItems.push(SERVICE_DESK);
   expect(getMenuItemsForUser(userDetails, []).map((i) => i.link)).toEqual(menuItems);
 });


### PR DESCRIPTION
![learn-border-b](https://user-images.githubusercontent.com/51614993/216242092-28acf641-29b4-45cc-a6d0-17844cfd8280.gif)

The indicator, the underline, for the active page disappears even if the page is a sub-section of the learn page. This PR fixes that.