### PR TITLE
Update tests for some smaller miscellaneous components

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -57,7 +57,7 @@ import { SwaggerView } from './views/swagger';
 import { ContributionsPage, ContributionsPageIndex, UserStats } from './views/contributions';
 import { NotificationsPage, NotificationPageIndex } from './views/notifications';
 import { Banner, ArchivalNotificationBanner } from './components/banner/index';
-import TopBanner from './components/banner/TopBanner';
+import { TopBanner } from './components/banner/topBanner';
 
 const ProjectEdit = React.lazy(() =>
   import('./views/projectEdit' /* webpackChunkName: "projectEdit" */),

--- a/frontend/src/components/banner/tests/topBanner.test.js
+++ b/frontend/src/components/banner/tests/topBanner.test.js
@@ -1,0 +1,14 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { banner } from '../../../network/tests/mockData/miscellaneous';
+import { ReduxIntlProviders } from '../../../utils/testWithIntl';
+import { TopBanner } from '../topBanner';
+
+it('should render the banner text ', async () => {
+  render(
+    <ReduxIntlProviders>
+      <TopBanner />
+    </ReduxIntlProviders>,
+  );
+  expect(await screen.findByText(banner.message)).toBeInTheDocument();
+});

--- a/frontend/src/components/banner/topBanner.js
+++ b/frontend/src/components/banner/topBanner.js
@@ -3,7 +3,7 @@ import { useFetchWithAbort } from '../../hooks/UseFetch';
 import { htmlFromMarkdown } from '../../utils/htmlFromMarkdown';
 import './styles.scss';
 
-function TopBanner() {
+export function TopBanner() {
   const [, error, data] = useFetchWithAbort(`system/banner/`);
 
   return (
@@ -19,5 +19,3 @@ function TopBanner() {
     </>
   );
 }
-
-export default TopBanner;

--- a/frontend/src/network/tests/mockData/miscellaneous.js
+++ b/frontend/src/network/tests/mockData/miscellaneous.js
@@ -13,3 +13,8 @@ export const countries = {
     'Azerbaijan',
   ],
 };
+
+export const banner = {
+  message: 'Banner text',
+  visible: true,
+};

--- a/frontend/src/network/tests/server-handlers.js
+++ b/frontend/src/network/tests/server-handlers.js
@@ -45,7 +45,7 @@ import {
 } from './mockData/teams';
 import { userTasks } from './mockData/tasksStats';
 import { homepageStats } from './mockData/homepageStats';
-import { countries } from './mockData/miscellaneous';
+import { banner, countries } from './mockData/miscellaneous';
 import tasksGeojson from '../../utils/tests/snippets/tasksGeometry';
 import { API_URL } from '../../config';
 import { notifications, ownCountUnread } from './mockData/notifications';
@@ -208,6 +208,9 @@ const handlers = [
   }),
   rest.get(API_URL + 'countries', (req, res, ctx) => {
     return res(ctx.json(countries));
+  }),
+  rest.get(API_URL + 'system/banner/', (req, res, ctx) => {
+    return res(ctx.json(banner));
   }),
   // EXTERNAL API
   rest.get('https://osmstats-api.hotosm.org/wildcard', (req, res, ctx) => {

--- a/frontend/src/views/fallback.js
+++ b/frontend/src/views/fallback.js
@@ -6,7 +6,7 @@ import messages from './messages';
 import { Button } from '../components/button';
 import { SERVICE_DESK } from '../config';
 
-export const FallbackComponent = (props) => {
+export const FallbackComponent = () => {
   return (
     <div className="cf w-100 pv5 base-font">
       <h3 className="f2 fw5 barlow-condensed tc">

--- a/frontend/src/views/notFound.js
+++ b/frontend/src/views/notFound.js
@@ -3,19 +3,17 @@ import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
 
-export const NotFound = (props) => {
+export const NotFound = ({ projectId }) => {
   return (
     <div className="cf w-100 pv5">
       <div className="tc">
-        {props.projectId ? (
-          <h3 className="f1 fw8 mb4 barlow-condensed">
-            <FormattedMessage {...messages.projectNotFound} values={{ id: props.projectId }} />
-          </h3>
-        ) : (
-          <h3 className="f1 fw8 mb4 barlow-condensed">
+        <h3 className="f1 fw8 mb4 barlow-condensed">
+          {projectId ? (
+            <FormattedMessage {...messages.projectNotFound} values={{ id: projectId }} />
+          ) : (
             <FormattedMessage {...messages.pageNotFound} />
-          </h3>
-        )}
+          )}
+        </h3>
         <p>
           <FormattedMessage {...messages.notFoundLead} />
         </p>

--- a/frontend/src/views/tests/fallback.test.js
+++ b/frontend/src/views/tests/fallback.test.js
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { IntlProviders, renderWithRouter } from '../../utils/testWithIntl';
+import { FallbackComponent } from '../fallback';
+import { SERVICE_DESK } from '../../config';
+import messages from '../messages';
+
+describe('Fallback component', () => {
+  it('should render component details', () => {
+    render(
+      <IntlProviders>
+        <FallbackComponent />
+      </IntlProviders>,
+    );
+    expect(
+      screen.getByRole('heading', {
+        name: messages.errorFallback.defaultMessage,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: messages.errorFallback.defaultMessage,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /return/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should render service desk link if present', () => {
+    render(
+      <IntlProviders>
+        <FallbackComponent />
+      </IntlProviders>,
+    );
+    expect(
+      screen.getByRole('button', {
+        name: messages.contactUs.defaultMessage,
+      }),
+    ).toBeInTheDocument();
+    if (SERVICE_DESK) {
+      expect(screen.queryByRole('link')).toHaveAttribute('href', SERVICE_DESK);
+    } else {
+      expect(screen.queryByRole('link')).toHaveAttribute('href', '/contact');
+    }
+  });
+
+  it('should trigger navigate on return button click', async () => {
+    const mockedUsedNavigate = jest.fn();
+    jest.mock('@reach/router', () => ({
+      navigate: () => mockedUsedNavigate,
+    }));
+    renderWithRouter(
+      <IntlProviders>
+        <FallbackComponent />
+      </IntlProviders>,
+    );
+    const returnBtn = screen.getByRole('button', {
+      name: messages.return.defaultMessage,
+    });
+    await userEvent.click(returnBtn);
+    waitFor(() => expect(mockedUsedNavigate).toHaveBeenCalledTimes(1));
+  });
+});

--- a/frontend/src/views/tests/notFound.test.js
+++ b/frontend/src/views/tests/notFound.test.js
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { IntlProviders } from '../../utils/testWithIntl';
+import messages from '../messages';
+import { NotFound } from '../notFound';
+
+describe('Not Found', () => {
+  it('should display project not found error', () => {
+    render(
+      <IntlProviders>
+        <NotFound projectId={123} />
+      </IntlProviders>,
+    );
+    expect(
+      screen.getByRole('heading', {
+        name: 'Project 123 not found',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(messages.notFoundLead.defaultMessage)).toBeInTheDocument();
+  });
+
+  it('should display page not found error', () => {
+    render(
+      <IntlProviders>
+        <NotFound />
+      </IntlProviders>,
+    );
+    expect(
+      screen.queryByRole('heading', {
+        name: 'Project 123 not found',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: messages.pageNotFound.defaultMessage,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(messages.notFoundLead.defaultMessage)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This PR adds test cases for the NotFound, Sentry fallback, and top banner components.