### PR TITLE
Bump use-query-params from 1.2.2 to 2.1.2 in /frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,7 +69,7 @@
     "slug": "^5.1.0",
     "tachyons": "^4.12.0",
     "tributejs": "^5.1.3",
-    "use-query-params": "^1.2.2",
+    "use-query-params": "^2.1.2",
     "webfontloader": "^1.6.28",
     "workbox-core": "^6.1.5",
     "workbox-expiration": "^6.1.5",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 import React, { Suspense, useEffect } from 'react';
-import { Router, Redirect, globalHistory } from '@reach/router';
+import { Router, Redirect } from '@reach/router';
 import { QueryParamProvider } from 'use-query-params';
+import { ReachAdapter } from 'use-query-params/adapters/reach';
 import ReactPlaceholder from 'react-placeholder';
 import { useMeta } from 'react-meta-elements';
 import { connect } from 'react-redux';
@@ -88,7 +89,7 @@ let App = (props) => {
             <Suspense
               fallback={<ReactPlaceholder showLoadingAnimation={true} rows={30} delay={300} />}
             >
-              <QueryParamProvider reachHistory={globalHistory}>
+              <QueryParamProvider adapter={ReachAdapter}>
                 <Router primary={false}>
                   <Home path="/" />
                   <ProjectsPage path="explore">

--- a/frontend/src/components/contributions/tests/myTasksNav.test.js
+++ b/frontend/src/components/contributions/tests/myTasksNav.test.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
-import { globalHistory } from '@reach/router';
+import { ReachAdapter } from 'use-query-params/adapters/reach';
 import { QueryParamProvider } from 'use-query-params';
 
 import { MyTasksNav, isActiveButton } from '../myTasksNav';
@@ -9,7 +9,7 @@ import { ReduxIntlProviders } from '../../../utils/testWithIntl';
 describe('MyTasksNav Component', () => {
   it('should display details', async () => {
     render(
-      <QueryParamProvider reachHistory={globalHistory}>
+      <QueryParamProvider adapter={ReachAdapter}>
         <ReduxIntlProviders>
           <MyTasksNav />
         </ReduxIntlProviders>
@@ -46,7 +46,7 @@ describe('MyTasksNav Component', () => {
   //   // with the updated values in the test, which would have caused
   //   // the 'Clear filters' button to appear. Uncomment to try
   //   renderWithRouter(
-  //     <QueryParamProvider reachHistory={globalHistory}>
+  //     <QueryParamProvider adapter={ReachAdapter}>
   //       <ReduxIntlProviders>
   //         <MyTasksNav />
   //       </ReduxIntlProviders>

--- a/frontend/src/components/projects/tests/myProjectNav.test.js
+++ b/frontend/src/components/projects/tests/myProjectNav.test.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
-import { globalHistory } from '@reach/router';
+import { ReachAdapter } from 'use-query-params/adapters/reach';
 import { QueryParamProvider } from 'use-query-params';
 import { act, render, screen, waitFor } from '@testing-library/react';
 
@@ -18,7 +18,7 @@ describe('Manage Projects Top Navigation Bar', () => {
     });
 
     const { container } = render(
-      <QueryParamProvider reachHistory={globalHistory}>
+      <QueryParamProvider adapter={ReachAdapter}>
         <ReduxIntlProviders>
           <MyProjectNav management={false} />
         </ReduxIntlProviders>
@@ -57,7 +57,7 @@ describe('Manage Projects Top Navigation Bar', () => {
     });
 
     const { container } = render(
-      <QueryParamProvider reachHistory={globalHistory}>
+      <QueryParamProvider adapter={ReachAdapter}>
         <ReduxIntlProviders>
           <MyProjectNav management />
         </ReduxIntlProviders>
@@ -83,7 +83,7 @@ describe('Manage Projects Top Navigation Bar', () => {
 
   it('should navigate to new project creation page on button click', async () => {
     const { history } = renderWithRouter(
-      <QueryParamProvider reachHistory={globalHistory}>
+      <QueryParamProvider adapter={ReachAdapter}>
         <ReduxIntlProviders>
           <MyProjectNav management />
         </ReduxIntlProviders>

--- a/frontend/src/views/tests/contributions.test.js
+++ b/frontend/src/views/tests/contributions.test.js
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { act, screen, render, waitFor } from '@testing-library/react';
-import { globalHistory } from '@reach/router';
+import { ReachAdapter } from 'use-query-params/adapters/reach';
 import { QueryParamProvider } from 'use-query-params';
 
 import { store } from '../../store';
@@ -18,13 +18,13 @@ describe('Contributions Page', () => {
     });
 
     renderWithRouter(
-      <QueryParamProvider reachHistory={globalHistory}>
+      <QueryParamProvider adapter={ReachAdapter}>
         <ReduxIntlProviders>
           <ContributionsPage navigate={navigateMock} />
         </ReduxIntlProviders>
       </QueryParamProvider>,
     );
-    
+
     await waitFor(() => expect(navigateMock).toHaveBeenCalled());
   });
 
@@ -38,7 +38,7 @@ describe('Contributions Page', () => {
     });
 
     renderWithRouter(
-      <QueryParamProvider reachHistory={globalHistory}>
+      <QueryParamProvider adapter={ReachAdapter}>
         <ReduxIntlProviders>
           <ContributionsPage />
         </ReduxIntlProviders>

--- a/frontend/src/views/tests/project.test.js
+++ b/frontend/src/views/tests/project.test.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
-import { globalHistory } from '@reach/router';
+import { ReachAdapter } from 'use-query-params/adapters/reach';
 import { QueryParamProvider } from 'use-query-params';
 import { act, render, screen, waitFor } from '@testing-library/react';
 
@@ -17,7 +17,7 @@ describe('UserProjectsPage Component', () => {
     });
 
     renderWithRouter(
-      <QueryParamProvider reachHistory={globalHistory}>
+      <QueryParamProvider adapter={ReachAdapter}>
         <ReduxIntlProviders>
           <UserProjectsPage navigate={navigateMock} management={false} />
         </ReduxIntlProviders>
@@ -33,7 +33,7 @@ describe('UserProjectsPage Component', () => {
     });
 
     renderWithRouter(
-      <QueryParamProvider reachHistory={globalHistory}>
+      <QueryParamProvider adapter={ReachAdapter}>
         <ReduxIntlProviders>
           <UserProjectsPage management={false} />
         </ReduxIntlProviders>
@@ -61,7 +61,7 @@ describe('UserProjectsPage Component', () => {
     });
 
     renderWithRouter(
-      <QueryParamProvider reachHistory={globalHistory}>
+      <QueryParamProvider adapter={ReachAdapter}>
         <ReduxIntlProviders>
           <UserProjectsPage management={false} />
         </ReduxIntlProviders>
@@ -82,7 +82,7 @@ describe('ManageProjectsPage', () => {
     });
 
     render(
-      <QueryParamProvider reachHistory={globalHistory}>
+      <QueryParamProvider adapter={ReachAdapter}>
         <ReduxIntlProviders>
           <ManageProjectsPage />
         </ReduxIntlProviders>
@@ -102,7 +102,7 @@ describe('ManageProjectsPage', () => {
       store.dispatch({ type: 'TOGGLE_MAP' });
     });
     render(
-      <QueryParamProvider reachHistory={globalHistory}>
+      <QueryParamProvider adapter={ReachAdapter}>
         <ReduxIntlProviders>
           <ManageProjectsPage />
         </ReduxIntlProviders>

--- a/frontend/src/views/tests/stats.test.js
+++ b/frontend/src/views/tests/stats.test.js
@@ -1,8 +1,9 @@
 import '@testing-library/jest-dom';
 import { render, screen, waitFor, act } from '@testing-library/react';
-import { globalHistory } from '@reach/router';
-import { ReduxIntlProviders } from '../../utils/testWithIntl';
 import { QueryParamProvider } from 'use-query-params';
+import { ReachAdapter } from 'use-query-params/adapters/reach';
+
+import { ReduxIntlProviders } from '../../utils/testWithIntl';
 import { store } from '../../store';
 
 import { Stats } from '../stats';
@@ -13,7 +14,7 @@ describe('Overall styats page', () => {
       store.dispatch({ type: 'SET_TOKEN', token: 'validToken' });
     });
     render(
-      <QueryParamProvider reachHistory={globalHistory}>
+      <QueryParamProvider adapter={ReachAdapter}>
         <ReduxIntlProviders>
           <Stats />
         </ReduxIntlProviders>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -14617,10 +14617,10 @@ serialize-javascript@^5.0.1:
   dependencies:
     randombytes "^2.1.0"
 
-serialize-query-params@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-1.3.3.tgz"
-  integrity sha512-rJIIETRuGUVbLekC73IiXV3738ylEHbHK1kxaXAbhxbxfio0yvVXaRMF+OyLZOBMwdgDHYLaj6EMBAEiSf8C/g==
+serialize-query-params@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-2.0.2.tgz#598a3fb9e13f4ea1c1992fbd20231aa16b31db81"
+  integrity sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q==
 
 serve-index@^1.9.1:
   version "1.9.1"
@@ -16068,12 +16068,12 @@ use-isomorphic-layout-effect@^1.1.2:
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
   integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
 
-use-query-params@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/use-query-params/-/use-query-params-1.2.2.tgz"
-  integrity sha512-Uyfe+/TECsNNzCSkgUM1MM24OEGxGE4aeWvZEf0a14iQFp/m43wiqI1HZ9oTlrRSZwD5yABeLc9rN+wtiB5B3Q==
+use-query-params@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/use-query-params/-/use-query-params-2.1.2.tgz#0bd100a0839e5195106cfb291b43d2159618ca9d"
+  integrity sha512-evg64srKaILvKyRQ1zpXvekTC7rktAT7OAekU7x6naHrOMqLHtq0MHR/PtKIQAP4d7HrkYNVOS8exHhiWy7m3A==
   dependencies:
-    serialize-query-params "^1.3.3"
+    serialize-query-params "^2.0.2"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
This PR does the following:

- Bump use-query-params from 1.2.2 to 2.1.2 in /frontend
- Utilize `ReachAdapter` from use-query-params as its adapter; replaces `globalHistory`.