### PR TITLE
Add tests for endpoints associated with the tasks  section

### DIFF
--- a/backend/api/tasks/resources.py
+++ b/backend/api/tasks/resources.py
@@ -545,23 +545,20 @@ class TasksQueriesOwnInvalidatedAPI(Resource):
         try:
             sort_column = {"updatedDate": "updated_date", "projectId": "project_id"}
             if request.args.get("sortBy", "updatedDate") in sort_column:
-                sort_column = sort_column[request.args.get("SortBy", "updatedDate")]
+                sort_column = sort_column[request.args.get("sortBy", "updatedDate")]
             else:
                 sort_column = sort_column["updatedDate"]
-
             # closed needs to be set to True, False, or None
             closed = None
             if request.args.get("closed") == "true":
                 closed = True
             elif request.args.get("closed") == "false":
                 closed = False
-
             # sort direction should only be desc or asc
             if request.args.get("sortDirection") in ["asc", "desc"]:
                 sort_direction = request.args.get("sortDirection")
             else:
                 sort_direction = "desc"
-
             invalidated_tasks = ValidatorService.get_user_invalidated_tasks(
                 request.args.get("asValidator") == "true",
                 username,

--- a/backend/api/tasks/resources.py
+++ b/backend/api/tasks/resources.py
@@ -466,8 +466,17 @@ class TasksQueriesMappedAPI(Resource):
                 description: Internal Server Error
         """
         try:
+            ProjectService.get_project_by_id(project_id)
             mapped_tasks = ValidatorService.get_mapped_tasks_by_user(project_id)
             return mapped_tasks.to_primitive(), 200
+        except NotFound:
+            return (
+                {
+                    "Error": "Not found; please check the project number.",
+                    "SubCode": "NotFound",
+                },
+                404,
+            )
         except Exception as e:
             error_msg = f"Task Lock API - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)

--- a/backend/api/tasks/statistics.py
+++ b/backend/api/tasks/statistics.py
@@ -64,13 +64,17 @@ class TasksStatisticsAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            start_date = validate_date_input(request.args.get("startDate"))
+            if request.args.get("startDate"):
+                start_date = validate_date_input(request.args.get("startDate"))
+            else:
+                return {
+                    "Error": "Start date is required",
+                    "SubCode": "MissingDate",
+                }, 400
             end_date = validate_date_input(request.args.get("endDate", date.today()))
-            if not (start_date):
-                raise KeyError("MissingDate- Missing start date parameter")
             if end_date < start_date:
                 raise ValueError(
-                    "InvalidStartDate- Start date must be earlier than end date"
+                    "InvalidDateRange- Start date must be earlier than end date"
                 )
             if (end_date - start_date) > timedelta(days=366):
                 raise ValueError(

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -33,4 +33,4 @@ def validate_date_input(input_date):
             input_date = datetime.strptime(input_date, "%Y-%m-%d").date()
         return input_date
     except (TypeError, ValueError):
-        raise ValueError("Invalid date value")
+        raise ValueError("InvalidDateValue- Invalid date value")

--- a/backend/services/mapping_service.py
+++ b/backend/services/mapping_service.py
@@ -66,7 +66,7 @@ class MappingService:
             last_action = TaskHistory.get_last_action(task.project_id, task.id)
 
             # User requesting task made the last change, so they are allowed to undo it.
-            is_user_permitted, _ = ProjectService.is_user_permitted_to_map(
+            is_user_permitted, _ = ProjectService.is_user_permitted_to_validate(
                 task.project_id, logged_in_user_id
             )
             if last_action.user_id == int(logged_in_user_id) or is_user_permitted:

--- a/backend/services/mapping_service.py
+++ b/backend/services/mapping_service.py
@@ -66,11 +66,10 @@ class MappingService:
             last_action = TaskHistory.get_last_action(task.project_id, task.id)
 
             # User requesting task made the last change, so they are allowed to undo it.
-            if last_action.user_id == int(
-                logged_in_user_id
-            ) or ProjectService.is_user_permitted_to_validate(
+            is_user_permitted, _ = ProjectService.is_user_permitted_to_map(
                 task.project_id, logged_in_user_id
-            ):
+            )
+            if last_action.user_id == int(logged_in_user_id) or is_user_permitted:
                 return True
 
         return False
@@ -331,7 +330,6 @@ class MappingService:
     ) -> TaskDTO:
         """Allows a user to Undo the task state they updated"""
         task = MappingService.get_task(task_id, project_id)
-
         if not MappingService._is_task_undoable(user_id, task):
             raise MappingServiceError(
                 "UndoPermissionError- Undo not allowed for this user"

--- a/backend/services/validator_service.py
+++ b/backend/services/validator_service.py
@@ -97,7 +97,7 @@ class ValidatorService:
                     )
             else:
                 raise ValidatorServiceError(
-                    f"Validation not allowed because: {error_reason}"
+                    f"ValidtionNotAllowed- Validation not allowed because: {error_reason}"
                 )
 
         # Lock all tasks for validation

--- a/tests/backend/api/tasks/test_resources.py
+++ b/tests/backend/api/tasks/test_resources.py
@@ -1,0 +1,156 @@
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import (
+    create_canned_project,
+    return_canned_user,
+    create_canned_organisation,
+    generate_encoded_token,
+    add_manager_to_organisation,
+)
+
+from backend.models.postgis.statuses import UserRole
+from backend.services.project_service import ProjectService
+
+
+class TestGetTasksQueriesJsonAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_project, self.test_author = create_canned_project()
+        self.url = f"/api/v2/projects/{self.test_project.id}/tasks/"
+
+    def test_returns_404_if_project_does_not_exist(self):
+        """ Test that a 404 is returned if the project does not exist. """
+        # Act
+        response = self.client.get("/api/projects/999/tasks")
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_all_tasks_if_task_ids_not_specified(self):
+        """ Test that all tasks are returned if no task_ids are specified. """
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json.keys(), {"type", "features"})
+        self.assertEqual(response.json["type"], "FeatureCollection")
+        self.assertEqual(len(response.json["features"]), 4)
+
+    def test_returns_only_specified_tasks_if_task_ids_specified(self):
+        """ Test that only the specified tasks are returned if task_ids are specified. """
+        # Act
+        response = self.client.get(self.url + "?tasks=1,2")
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["features"]), 2)
+        self.assertEqual(response.json["features"][0]["properties"]["taskId"], 1)
+        self.assertEqual(response.json["features"][1]["properties"]["taskId"], 2)
+
+    def test_returns_tasks_as_file_id_as_file_set_true(self):
+        """ Test that the tasks are returned with the file_id as the file if file_set is true. """
+        # Act
+        response = self.client.get(self.url + "?as_file=true")
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["Content-Type"], "application/json")
+        self.assertEqual(
+            response.headers["Content-Disposition"],
+            f"attachment; filename={self.test_project.id}-tasks.geojson",
+        )
+        self.assertEqual(response.json.keys(), {"type", "features"})
+        self.assertEqual(response.json["type"], "FeatureCollection")
+        self.assertEqual(len(response.json["features"]), 4)
+
+
+class TestDeleteTasksJsonAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_project, self.test_author = create_canned_project()
+        self.url = f"/api/v2/projects/{self.test_project.id}/tasks/"
+        self.test_user = return_canned_user("test_user", 11111)
+        self.test_user.create()
+        self.test_user_access_token = generate_encoded_token(self.test_user.id)
+        self.test_author_access_token = generate_encoded_token(self.test_author.id)
+        self.test_organization = create_canned_organisation()
+        self.test_project.organization = self.test_organization
+        self.test_project.save()
+
+    def test_returns_401_if_not_authorized(self):
+        """ Test that a 401 is returned if the user is not authorized. """
+        # Act
+        response = self.client.delete(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_403_if_user_not_admin(self):
+        """ Test that a 403 is returned if the user is not a project manager. """
+        # Act
+        response = self.client.delete(
+            self.url, headers={"Authorization": self.test_user_access_token}
+        )
+        # Assert
+        self.assertEqual(response.status_code, 403)
+
+    def test_returns_404_if_project_does_not_exist(self):
+        """ Test that a 404 is returned if the project does not exist. """
+        # Act
+        response = self.client.delete("/api/projects/999/tasks")
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    def test_even_org_manager_cannot_delete_tasks(self):
+        """ Test that an org manager cannot delete tasks. """
+        # Arrange
+        add_manager_to_organisation(self.test_organization, self.test_user)
+        # Act
+        response = self.client.delete(
+            self.url, headers={"Authorization": self.test_user_access_token}
+        )
+        # Assert
+        self.assertEqual(response.status_code, 403)
+
+    def test_returns_400_if_no_task_ids_specified(self):
+        """ Test that a 400 is returned if no task_ids are specified. """
+        # Arrange
+        self.test_user.role = UserRole.ADMIN.value
+        self.test_user.save()
+        # Act
+        response = self.client.delete(
+            self.url,
+            headers={"Authorization": self.test_user_access_token},
+            json={},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 400)
+
+    def test_returns_404_if_task_not_found(self):
+        """ Test that a 400 is returned if the task is not found. """
+        # Arrange
+        self.test_user.role = UserRole.ADMIN.value
+        self.test_user.save()
+        # Act
+        response = self.client.delete(
+            self.url,
+            headers={"Authorization": self.test_user_access_token},
+            json={"tasks": [999]},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    def test_deletes_specified_tasks_if_user_admin(self):
+        """ Test that the specified tasks are deleted. """
+        # Arrange
+        self.test_user.role = UserRole.ADMIN.value
+        self.test_user.save()
+        # Act
+        response = self.client.delete(
+            self.url,
+            headers={"Authorization": self.test_user_access_token},
+            json={"tasks": [1, 2]},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        project_tasks = ProjectService.get_project_tasks(self.test_project.id, None)
+        self.assertEqual(len(project_tasks["features"]), 2)
+        self.assertEqual(project_tasks["features"][0]["properties"]["taskId"], 3)
+        self.assertEqual(project_tasks["features"][1]["properties"]["taskId"], 4)
+
+

--- a/tests/backend/api/tasks/test_resources.py
+++ b/tests/backend/api/tasks/test_resources.py
@@ -1,3 +1,5 @@
+import xml.etree.ElementTree as ET
+
 from tests.backend.base import BaseTestCase
 from tests.backend.helpers.test_helpers import (
     create_canned_project,
@@ -7,8 +9,9 @@ from tests.backend.helpers.test_helpers import (
     add_manager_to_organisation,
 )
 
-from backend.models.postgis.statuses import UserRole
+from backend.models.postgis.statuses import UserRole, TaskStatus
 from backend.services.project_service import ProjectService
+from backend.models.postgis.task import Task
 
 
 class TestGetTasksQueriesJsonAPI(BaseTestCase):
@@ -154,3 +157,183 @@ class TestDeleteTasksJsonAPI(BaseTestCase):
         self.assertEqual(project_tasks["features"][1]["properties"]["taskId"], 4)
 
 
+class TestTaskRestAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_project, self.test_author = create_canned_project()
+        self.test_author_access_token = generate_encoded_token(self.test_author.id)
+        self.url = f"/api/v2/projects/{self.test_project.id}/tasks/1/"
+
+    def test_returrns_404_if_project_does_not_exist(self):
+        """ Test that a 404 is returned if the project does not exist. """
+        # Act
+        response = self.client.get("/api/projects/999/tasks/1")
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_404_if_task_does_not_exist(self):
+        """ Test that a 404 is returned if the task does not exist. """
+        # Act
+        response = self.client.get(f"/api/projects/{self.test_project.id}/tasks/999")
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_200_if_task_exists(self):
+        """ Test that a 200 is returned if the task exists. """
+        # Lets add task history
+        task = Task.get(1, self.test_project.id)
+        task.lock_task_for_validating(self.test_author.id)
+        task.unlock_task(self.test_author.id, TaskStatus.VALIDATED, "Test comment")
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            set(response.json.keys()),
+            set(
+                {
+                    "taskId",
+                    "projectId",
+                    "taskStatus",
+                    "taskHistory",
+                    "taskAnnotation",
+                    "perTaskInstructions",
+                    "autoUnlockSeconds",
+                    "lastUpdated",
+                    "numberOfComments",
+                }
+            ),
+        )
+        self.assertEqual(response.json["taskId"], 1)
+        self.assertEqual(response.json["projectId"], self.test_project.id)
+        self.assertEqual(response.json["taskStatus"], TaskStatus.VALIDATED.name)
+        self.assertEqual(len(response.json["taskHistory"]), 3)
+        self.assertEqual(
+            response.json["taskHistory"][2]["action"], "LOCKED_FOR_VALIDATION"
+        )
+        self.assertEqual(response.json["taskHistory"][1]["action"], "COMMENT")
+        self.assertEqual(response.json["taskHistory"][0]["action"], "STATE_CHANGE")
+
+
+class TestTasksQueriesGpxAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_project, self.test_author = create_canned_project()
+        self.test_author_access_token = generate_encoded_token(self.test_author.id)
+        self.url = f"/api/v2/projects/{self.test_project.id}/tasks/queries/gpx/"
+
+    def test_returns_404_if_project_does_not_exist(self):
+        """ Test that a 404 is returned if the project does not exist. """
+        # Act
+        response = self.client.get("/api/projects/999/tasks/queries/gpx")
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_all_tasks_if_no_tasks_specified(self):
+        """ Test that all tasks are returned if no tasks are specified. """
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        ns = {"gpx": "http://www.topografix.com/GPX/1/1"}
+        self.assertEqual(response.status_code, 200)
+        response_xml = ET.fromstring(response.get_data(as_text=True))
+        self.assertEqual(
+            response_xml.attrib, {"version": "1.1", "creator": "HOT Tasking Manager"}
+        )
+        trk = response_xml.find("gpx:trk", namespaces=ns)
+        self.assertEqual(
+            trk.find("gpx:name", ns).text,
+            f"Task for project {self.test_project.id}. Do not edit outside of this area!",
+        )
+        self.assertEqual(
+            len([i for i in trk.findall("gpx:trkseg", ns)]), 4
+        )  # Since project has 4 tasks
+
+    def test_returns_gpx_for_specified_tasks(self):
+        """ Test that the specified tasks are returned. """
+        # Act
+        response = self.client.get(self.url + "?tasks=1,2")
+        # Assert
+        ns = {"gpx": "http://www.topografix.com/GPX/1/1"}
+        self.assertEqual(response.status_code, 200)
+        response_xml = ET.fromstring(response.get_data(as_text=True))
+        self.assertEqual(
+            response_xml.attrib, {"version": "1.1", "creator": "HOT Tasking Manager"}
+        )
+        trk = response_xml.find("gpx:trk", namespaces=ns)
+        self.assertEqual(
+            trk.find("gpx:name", ns).text,
+            f"Task for project {self.test_project.id}. Do not edit outside of this area!",
+        )
+        self.assertEqual(
+            len([i for i in trk.findall("gpx:trkseg", ns)]), 2
+        )  # Since we only asked for tasks 1 and 2
+
+    def test_returns_file_if_as_file_set_true(self):
+        """ Test that the file is returned if the as_file parameter is set to true. """
+        # Act
+        response = self.client.get(self.url + "?as_file=true")
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["Content-Type"], "text.xml")
+        self.assertEqual(
+            response.headers["Content-Disposition"],
+            f"attachment; filename=HOT-project-{self.test_project.id}.gpx",
+        )
+
+
+class TestTasksQueriesXmlAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_project, self.test_author = create_canned_project()
+        self.test_author_access_token = generate_encoded_token(self.test_author.id)
+        self.url = f"/api/v2/projects/{self.test_project.id}/tasks/queries/xml/"
+
+    def test_returns_404_if_project_does_not_exist(self):
+        """ Test that a 404 is returned if the project does not exist. """
+        # Act
+        response = self.client.get("/api/projects/999/tasks/queries/xml")
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_all_tasks_if_no_tasks_specified(self):
+        """ Test that all tasks are returned if no tasks are specified. """
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        response_xml = ET.fromstring(response.get_data(as_text=True))
+        self.assertEqual(
+            response_xml.attrib,
+            {"version": "0.6", "upload": "never", "creator": "HOT Tasking Manager"},
+        )
+        self.assertEqual(
+            len([i for i in response_xml.findall("way")]), 4
+        )  # Since project has 4 tasks
+
+    def test_returns_xml_for_specified_tasks(self):
+        """ Test that the specified tasks are returned. """
+        # Act
+        response = self.client.get(self.url + "?tasks=1,2")
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        response_xml = ET.fromstring(response.get_data(as_text=True))
+        self.assertEqual(
+            response_xml.attrib,
+            {"version": "0.6", "upload": "never", "creator": "HOT Tasking Manager"},
+        )
+        self.assertEqual(
+            len([i for i in response_xml.findall("way")]), 2
+        )  # Since we are only requesting 2 tasks
+
+    def test_returns_file_if_as_file_set_true(self):
+        """ Test that the file is returned if the as_file parameter is set to true. """
+        # Act
+        response = self.client.get(self.url + "?as_file=true")
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["Content-Type"], "text.xml")
+        self.assertEqual(
+            response.headers["Content-Disposition"],
+            f"attachment; filename=HOT-project-{self.test_project.id}.osm",
+        )

--- a/tests/backend/base.py
+++ b/tests/backend/base.py
@@ -19,7 +19,9 @@ class BaseTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        db.session.remove()
         cls.db.drop_all()
+        cls.db.get_engine(cls.app).dispose()
         super(BaseTestCase, cls).tearDownClass()
 
     def setUp(self):
@@ -27,11 +29,11 @@ class BaseTestCase(unittest.TestCase):
         self.client = self.app.test_client()
         self.app_context = self.app.app_context()
         self.app_context.push()
+        self.db.session.begin(subtransactions=True)
         clean_db(self.db)
 
     def tearDown(self):
         super(BaseTestCase, self).tearDown()
         self.db.session.rollback()
-        self.app_context.pop()
         self.db.session.close()
-        self.db.engine.dispose()
+        self.app_context.pop()

--- a/tests/backend/base.py
+++ b/tests/backend/base.py
@@ -34,3 +34,4 @@ class BaseTestCase(unittest.TestCase):
         self.db.session.rollback()
         self.app_context.pop()
         self.db.session.close()
+        self.db.engine.dispose()

--- a/tests/backend/base.py
+++ b/tests/backend/base.py
@@ -33,3 +33,4 @@ class BaseTestCase(unittest.TestCase):
         super(BaseTestCase, self).tearDown()
         self.db.session.rollback()
         self.app_context.pop()
+        self.db.session.close()

--- a/tests/backend/helpers/test_helpers.py
+++ b/tests/backend/helpers/test_helpers.py
@@ -23,6 +23,8 @@ from backend.models.postgis.user import User
 from backend.models.postgis.organisation import Organisation
 from backend.services.users.authentication_service import AuthenticationService
 from backend.services.interests_service import InterestService, Interest
+from backend.services.license_service import LicenseService, LicenseDTO
+
 
 TEST_USER_ID = 777777
 TEST_USERNAME = "Thinkwhere Test"
@@ -332,3 +334,13 @@ def create_canned_interest(name="test_interest") -> Interest:
     """Returns test interest without writing to db"""
     test_interest = InterestService.create(name=name)
     return test_interest
+
+
+def create_canned_license(name="test_license") -> int:
+    """Returns test license without writing to db"""
+    license_dto = LicenseDTO()
+    license_dto.name = name
+    license_dto.description = "test license"
+    license_dto.plain_text = "test license"
+    test_license = LicenseService.create_licence(license_dto)
+    return test_license

--- a/tests/backend/integration/api/tasks/test_actions.py
+++ b/tests/backend/integration/api/tasks/test_actions.py
@@ -1,12 +1,15 @@
 from unittest.mock import patch
-from backend.models.postgis.statuses import TaskStatus
+from backend.models.postgis.statuses import TaskStatus, MappingNotAllowed, ProjectStatus
 
 from backend.services.project_admin_service import ProjectAdminService
+from backend.services.project_service import ProjectService
+from backend.services.users.user_service import UserService
 from tests.backend.base import BaseTestCase
 from tests.backend.helpers.test_helpers import (
     create_canned_project,
     return_canned_user,
     generate_encoded_token,
+    create_canned_license,
 )
 from backend.models.postgis.task import Task
 
@@ -304,3 +307,135 @@ class TasksActionsResetAllAPI(BaseTestCase):
         self.assertEqual(self.test_project.tasks_mapped, 0)
         self.assertEqual(self.test_project.tasks_validated, 0)
         self.assertEqual(self.test_project.tasks_bad_imagery, 0)
+
+
+class TestTasksActionsMappingLockAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_project, _ = create_canned_project()
+        self.url = (
+            f"/api/v2/projects/{self.test_project.id}/tasks/actions/lock-for-mapping/1/"
+        )
+        self.test_user = return_canned_user(username="Test User", id=11111)
+        self.test_user.create()
+        self.user_session_token = generate_encoded_token(self.test_user.id)
+
+    def test_mapping_lock_returns_401_for_unauthorized_request(self):
+        # Arrange
+        "Test returns 401 on request without session token."
+        # Act
+        response = self.client.post(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_mapping_lock_returns_404_for_invalid_project_id(self):
+        # Arrange
+        "Test returns 404 on request with invalid project id."
+        # Act
+        response = self.client.post(
+            "/api/v2/projects/999999/tasks/actions/lock-for-mapping/1/",
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json["SubCode"], "NotFound")
+
+    def test_mapping_lock_returns_404_for_invalid_task_id(self):
+        # Arrange
+        "Test returns 404 on request with invalid task id."
+        # Act
+        response = self.client.post(
+            f"/api/v2/projects/{self.test_project.id}/tasks/actions/lock-for-mapping/999999/",
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json["SubCode"], "NotFound")
+
+    @patch.object(ProjectService, "is_user_permitted_to_map")
+    def test_mapping_lock_returns_403_for_if_user_not_allowed_to_map(
+        self, mock_permitted
+    ):
+        "Test returns 403 on request by user who doesn't have required permission to map."
+        # Arrange
+        mock_permitted.return_value = False, MappingNotAllowed.PROJECT_NOT_PUBLISHED
+        task = Task.get(1, self.test_project.id)
+        task.task_status = TaskStatus.READY.value
+        task.update()
+        # Act
+        response = self.client.post(
+            self.url, headers={"Authorization": self.user_session_token}
+        )
+        # Assert
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json["SubCode"], "ProjectNotPublished")
+
+    @patch.object(ProjectAdminService, "is_user_action_permitted_on_project")
+    def test_mapping_lock_returns_403_if_task_in_invalid_state_for_mapping(
+        self, mock_pm_role
+    ):
+        """ Test returns 403 if task is in invalid state for mapping. i.e. not in READY or INVALIDATED state. """
+        # Arrange
+        mock_pm_role.return_value = True
+        # Act
+        response = self.client.post(
+            self.url, headers={"Authorization": self.user_session_token}
+        )
+        # Assert
+        # As Task 1 is in MAPPED state, it should not be allowed to be locked for mapping.
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json["SubCode"], "InvalidTaskState")
+
+        # Arrange
+        # Change task state to VALIDATED
+        self.test_project.tasks[0].task_status = TaskStatus.VALIDATED.value
+        self.test_project.tasks[0].update()
+        # Act
+        response = self.client.post(
+            self.url, headers={"Authorization": self.user_session_token}
+        )
+        # Assert
+        # As Task 1 is in VALIDATED state, it should not be allowed to be locked for mapping.
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json["SubCode"], "InvalidTaskState")
+
+    @patch.object(UserService, "has_user_accepted_license")
+    def test_mapping_lock_returns_403_if_project_licence_not_accepted(
+        self, mock_accepted
+    ):
+        """ Test returns 403 if project licence is not accepted. """
+        # Arrange
+        mock_accepted.return_value = False
+        self.test_project.status = ProjectStatus.PUBLISHED.value
+        self.test_project.license_id = create_canned_license()
+        self.test_project.save()
+        task = Task.get(1, self.test_project.id)
+        task.task_status = TaskStatus.READY.value
+        task.update()
+        # Act
+        response = self.client.post(
+            self.url, headers={"Authorization": self.user_session_token}
+        )
+        # Assert
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json["SubCode"], "UserLicenseError")
+
+    @patch.object(ProjectService, "is_user_permitted_to_map")
+    def test_mapping_lock_is_allowed_for_user_with_pm_role(self, mock_permitted):
+        # Arrange
+        mock_permitted.return_value = True, "User allowed to map"
+        task = Task.get(1, self.test_project.id)
+        task.task_status = TaskStatus.READY.value
+        task.update()
+        # Act
+        response = self.client.post(
+            self.url, headers={"Authorization": self.user_session_token}
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["taskId"], 1)
+        self.assertEqual(response.json["projectId"], self.test_project.id)
+        self.assertEqual(
+            response.json["taskStatus"], TaskStatus.LOCKED_FOR_MAPPING.name
+        )
+        self.assertEqual(response.json["lockHolder"], self.test_user.username)

--- a/tests/backend/integration/api/tasks/test_actions.py
+++ b/tests/backend/integration/api/tasks/test_actions.py
@@ -11,7 +11,7 @@ from tests.backend.helpers.test_helpers import (
     generate_encoded_token,
     create_canned_license,
 )
-from backend.models.postgis.task import Task
+from backend.models.postgis.task import Task, TaskAction
 
 
 class TasksActionsMapAllAPI(BaseTestCase):
@@ -24,7 +24,7 @@ class TasksActionsMapAllAPI(BaseTestCase):
         self.user_session_token = generate_encoded_token(self.test_user.id)
 
     def test_map_all_tasks_returns_401_for_unauthorized_request(self):
-        "Test returns 401 on request without session token."
+        """Test returns 401 on request without session token."""
 
         # Act
         response = self.client.post(self.url)
@@ -33,7 +33,7 @@ class TasksActionsMapAllAPI(BaseTestCase):
 
     @patch.object(ProjectAdminService, "is_user_action_permitted_on_project")
     def test_map_all_tasks_returns_403_for_non_PM_role_request(self, mock_pm_role):
-        "Test returns 403 on request by user without PM role"
+        """Test returns 403 on request by user without PM role"""
 
         # Arrange
         mock_pm_role.return_value = False
@@ -47,6 +47,7 @@ class TasksActionsMapAllAPI(BaseTestCase):
 
     @patch.object(ProjectAdminService, "is_user_action_permitted_on_project")
     def test_map_all_tasks_is_allowed_for_user_with_pm_role(self, mock_pm_role):
+        """Test returns 200 on request by user with PM role and all tasks are mapped"""
         # Arrange
         init_ready_tasks = Task.get_tasks_by_status(
             self.test_project.id, TaskStatus.READY.name
@@ -82,8 +83,7 @@ class TasksActionsValidateAllAPI(BaseTestCase):
         self.user_session_token = generate_encoded_token(self.test_user.id)
 
     def test_validate_all_tasks_returns_401_for_unauthorized_request(self):
-        # Arrange
-        "Test returns 401 on request without session token."
+        """Test returns 401 on request without session token."""
         # Act
         response = self.client.post(self.url)
         # Assert
@@ -91,7 +91,7 @@ class TasksActionsValidateAllAPI(BaseTestCase):
 
     @patch.object(ProjectAdminService, "is_user_action_permitted_on_project")
     def test_validate_all_tasks_returns_403_for_non_PM_role_request(self, mock_pm_role):
-        "Test returns 403 on request by user without PM role"
+        """Test returns 403 on request by user without PM role"""
 
         # Arrange
         mock_pm_role.return_value = False
@@ -105,6 +105,7 @@ class TasksActionsValidateAllAPI(BaseTestCase):
 
     @patch.object(ProjectAdminService, "is_user_action_permitted_on_project")
     def test_validate_all_tasks_is_allowed_for_user_with_pm_role(self, mock_pm_role):
+        """Test returns 200 on request by user with PM role and all tasks are validated"""
         # Arrange
         init_mapped_tasks = Task.get_tasks_by_status(
             self.test_project.id, TaskStatus.MAPPED.name
@@ -137,8 +138,7 @@ class TasksActionsInvalidateAllAPI(BaseTestCase):
         self.user_session_token = generate_encoded_token(self.test_user.id)
 
     def test_invalidate_all_tasks_returns_401_for_unauthorized_request(self):
-        # Arrange
-        "Test returns 401 on request without session token."
+        """Test returns 401 on request without session token."""
         # Act
         response = self.client.post(self.url)
         # Assert
@@ -148,7 +148,7 @@ class TasksActionsInvalidateAllAPI(BaseTestCase):
     def test_invalidate_all_tasks_returns_403_for_non_PM_role_request(
         self, mock_pm_role
     ):
-        "Test returns 403 on request by user without PM role"
+        """Test returns 403 on request by user without PM role"""
 
         # Arrange
         mock_pm_role.return_value = False
@@ -162,6 +162,7 @@ class TasksActionsInvalidateAllAPI(BaseTestCase):
 
     @patch.object(ProjectAdminService, "is_user_action_permitted_on_project")
     def test_invalidate_all_tasks_is_allowed_for_user_with_pm_role(self, mock_pm_role):
+        """Test that all tasks with status of validated are invalidated"""
         # Arrange
         validated_tasks = Task.get_tasks_by_status(
             self.test_project.id, TaskStatus.VALIDATED.name
@@ -197,8 +198,7 @@ class TasksActionsResetBadImageryAllAPI(BaseTestCase):
         self.user_session_token = generate_encoded_token(self.test_user.id)
 
     def test_reset_all_badimagery_tasks_returns_401_for_unauthorized_request(self):
-        # Arrange
-        "Test returns 401 on request without session token."
+        """Test returns 401 on request without session token."""
         # Act
         response = self.client.post(self.url)
         # Assert
@@ -208,7 +208,7 @@ class TasksActionsResetBadImageryAllAPI(BaseTestCase):
     def test_reset_all_badimagery_tasks_returns_403_for_non_PM_role_request(
         self, mock_pm_role
     ):
-        "Test returns 403 on request by user without PM role"
+        """Test returns 403 on request by user without PM role"""
 
         # Arrange
         mock_pm_role.return_value = False
@@ -224,6 +224,7 @@ class TasksActionsResetBadImageryAllAPI(BaseTestCase):
     def test_reset_all_badimagery_tasks_is_allowed_for_user_with_pm_role(
         self, mock_pm_role
     ):
+        """Test returns 200 on request by user with PM role and resets all bad imagery tasks to ready"""
         # Arrange
         init_bad_imagery_tasks = Task.get_tasks_by_status(
             self.test_project.id, TaskStatus.BADIMAGERY.name
@@ -253,8 +254,7 @@ class TasksActionsResetAllAPI(BaseTestCase):
         self.user_session_token = generate_encoded_token(self.test_user.id)
 
     def test_reset_all_tasks_returns_401_for_unauthorized_request(self):
-        # Arrange
-        "Test returns 401 on request without session token."
+        """Test returns 401 on request without session token."""
         # Act
         response = self.client.post(self.url)
         # Assert
@@ -276,6 +276,7 @@ class TasksActionsResetAllAPI(BaseTestCase):
 
     @patch.object(ProjectAdminService, "is_user_action_permitted_on_project")
     def test_reset_all_tasks_is_allowed_for_user_with_pm_role(self, mock_pm_role):
+        """ Test returns 200 on request by user with PM role and resets all tasks to ready """
         # Arrange
         init_non_ready_tasks = []
         for status in [
@@ -321,16 +322,14 @@ class TestTasksActionsMappingLockAPI(BaseTestCase):
         self.user_session_token = generate_encoded_token(self.test_user.id)
 
     def test_mapping_lock_returns_401_for_unauthorized_request(self):
-        # Arrange
-        "Test returns 401 on request without session token."
+        """Test returns 401 on request without session token."""
         # Act
         response = self.client.post(self.url)
         # Assert
         self.assertEqual(response.status_code, 401)
 
     def test_mapping_lock_returns_404_for_invalid_project_id(self):
-        # Arrange
-        "Test returns 404 on request with invalid project id."
+        """Test returns 404 on request with invalid project id."""
         # Act
         response = self.client.post(
             "/api/v2/projects/999999/tasks/actions/lock-for-mapping/1/",
@@ -341,8 +340,7 @@ class TestTasksActionsMappingLockAPI(BaseTestCase):
         self.assertEqual(response.json["SubCode"], "NotFound")
 
     def test_mapping_lock_returns_404_for_invalid_task_id(self):
-        # Arrange
-        "Test returns 404 on request with invalid task id."
+        """Test returns 404 on request with invalid task id."""
         # Act
         response = self.client.post(
             f"/api/v2/projects/{self.test_project.id}/tasks/actions/lock-for-mapping/999999/",
@@ -356,7 +354,7 @@ class TestTasksActionsMappingLockAPI(BaseTestCase):
     def test_mapping_lock_returns_403_for_if_user_not_allowed_to_map(
         self, mock_permitted
     ):
-        "Test returns 403 on request by user who doesn't have required permission to map."
+        """Test returns 403 on request by user who doesn't have required permission to map."""
         # Arrange
         mock_permitted.return_value = False, MappingNotAllowed.PROJECT_NOT_PUBLISHED
         task = Task.get(1, self.test_project.id)
@@ -421,7 +419,10 @@ class TestTasksActionsMappingLockAPI(BaseTestCase):
         self.assertEqual(response.json["SubCode"], "UserLicenseError")
 
     @patch.object(ProjectService, "is_user_permitted_to_map")
-    def test_mapping_lock_is_allowed_for_user_with_pm_role(self, mock_permitted):
+    def test_mapping_lock_is_allowed_for_user_with_mapping_permission(
+        self, mock_permitted
+    ):
+        """ Test returns 200 if user has mapping permission. """
         # Arrange
         mock_permitted.return_value = True, "User allowed to map"
         task = Task.get(1, self.test_project.id)
@@ -439,3 +440,159 @@ class TestTasksActionsMappingLockAPI(BaseTestCase):
             response.json["taskStatus"], TaskStatus.LOCKED_FOR_MAPPING.name
         )
         self.assertEqual(response.json["lockHolder"], self.test_user.username)
+
+
+class TestTasksActionsMappingUnlockAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_project, self.test_author = create_canned_project()
+        self.test_user = return_canned_user("Test User", 1111111)
+        self.test_user.create()
+        self.user_session_token = generate_encoded_token(self.test_user.id)
+        self.url = f"/api/v2/projects/{self.test_project.id}/tasks/actions/unlock-after-mapping/1/"
+
+    def test_mapping_unlock_returns_401_for_unauthenticated_user(self):
+        """Test returns 401 on request from unauthenticated user."""
+        # Act
+        response = self.client.post(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_mapping_unlock_returns_400_if_invalid_data(self):
+        """Test returns 404 on request with invalid data."""
+        # Act
+        response = self.client.post(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            json={
+                "status": "test"
+            },  # Since valid status are MAPPED, INVALIDATED, BADIMAGERY
+        )
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["SubCode"], "InvalidData")
+
+    def test_mapping_unlock_returns_404_for_invalid_project_id(self):
+        """Test returns 404 on request with invalid project id."""
+        # Act
+        response = self.client.post(
+            "/api/v2/projects/999999/tasks/actions/unlock-after-mapping/1/",
+            headers={"Authorization": self.user_session_token},
+            json={"status": "MAPPED"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json["SubCode"], "NotFound")
+
+    def test_mapping_unlock_returns_404_for_invalid_task_id(self):
+        """Test returns 404 on request with invalid task id."""
+        # Act
+        response = self.client.post(
+            f"/api/v2/projects/{self.test_project.id}/tasks/actions/unlock-after-mapping/999999/",
+            headers={"Authorization": self.user_session_token},
+            json={"status": "MAPPED"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json["SubCode"], "NotFound")
+
+    def test_mapping_unlock_returns_403_if_task_not_locked_for_mapping(self):
+        """Test returns 403 if task is not locked for mapping."""
+        # Act
+        response = self.client.post(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            json={"status": "MAPPED"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json["SubCode"], "LockBeforeUnlocking")
+
+    def test_mapping_unlock_returns_403_if_task_locked_by_other_user(self):
+        """Test returns 403 if task is locked by other user."""
+        # Arrange
+        task = Task.get(1, self.test_project.id)
+        task.task_status = TaskStatus.LOCKED_FOR_MAPPING.value
+        task.locked_by = self.test_author.id
+        task.update()
+        # Act
+        response = self.client.post(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            json={"status": "MAPPED"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json["SubCode"], "TaskNotOwned")
+
+    def test_returns_403_if_invalid_new_state_passed(self):
+        """Test returns 403 if invalid new state passed as new task state should be READY, MAPPED or BADIMAGERY."""
+        # Arrange
+        task = Task.get(1, self.test_project.id)
+        task.task_status = TaskStatus.LOCKED_FOR_MAPPING.value
+        task.locked_by = self.test_user.id
+        task.update()
+        # Act
+        response = self.client.post(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            json={"status": "INVALIDATED"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json["SubCode"], "InvalidUnlockState")
+
+    def test_mapping_unlock_returns_200_on_success(self):
+        """Test returns 200 on success."""
+        # Arrange
+        task = Task.get(1, self.test_project.id)
+        task.task_status = TaskStatus.LOCKED_FOR_MAPPING.value
+        task.locked_by = self.test_user.id
+        task.update()
+        # Act
+        response = self.client.post(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            json={"status": "MAPPED"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["taskId"], 1)
+        self.assertEqual(response.json["projectId"], self.test_project.id)
+        self.assertEqual(response.json["taskStatus"], TaskStatus.MAPPED.name)
+        last_task_history = response.json["taskHistory"][0]
+        self.assertEqual(last_task_history["action"], TaskAction.STATE_CHANGE.name)
+        self.assertEqual(last_task_history["actionText"], TaskStatus.MAPPED.name)
+        self.assertEqual(last_task_history["actionBy"], self.test_user.username)
+
+    def test_mapping_unlock_returns_200_on_success_with_comment(self):
+        """Test returns 200 on success."""
+        # Arrange
+        task = Task.get(1, self.test_project.id)
+        task.task_status = TaskStatus.LOCKED_FOR_MAPPING.value
+        task.locked_by = self.test_user.id
+        task.update()
+        # Act
+        response = self.client.post(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            json={
+                "status": "BADIMAGERY",  # Lets test with BADIMAGERY this time
+                "comment": "cannot map",
+            },
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["taskId"], 1)
+        self.assertEqual(response.json["projectId"], self.test_project.id)
+        self.assertEqual(response.json["taskStatus"], TaskStatus.BADIMAGERY.name)
+
+        last_task_history = response.json["taskHistory"][0]
+        self.assertEqual(last_task_history["action"], TaskAction.STATE_CHANGE.name)
+        self.assertEqual(last_task_history["actionText"], TaskStatus.BADIMAGERY.name)
+        self.assertEqual(last_task_history["actionBy"], self.test_user.username)
+
+        last_comment_history = response.json["taskHistory"][1]
+        self.assertEqual(last_comment_history["action"], TaskAction.COMMENT.name)
+        self.assertEqual(last_comment_history["actionText"], "cannot map")
+        self.assertEqual(last_comment_history["actionBy"], self.test_user.username)

--- a/tests/backend/integration/api/tasks/test_statistics.py
+++ b/tests/backend/integration/api/tasks/test_statistics.py
@@ -1,0 +1,250 @@
+from datetime import datetime
+
+from backend.models.postgis.task import Task, TaskStatus
+from backend.services.campaign_service import CampaignService, CampaignProjectDTO
+
+
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import (
+    return_canned_user,
+    generate_encoded_token,
+    create_canned_campaign,
+    create_canned_project,
+    create_canned_organisation,
+)
+
+
+class TestTasksStatisticsAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.url = "/api/v2/tasks/statistics/"
+        self.test_user = return_canned_user("test_user", 1111111)
+        self.test_user.create()
+        self.user_session_token = generate_encoded_token(self.test_user.id)
+        self.test_project_1, _ = create_canned_project()
+        self.test_project_2, _ = create_canned_project()
+        TestTasksStatisticsAPI.create_task_history(
+            1, self.test_project_1.id, self.test_user.id, TaskStatus.MAPPED
+        )
+        TestTasksStatisticsAPI.create_task_history(
+            2, self.test_project_1.id, self.test_user.id, TaskStatus.VALIDATED
+        )
+        TestTasksStatisticsAPI.create_task_history(
+            3, self.test_project_2.id, self.test_user.id, TaskStatus.MAPPED
+        )
+
+    def test_returns_401_if_not_authenticated(self):
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_400_if_start_date_is_not_provided(self):
+        # Act
+        response = self.client.get(
+            self.url, headers={"Authorization": self.user_session_token}
+        )
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["SubCode"], "MissingDate")
+
+    def test_returns_400_if_start_date_is_not_valid(self):
+        """ Test returns 400 if start date is not valid """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"startDate": "not a date"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["SubCode"], "InvalidDateValue")
+
+    def test_returns_400_if_end_date_is_not_valid(self):
+        """ Test returns 400 if end date is not valid """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"startDate": "2020-01-01", "endDate": "not a date"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["SubCode"], "InvalidDateValue")
+
+    def test_returns_400_if_start_date_is_after_end_date(self):
+        """ Test returns 400 if start date is after end date """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"startDate": "2020-01-02", "endDate": "2020-01-01"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["SubCode"], "InvalidDateRange")
+
+    def test_returns_400_if_date_range_is_greater_than_1_year(self):
+        """ Test returns 400 if date range is greater than 1 year """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={
+                "startDate": "2019-01-01",
+                "endDate": datetime.now().strftime("%Y-%m-%d"),
+            },
+        )
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["SubCode"], "InvalidDateRange")
+
+    def test_returns_200_if_valid_date_range(self):
+        """ Test returns 200 if date range is valid """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"startDate": "2023-01-01"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["taskStats"][0]["mapped"], 2)
+        self.assertEqual(response.json["taskStats"][0]["validated"], 1)
+        self.assertEqual(response.json["taskStats"][0]["badImagery"], 0)
+
+    @staticmethod
+    def create_task_history(task_id, project_id, user_id, action):
+        """ Create task history"""
+        task = Task.get(task_id, project_id)
+        if action in [TaskStatus.MAPPED, TaskStatus.BADIMAGERY]:
+            task.lock_task_for_mapping(user_id)
+        elif action == TaskStatus.VALIDATED:
+            task.lock_task_for_validating(user_id)
+        task.unlock_task(user_id, action)
+
+    def test_filters_task_by_project(self):
+        """ Test filters task by project """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={
+                "startDate": "2023-01-01",
+                "projectId": self.test_project_1.id,
+            },
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["taskStats"][0]["mapped"], 1)
+        self.assertEqual(response.json["taskStats"][0]["validated"], 1)
+        self.assertEqual(response.json["taskStats"][0]["badImagery"], 0)
+
+    def test_filters_by_multiple_projects(self):
+        """ Test filters by multiple projects """
+        # Arrange
+        test_project_3, _ = create_canned_project()
+        TestTasksStatisticsAPI.create_task_history(
+            4, test_project_3.id, self.test_user.id, TaskStatus.MAPPED
+        )
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={
+                "startDate": "2023-01-01",
+                "projectId": f"{self.test_project_1.id}, {self.test_project_2.id}",
+            },
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["taskStats"][0]["mapped"], 2)
+        self.assertEqual(response.json["taskStats"][0]["validated"], 1)
+        self.assertEqual(response.json["taskStats"][0]["badImagery"], 0)
+
+    def test_filters_by_organisation_id(self):
+        """ Test filters by organisation id """
+        # Arrange
+        test_organisation = create_canned_organisation()
+        self.test_project_1.organisation_id = test_organisation.id
+        self.test_project_1.save()
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={
+                "startDate": "2023-01-01",
+                "organisationId": test_organisation.id,
+            },
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["taskStats"][0]["mapped"], 1)
+        self.assertEqual(response.json["taskStats"][0]["validated"], 1)
+        self.assertEqual(response.json["taskStats"][0]["badImagery"], 0)
+
+    def test_filters_by_organisation_name(self):
+        """ Test filters by organisation name """
+        # Arrange
+        test_organisation = create_canned_organisation()
+        self.test_project_1.organisation_id = test_organisation.id
+        self.test_project_1.save()
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={
+                "startDate": "2023-01-01",
+                "organisationName": test_organisation.name,
+            },
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["taskStats"][0]["mapped"], 1)
+        self.assertEqual(response.json["taskStats"][0]["validated"], 1)
+        self.assertEqual(response.json["taskStats"][0]["badImagery"], 0)
+
+    def test_filters_by_campaign(self):
+        """ Test filters by campaign """
+        # Arrange
+        test_campaign = create_canned_campaign()
+        campaign_dto = CampaignProjectDTO()
+        campaign_dto.campaign_id = test_campaign.id
+        campaign_dto.project_id = self.test_project_2.id
+        CampaignService.create_campaign_project(campaign_dto)
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={
+                "startDate": "2023-01-01",
+                "campaign": test_campaign.name,
+            },
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["taskStats"][0]["mapped"], 1)
+        self.assertEqual(response.json["taskStats"][0]["validated"], 0)
+        self.assertEqual(response.json["taskStats"][0]["badImagery"], 0)
+
+    def test_filters_by_country(self):
+        """ Test filters by country """
+        # Arrange
+        self.test_project_1.country = ["Nepal"]
+        self.test_project_1.save()
+        self.test_project_2.country = ["England"]
+        self.test_project_2.save()
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={
+                "startDate": "2023-01-01",
+                "country": "Nepal",
+            },
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["taskStats"][0]["mapped"], 1)
+        self.assertEqual(response.json["taskStats"][0]["validated"], 1)
+        self.assertEqual(response.json["taskStats"][0]["badImagery"], 0)

--- a/tests/backend/unit/services/test_mapping_service.py
+++ b/tests/backend/unit/services/test_mapping_service.py
@@ -209,7 +209,7 @@ class TestMappingService(BaseTestCase):
         task.mapped_by = 1
 
         # Act
-        mock_project.return_value = True
+        mock_project.return_value = True, None
         is_undoable = MappingService._is_task_undoable(1, task)
 
         # Assert
@@ -230,7 +230,7 @@ class TestMappingService(BaseTestCase):
         task.mapped_by = 1
 
         # Act
-        mock_project.return_value = False
+        mock_project.return_value = (False, None)
         is_undoable = MappingService._is_task_undoable(1, task)
 
         # Assert


### PR DESCRIPTION
This will extend test coverage for the following endpoints that have received at least one hit over the past three months.
This will increase backend test coverage to 70% from 65%
| Endpoint                                              | Total hits( Last 3months )  |
| ----------------------------------------------------------- | ------------ |
| backend.api.tasks.resources:tasksqueriesjsonapi             | 1.08 million |
| backend.api.tasks.resources:tasksrestapi                    | 752k         |
| backend.api.tasks.actions:tasksactionsmappinglockapi        | 303k         |
| backend.api.tasks.resources:tasksqueriesgpxapi              | 279k         |
| backend.api.tasks.actions:tasksactionsmappingunlockapi      | 199k         |
| backend.api.tasks.resources:tasksqueriesxmlapi              | 113k         |
| backend.api.tasks.actions:tasksactionsmappingstopapi        | 80.7k        |
| backend.api.tasks.actions:tasksactionsvalidationlockapi     | 66.2k        |
| backend.api.tasks.actions:tasksactionsvalidationunlockapi   | 61k          |
| backend.api.tasks.actions:tasksactionssplitapi              | 5.08k        |
| backend.api.tasks.actions:tasksactionsvalidationstopapi     | 4.5k         |
| backend.api.tasks.actions:tasksactionsmappingundoapi        | 2.9k         |
| backend.api.tasks.actions:tasksactionsextendapi             | 976          |
| backend.api.tasks.statistics:tasksstatisticsapi             | 495          |
| backend.api.tasks.actions:tasksactionsresetbadimageryallapi | 69           |
| backend.api.tasks.actions:tasksactionsresetallapi           | 15           |
| backend.api.tasks.actions:tasksactionsmapallapi             | 7            |
| backend.api.tasks.resources:tasksqueriesowninvalidatedapi   | 6            |
| backend.api.tasks.actions:tasksactionsvalidateallapi        | 5            |
| backend.api.tasks.resources:tasksqueriesmappedapi           | 2            |