### PR TITLE
Add organisation tests

### DIFF
--- a/backend/api/organisations/resources.py
+++ b/backend/api/organisations/resources.py
@@ -45,8 +45,6 @@ class OrganisationsBySlugRestAPI(Resource):
         responses:
             200:
                 description: Organisation found
-            401:
-                description: Unauthorized - Invalid credentials
             404:
                 description: Organisation not found
             500:
@@ -151,7 +149,7 @@ class OrganisationsRestAPI(Resource):
         except OrganisationServiceError as e:
             return {"Error": str(e).split("-")[1], "SubCode": str(e).split("-")[0]}, 400
         except Exception as e:
-            error_msg = f"Organisation PUT - unhandled error: {str(e)}"
+            error_msg = f"Organisation POST - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)
             return {"Error": error_msg, "SubCode": "InternalServerError"}, 500
 

--- a/tests/backend/integration/api/organisations/test_campaigns.py
+++ b/tests/backend/integration/api/organisations/test_campaigns.py
@@ -1,0 +1,157 @@
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import (
+    create_canned_organisation,
+    create_canned_project,
+    generate_encoded_token,
+    return_canned_user,
+    return_canned_campaign,
+)
+
+CAMPAIGN_NAME = "New Campaign"
+CAMPAIGN_ID = 2
+
+
+class TestOrganisationsCampaignsAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_org = create_canned_organisation()
+        self.endpoint_url = f"/api/v2/organisations/{self.test_org.id}/campaigns/"
+        self.test_campaign = return_canned_campaign()
+        self.test_campaign.create()
+        self.test_project, self.test_author = create_canned_project()
+        self.test_user = return_canned_user("test_user", 11111111)
+        self.test_user.create()
+        self.test_org.managers = [self.test_author]
+        self.test_org.campaign = [self.test_campaign]
+        self.test_org.save()
+        self.test_author_session_token = generate_encoded_token(self.test_author.id)
+        self.test_user_session_token = generate_encoded_token(self.test_user.id)
+
+    # post
+    def test_add_already_assigned_campaign_to_same_org_fails(self):
+        """
+        Test that the endpoint returns 400 if the campaign had already been assigned to the organisation
+        """
+        response = self.client.post(
+            f"/api/v2/organisations/{self.test_org.id}/campaigns/{self.test_campaign.id}/",
+            json={
+                "logo": None,
+                "name": "Test Campaign",
+                "organisations": [self.test_org.id],
+                "url": None,
+            },
+            headers={"Authorization": self.test_author_session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response_body["Error"], "Campaign 1 is already assigned to organisation 23."
+        )
+        self.assertEqual(response_body["SubCode"], "CampaignAlreadyAssigned")
+
+    def test_assign_org_new_campaign_passes(self):
+        """
+        Test that the endpoint returns 200 when a new campaign is assigned to the organisation
+        """
+        new_campaign = return_canned_campaign(
+            id=2, name=CAMPAIGN_NAME, description=None, logo=None
+        )
+        new_campaign.create()
+        response = self.client.post(
+            f"/api/v2/organisations/{self.test_org.id}/campaigns/{new_campaign.id}/",
+            json={
+                "logo": None,
+                "name": CAMPAIGN_NAME,
+                "organisations": [self.test_org.id],
+                "url": None,
+            },
+            headers={"Authorization": self.test_author_session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response_body["Success"],
+            "campaign with id 2 assigned for organisation with id 23",
+        )
+
+    def test_non_org_admin_assigns_new_campaign_to_org_fails(self):
+        """
+        Test that the endpoint returns 403 when a non admin tries to add a new campaign to an organisation
+        """
+        new_campaign = return_canned_campaign(
+            id=2, name=CAMPAIGN_NAME, description=None, logo=None
+        )
+        new_campaign.create()
+        response = self.client.post(
+            f"/api/v2/organisations/{self.test_org.id}/campaigns/{new_campaign.id}/",
+            json={
+                "logo": None,
+                "name": CAMPAIGN_NAME,
+                "organisations": [self.test_org.id],
+                "url": None,
+            },
+            headers={"Authorization": self.test_user_session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response_body["Error"], "User is not a manager of the organisation"
+        )
+        self.assertEqual(response_body["SubCode"], "UserNotPermitted")
+
+    # get
+    def test_get_organisation_campaigns_passes(self):
+        """
+        Test that the endpoint returns 200 when retrieving organisation campaigns
+        """
+        response = self.client.get(self.endpoint_url)
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response_body, {"campaigns": [{"id": 1, "name": "Test Campaign"}]}
+        )
+
+    def test_get_non_existent_organisation_campaigns_fails(self):
+        """
+        Test that the endpoint returns 404 when retrieving campaigns for non existent organisation
+        """
+        response = self.client.get(f"{self.endpoint_url}98/campaigns/")
+        self.assertEqual(response.status_code, 404)
+
+    # delete
+    def test_delete_organisation_campaign_by_admin_passes(self):
+        """Test that the endpoint returns 200 and unassigns a campaign from an organisation"""
+        response = self.client.delete(
+            f"/api/v2/organisations/{self.test_org.id}/campaigns/{self.test_campaign.id}/",
+            headers={"Authorization": self.test_author_session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response_body,
+            {"Success": "Organisation and campaign unassociated successfully"},
+        )
+
+    def test_delete_organisation_campaign_non_admin_fails(self):
+        """Test that the endpoint returns 403 when a non admin attempts to delete an organisation campaign"""
+        response = self.client.delete(
+            f"/api/v2/organisations/{self.test_org.id}/campaigns/{self.test_campaign.id}/",
+            headers={"Authorization": self.test_user_session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response_body["Error"], "User is not a manager of the organisation"
+        )
+        self.assertEqual(response_body["SubCode"], "UserNotPermitted")
+
+    def test_delete_non_existent_organisation_campaign_fails(self):
+        """Tests that the endpoint returns 404 when the org admin deletes a non existent campaign"""
+        response = self.client.delete(
+            f"/api/v2/organisations/{self.test_org.id}/campaigns/5/",
+            headers={"Authorization": self.test_author_session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], "Organisation Campaign Not Found")
+        self.assertEqual(response_body["SubCode"], "NotFound")

--- a/tests/backend/integration/api/organisations/test_resources.py
+++ b/tests/backend/integration/api/organisations/test_resources.py
@@ -4,9 +4,17 @@ from tests.backend.base import BaseTestCase, db
 from tests.backend.helpers.test_helpers import (
     create_canned_organisation,
     create_canned_project,
+    create_canned_user,
     add_manager_to_organisation,
+    generate_encoded_token,
+    return_canned_user,
 )
 from backend.services.users.authentication_service import AuthenticationService
+
+
+TEST_USER_ID = 777777
+TEST_USERNAME = "Thinkwhere Test"
+ORG_NOT_FOUND = "Organisation Not Found"
 
 
 class TestOrganisationAllAPI(BaseTestCase):
@@ -80,3 +88,302 @@ class TestOrganisationAllAPI(BaseTestCase):
         response_body = response.json["organisations"]
 
         self.assertEqual(response_body[0]["stats"]["projects"]["draft"], 1)
+
+
+class TestOrganisationsBySlugRestAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_user = create_canned_user()
+        self.test_org = create_canned_organisation()
+        self.session_token = generate_encoded_token(self.test_user.id)
+        self.endpoint_url = f"/api/v2/organisations/{self.test_org.slug}/"
+
+    def test_get_org_by_slug_by_without_token_passes(self):
+        """
+        Test that endpoint returns 200 and and organisation details
+        """
+        response = self.client.get(self.endpoint_url)
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response_body), 12)
+        self.assertEqual(response_body["organisationId"], self.test_org.id)
+        self.assertEqual(response_body["name"], self.test_org.name)
+        self.assertEqual(response_body["slug"], self.test_org.slug)
+        self.assertEqual(response_body["name"], self.test_org.name)
+        self.assertEqual(response_body["logo"], None)
+        self.assertEqual(response_body["description"], None)
+        self.assertEqual(response_body["url"], None)
+        self.assertEqual(response_body["teams"], [])
+        self.assertEqual(response_body["campaigns"], None)
+        self.assertEqual(response_body["type"], "FREE")
+        self.assertEqual(response_body["subscriptionTier"], None)
+
+    def test_get_org_by_slug_by_authorised_user_and_omitManagerList_is_false_passes(
+        self,
+    ):
+        """
+        Test that endpoint returns 200 and organisation details including manager details
+        """
+        add_manager_to_organisation(self.test_org, self.test_user)
+        response = self.client.get(
+            self.endpoint_url, headers={"Authorization": self.session_token}
+        )  # by default, omitManagerList=False"
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response_body), 12)
+        self.assertEqual(response_body["organisationId"], self.test_org.id)
+        # Manager list included
+        self.assertEqual(len(response_body["managers"]), 1)
+        self.assertEqual(
+            response_body["managers"],
+            [{"username": TEST_USERNAME, "pictureUrl": None}],
+        )
+
+    def test_get_org_by_slug_by_authorised_user_and_omitManagerList_is_true_passes(
+        self,
+    ):
+        """
+        Test that endpoint returns 200 and organisation details excluding manager details
+        """
+        add_manager_to_organisation(self.test_org, self.test_user)
+        response = self.client.get(
+            f"{self.endpoint_url}?omitManagerList=True",
+            headers={"Authorization": self.session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response_body), 12)
+        self.assertEqual(response_body["organisationId"], self.test_org.id)
+        # Manager list omitted
+        self.assertEqual(len(response_body["managers"]), 0)
+        self.assertEqual(response_body["managers"], [])
+
+    def test_get_non_existent_org_by_slug_fails(self):
+        """
+        Test that endpoint returns 404 when queried for non existent organisation
+        """
+        response = self.client.get("/api/v2/organisations/random-organisation/")
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(len(response_body), 2)
+        self.assertEqual(response_body["Error"], ORG_NOT_FOUND)
+        self.assertEqual(response_body["SubCode"], "NotFound")
+
+
+class TestOrganisationsRestAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_project, self.test_author = create_canned_project()
+        self.test_org = create_canned_organisation()
+        self.test_org.managers = [self.test_author]
+        self.test_org.save()
+        self.endpoint_url = "/api/v2/organisations/"
+        self.session_token = generate_encoded_token(self.test_author.id)
+
+    # post method tests
+    def test_create_org_by_unauthenticated_user_fails(self):
+        """
+        Tests that endpoint returns 401 when unauthenticated user tries to create a new org
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={"name": "New Org", "slug": "new-org", "managers": ["Test User"]},
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_create_org_with_non_admin_fails(self):
+        """
+        Tests that endpoint returns 403 when non admin tries to create a new org
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            headers={"Authorization": self.session_token},
+            json={
+                "name": "New Org",
+                "slug": "new-org",
+                "logo": None,
+                "managers": [TEST_USERNAME],
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response_body["Error"], "Only admin users can create organisations."
+        )
+        self.assertEqual(response_body["SubCode"], "OnlyAdminAccess")
+
+    # get organisation
+    def test_get_org_when_omitManagerList_is_false_passes(self):
+        """
+        Test that endpoint returns 200 while retrieving an organisation by id when omitManagersList is false
+        """
+        response = self.client.get(
+            f"{self.endpoint_url}{self.test_org.id}/",
+            headers={"Authorization": self.session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["organisationId"], 23)
+        self.assertEqual(len(response_body["managers"]), 1)
+        self.assertEqual(
+            response_body["managers"],
+            [{"username": TEST_USERNAME, "pictureUrl": None}],
+        )
+
+    def test_get_non_existent_org_fails(self):
+        """
+        Test that endpoint returns 404 when queried for non-existent org by id
+        """
+        response = self.client.get(
+            f"{self.endpoint_url}99/",
+            headers={"Authorization": self.session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], ORG_NOT_FOUND)
+        self.assertEqual(response_body["SubCode"], "NotFound")
+
+    # delete method tests
+    def test_delete_org_by_admin_user_passes(self):
+        """
+        Test that endpoint returns 200 after deleting existing organisation by org admin
+        """
+        response = self.client.delete(
+            f"{self.endpoint_url}{self.test_org.id}/",
+            headers={"Authorization": self.session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["Success"], "Organisation deleted")
+
+    def test_delete_item_by_non_admin_user_fails(self):
+        """
+        Test that endpoint returns 403 when deleting existing organisation by non org admin
+        """
+        non_admin = return_canned_user(username="Random User", id=2222)
+        non_admin.create()
+        non_admin_token = generate_encoded_token(non_admin.id)
+        response = self.client.delete(
+            f"/api/v2/organisations/{self.test_org.id}/",
+            headers={"Authorization": non_admin_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response_body["Error"], "User is not an admin for the org")
+        self.assertEqual(response_body["SubCode"], "UserNotOrgAdmin")
+
+    def test_delete_org_with_projects_fails(self):
+        """
+        Test that endpoint returns 403 when trying to delete organisation with projects
+        """
+        self.test_project.organisation = self.test_org
+        self.test_project.save()
+        response = self.client.delete(
+            f"{self.endpoint_url}{self.test_org.id}/",
+            headers={"Authorization": self.session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response_body["Error"], "Organisation has some projects")
+        self.assertEqual(response_body["SubCode"], "OrgHasProjects")
+
+    # patch
+    def test_update_org_details_by_admin_passes(self):
+        """
+        Tests that endpoint returns 200 when admin successfully updates an organisation's details
+        """
+        response = self.client.patch(
+            f"{self.endpoint_url}{self.test_org.id}/",
+            headers={"Authorization": self.session_token},
+            json={
+                "name": "HOT",
+                "slug": "hot",
+                "logo": None,
+                "managers": [TEST_USERNAME],
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body, {"Status": "Updated"})
+
+    def test_update_org_details_by_non_admin_fails(self):
+        """
+        Tests that endpoint returns 403 when non admin tries to update an organisation's details
+        """
+        non_admin = return_canned_user(username="New User", id=444)
+        non_admin.create()
+        non_admin_token = generate_encoded_token(non_admin.id)
+        response = self.client.patch(
+            f"{self.endpoint_url}{self.test_org.id}/",
+            headers={"Authorization": non_admin_token},
+            json={
+                "name": "HOT",
+                "slug": "hot",
+                "logo": None,
+                "managers": [TEST_USERNAME],
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response_body["Error"], "User is not an admin for the org")
+        self.assertEqual(response_body["SubCode"], "UserNotOrgAdmin")
+
+    def test_update_org_details_with_invalid_data_fails(self):
+        """
+        Tests that endpoint returns 400 when admin tries to  update an organisation's details using invalid keys
+        """
+        response = self.client.patch(
+            f"{self.endpoint_url}{self.test_org.id}/",
+            headers={"Authorization": self.session_token},
+            json={
+                "org_name": "HOT",
+                "org_slug": "hot",
+                "org_logo": None,
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+
+
+class TestOrganisationsStatsAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_org = create_canned_organisation()
+        self.test_project, self.test_author = create_canned_project()
+        self.test_org.save()
+        self.test_project.organisation = self.test_org
+        self.test_project.save()
+        self.endpoint_url = f"/api/v2/organisations/{self.test_org.id}/statistics/"
+
+    def test_get_org_statistics_passes(self):
+        """
+        Tests that endpoint returns 200 when retrieving an organisation's statistics
+        """
+        response = self.client.get(self.endpoint_url)
+        self.assertEqual(response.status_code, 200)
+        response_body = response.get_json()
+        self.assertEqual(
+            response_body["projects"],
+            {"draft": 1, "published": 0, "archived": 0, "recent": 0, "stale": 0},
+        )
+        self.assertEqual(
+            response_body["activeTasks"],
+            {
+                "badImagery": 0,
+                "invalidated": 0,
+                "lockedForMapping": 0,
+                "lockedForValidation": 0,
+                "mapped": 0,
+                "ready": 0,
+                "validated": 0,
+            },
+        )
+
+    def test_get_non_existent_org_statistics_fails(self):
+        """
+        Tests that endpoint returns 404 when retrieving a non existent organisation's statistics
+        """
+        response = self.client.get("/api/v2/organisations/99/statistics/")
+        self.assertEqual(response.status_code, 404)
+        response_body = response.get_json()
+        self.assertEqual(response_body["Error"], ORG_NOT_FOUND)
+        self.assertEqual(response_body["SubCode"], "NotFound")


### PR DESCRIPTION
This PR handles organisation-related API endpoint tests. 

How to test:
- create a test database following the instructions [here](https://github.com/hotosm/tasking-manager/blob/develop/docs-old/setup-development.md#create-the-database-user-and-database). The database name is preceded by `test_`
- pull and checkout test branch using `git fetch && git checkout chore/organisations-tests`
- run tests using `python3 -m unittest discover tests/backend`