### PR TITLE
Add tests for endpoints associated with the users section

### DIFF
--- a/backend/api/users/actions.py
+++ b/backend/api/users/actions.py
@@ -32,6 +32,9 @@ class UsersActionsSetUsersAPI(Resource):
               description: JSON object to update a user
               schema:
                   properties:
+                      id:
+                        type: integer
+                        example: 1
                       name:
                           type: string
                           example: Your Name

--- a/backend/api/users/actions.py
+++ b/backend/api/users/actions.py
@@ -307,6 +307,8 @@ class UsersActionsVerifyEmailAPI(Resource):
         try:
             MessageService.resend_email_validation(token_auth.current_user())
             return {"Success": "Verification email resent"}, 200
+        except ValueError as e:
+            return {"Error": str(e).split("-")[1], "SubCode": str(e).split("-")[0]}, 400
         except Exception as e:
             error_msg = f"User GET - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)

--- a/backend/api/users/actions.py
+++ b/backend/api/users/actions.py
@@ -416,7 +416,7 @@ class UsersActionsSetInterestsAPI(Resource):
                 token_auth.current_user(), data["interests"]
             )
             return user_interests.to_primitive(), 200
-        except ValueError as e:
+        except (ValueError, KeyError) as e:
             return {"Error": str(e)}, 400
         except NotFound:
             return {"Error": "Interest not Found", "SubCode": "NotFound"}, 404

--- a/backend/api/users/openstreetmap.py
+++ b/backend/api/users/openstreetmap.py
@@ -1,7 +1,7 @@
 from flask_restful import Resource, current_app
 
 from backend.services.users.authentication_service import token_auth
-from backend.services.users.user_service import UserService, UserServiceError, NotFound
+from backend.services.users.user_service import UserService, OSMServiceError, NotFound
 
 
 class UsersOpenStreetMapAPI(Resource):
@@ -44,7 +44,7 @@ class UsersOpenStreetMapAPI(Resource):
             return osm_dto.to_primitive(), 200
         except NotFound:
             return {"Error": "User not found", "SubCode": "NotFound"}, 404
-        except UserServiceError as e:
+        except OSMServiceError as e:
             return {"Error": str(e)}, 502
         except Exception as e:
             error_msg = f"User OSM GET - unhandled error: {str(e)}"

--- a/backend/api/users/statistics.py
+++ b/backend/api/users/statistics.py
@@ -134,17 +134,21 @@ class UsersStatisticsAllAPI(Resource):
                 description: Internal Server Error
         """
         try:
-            start_date = validate_date_input(request.args.get("startDate"))
+            if request.args.get("startDate"):
+                start_date = validate_date_input(request.args.get("startDate"))
+            else:
+                return {
+                    "Error": "Start date is required",
+                    "SubCode": "MissingDate",
+                }, 400
             end_date = validate_date_input(request.args.get("endDate", date.today()))
-            if not (start_date):
-                raise KeyError("MissingDate- Missing start date parameter")
             if end_date < start_date:
                 raise ValueError(
-                    "InvalidStartDate- Start date must be earlier than end date"
+                    "InvalidDateRange- Start date must be earlier than end date"
                 )
             if (end_date - start_date) > timedelta(days=366 * 3):
                 raise ValueError(
-                    "DateRangeGreaterThan3- Date range can not be bigger than 3 years"
+                    "InvalidDateRange- Date range can not be bigger than 1 year"
                 )
 
             stats = StatsService.get_all_users_statistics(start_date, end_date)

--- a/backend/services/messaging/message_service.py
+++ b/backend/services/messaging/message_service.py
@@ -602,6 +602,8 @@ class MessageService:
     def resend_email_validation(user_id: int):
         """Resends the email validation email to the logged in user"""
         user = UserService.get_user_by_id(user_id)
+        if user.email_address is None:
+            raise ValueError("EmailNotSet- User does not have an email address")
         SMTPService.send_verification_email(user.email_address, user.username)
 
     @staticmethod

--- a/tests/backend/helpers/test_helpers.py
+++ b/tests/backend/helpers/test_helpers.py
@@ -22,7 +22,7 @@ from backend.models.postgis.team import Team, TeamMembers
 from backend.models.postgis.user import User
 from backend.models.postgis.organisation import Organisation
 from backend.services.users.authentication_service import AuthenticationService
-from backend.services.interests_service import InterestService, Interest
+from backend.services.interests_service import Interest
 from backend.services.license_service import LicenseService, LicenseDTO
 
 
@@ -331,13 +331,21 @@ def create_canned_campaign(
 
 
 def create_canned_interest(name="test_interest") -> Interest:
-    """Returns test interest without writing to db"""
-    test_interest = InterestService.create(name=name)
+    """Returns test interest without writing to db
+    param name: name of interest
+    return: Interest object
+    """
+    test_interest = Interest()
+    test_interest.name = name
+    test_interest.create()
     return test_interest
 
 
 def create_canned_license(name="test_license") -> int:
-    """Returns test license without writing to db"""
+    """Returns test license without writing to db
+    param name: name of license
+    return: license id
+    """
     license_dto = LicenseDTO()
     license_dto.name = name
     license_dto.description = "test license"

--- a/tests/backend/integration/api/users/test_actions.py
+++ b/tests/backend/integration/api/users/test_actions.py
@@ -4,8 +4,11 @@ from tests.backend.base import BaseTestCase
 from tests.backend.helpers.test_helpers import (
     return_canned_user,
     generate_encoded_token,
+    create_canned_interest,
 )
 from backend.services.messaging.smtp_service import SMTPService
+
+TEST_EMAIL = "test@test.com"
 
 
 class TestUsersActionsSetUsersAPI(BaseTestCase):
@@ -97,8 +100,88 @@ class TestUsersActionsSetUsersAPI(BaseTestCase):
         response = self.client.patch(
             self.url,
             headers={"Authorization": self.user_seesion_token},
-            json={"id": self.test_user.id, "emailAddress": "test@test.com"},
+            json={"id": self.test_user.id, "emailAddress": TEST_EMAIL},
         )
         # Assert
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json["verificationEmailSent"], True)
+
+
+class TestUsersActionsRegisterEmailAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.url = "/api/v2/users/actions/register/"
+
+    def test_returns_400_if_no_data(self):
+        """ Test that the API returns 400 if no data is provided """
+        # Act
+        response = self.client.post(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 400)
+
+    def test_returns_200_if_email_registered(self):
+        """ Test that the API returns 200 if email is registered """
+        # Arrange
+        sample_payload = {"email": TEST_EMAIL}
+        # Act
+        response = self.client.post(self.url, json=sample_payload)
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["email"], TEST_EMAIL)
+        self.assertEqual(response.json["success"], True)
+
+
+class TestUsersActionsSetInterestsAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_user = return_canned_user()
+        self.test_user.create()
+        self.url = "/api/v2/users/me/actions/set-interests/"
+        self.user_seesion_token = generate_encoded_token(self.test_user.id)
+
+    def test_returns_401_if_no_token(self):
+        """ Test that the API returns 401 if no token is provided """
+        # Act
+        response = self.client.post(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_404_if_interests_not_found(self):
+        """ Test that the API returns 404 if interests are not found """
+        # Act
+        response = self.client.post(
+            self.url,
+            headers={"Authorization": self.user_seesion_token},
+            json={"interests": [999]},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_400_if_invalid_data(self):
+        """ Test that the API returns 400 if invalid data is provided """
+        # Act
+        response = self.client.post(
+            self.url,
+            headers={"Authorization": self.user_seesion_token},
+            json={"key": "invalid"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 400)
+
+    def test_returns_200_if_interests_set(self):
+        """ Test that the API returns 200 if interests are set """
+        # Arrange
+        interest_1 = create_canned_interest("test_interest_1")
+        interest_2 = create_canned_interest("test_interest_2")
+        sample_payload = {"interests": [interest_1.id, interest_2.id]}
+        # Act
+        response = self.client.post(
+            self.url,
+            headers={"Authorization": self.user_seesion_token},
+            json=sample_payload,
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["interests"]), 2)
+        self.assertEqual(response.json["interests"][0]["id"], interest_1.id)
+        self.assertEqual(response.json["interests"][1]["id"], interest_2.id)

--- a/tests/backend/integration/api/users/test_actions.py
+++ b/tests/backend/integration/api/users/test_actions.py
@@ -1,0 +1,104 @@
+from unittest.mock import patch
+
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import (
+    return_canned_user,
+    generate_encoded_token,
+)
+from backend.services.messaging.smtp_service import SMTPService
+
+
+class TestUsersActionsSetUsersAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_user = return_canned_user()
+        self.test_user.create()
+        self.url = "/api/v2/users/me/actions/set-user/"
+        self.user_seesion_token = generate_encoded_token(self.test_user.id)
+
+    def test_returns_401_if_no_token(self):
+        """ Test that the API returns 401 if no token is provided """
+        # Act
+        response = self.client.patch(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_401_if_other_user_requested(self):
+        """ Test that the API returns 401 if another user is requested """
+        # Act
+        response = self.client.patch(
+            self.url,
+            headers={"Authorization": self.user_seesion_token},
+            json={"id": 2},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_400_if_invalid_data(self):
+        """ Test that the API returns 400 if invalid data is provided """
+        # Act
+        response = self.client.patch(
+            self.url,
+            headers={"Authorization": self.user_seesion_token},
+            json={"id": self.test_user.id, "emailAddress": "invalid_email"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 400)
+
+    def test_returns_404_if_user_not_found(self):
+        """ Test that the API returns 404 if user is not found """
+        # Act
+        response = self.client.patch(
+            self.url,
+            headers={"Authorization": generate_encoded_token(999)},
+            json={"id": 999},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_200_if_user_updated(self):
+        """ Test that the API returns 200 if user is updated """
+        # Arrange
+        sample_payload = {
+            "id": self.test_user.id,
+            "name": "ThinkWhere",
+            "city": "test_city",
+            "country": "AD",
+            "twitterId": "test_twitter",
+            "facebookId": "test_facebook",
+            "linkedinId": "test_linkedin",
+            "slackId": "test_slack",
+            "gender": "MALE",
+            "selfDescriptionGender": None,
+        }
+        # Act
+        response = self.client.patch(
+            self.url,
+            headers={"Authorization": self.user_seesion_token},
+            json=sample_payload,
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["verificationEmailSent"], False)
+        self.assertEqual(self.test_user.name, sample_payload["name"])
+        self.assertEqual(self.test_user.city, sample_payload["city"])
+        self.assertEqual(self.test_user.country, sample_payload["country"])
+        self.assertEqual(self.test_user.twitter_id, sample_payload["twitterId"])
+        self.assertEqual(self.test_user.facebook_id, sample_payload["facebookId"])
+        self.assertEqual(self.test_user.linkedin_id, sample_payload["linkedinId"])
+        self.assertEqual(self.test_user.slack_id, sample_payload["slackId"])
+
+    @patch.object(SMTPService, "send_verification_email")
+    def test_returns_200_if_user_updated_with_email(self, mock_send_verification_email):
+        """ Test that the API returns 200 if user is updated """
+        # Arrange
+        mock_send_verification_email.return_value = True
+        # Act
+        response = self.client.patch(
+            self.url,
+            headers={"Authorization": self.user_seesion_token},
+            json={"id": self.test_user.id, "emailAddress": "test@test.com"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["verificationEmailSent"], True)

--- a/tests/backend/integration/api/users/test_openstreetmap.py
+++ b/tests/backend/integration/api/users/test_openstreetmap.py
@@ -1,0 +1,60 @@
+from unittest.mock import patch
+
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import (
+    return_canned_user,
+    generate_encoded_token,
+)
+from backend.services.users.osm_service import OSMServiceError, OSMService, UserOSMDTO
+
+TEST_USERNAME = "testuser"
+TEST_USER_ID = 111111
+
+
+class TestUsersOpenStreetMapAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_user = return_canned_user(TEST_USERNAME, TEST_USER_ID)
+        self.test_user.create()
+        self.user_access_token = generate_encoded_token(TEST_USER_ID)
+        self.url = f"/api/v2/users/{self.test_user.username}/openstreetmap/"
+
+    def test_returns_401_if_user_not_authorized(self):
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_404_if_user_not_found(self):
+        # Act
+        response = self.client.get(
+            "/api/v2/users/doesnotexist/openstreetmap/",
+            headers={"Authorization": self.user_access_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    @patch.object(OSMService, "get_osm_details_for_user")
+    def test_returns_502_if_osm_service_error(self, mock_osm_service):
+        # Arrange
+        mock_osm_service.side_effect = OSMServiceError("Bad response from OSM")
+        # Act
+        response = self.client.get(
+            self.url, headers={"Authorization": self.user_access_token}
+        )
+        # Assert
+        self.assertEqual(response.status_code, 502)
+
+    @patch.object(OSMService, "get_osm_details_for_user")
+    def test_returns_200_if_user_found(self, mock_osm_service):
+        # Arrange
+        user_dto = UserOSMDTO({"accountCreated": "1234567890", "changesetCount": 123})
+        mock_osm_service.return_value = user_dto
+        # Act
+        response = self.client.get(
+            self.url, headers={"Authorization": self.user_access_token}
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["accountCreated"], user_dto.account_created)
+        self.assertEqual(response.json["changesetCount"], user_dto.changeset_count)

--- a/tests/backend/integration/api/users/test_resources.py
+++ b/tests/backend/integration/api/users/test_resources.py
@@ -428,3 +428,42 @@ class TestUsersAllAPI(BaseTestCase):
         self.assertEqual(len(response.json["users"]), 1)
         self.assertEqual(response.json["pagination"]["page"], 1)
         self.assertEqual(response.json["pagination"]["total"], 1)
+
+
+class TestUsersRecommendedProjectsAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = return_canned_user(TEST_USERNAME, TEST_USER_ID)
+        self.user.create()
+        self.user_session_token = generate_encoded_token(TEST_USER_ID)
+        self.url = f"/api/v2/users/{self.user.username}/recommended-projects/"
+
+    def test_returns_401_without_session_token(self):
+        """ Test that the API returns 401 if no session token is provided """
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_404_if_user_does_not_exist(self):
+        """ Test that the API returns 404 if user does not exist """
+        # Act
+        response = self.client.get(
+            "/api/v2/users/999/recommendedProjects/",
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_recommended_projects(self):
+        """ Test that the API returns recommended projects """
+        # Arrange
+        project, _ = create_canned_project()
+        project.create()
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)

--- a/tests/backend/integration/api/users/test_resources.py
+++ b/tests/backend/integration/api/users/test_resources.py
@@ -1,5 +1,5 @@
 from backend.models.postgis.task import Task, TaskStatus
-from backend.models.postgis.statuses import UserGender
+from backend.models.postgis.statuses import UserGender, UserRole, MappingLevel
 
 from tests.backend.base import BaseTestCase
 from tests.backend.helpers.test_helpers import (
@@ -235,3 +235,196 @@ class UsersQueriesInterestsAPI(BaseTestCase):
         self.assertEqual(response.json["interests"][0]["name"], interest_1.name)
         self.assertEqual(response.json["interests"][1]["id"], interest_2.id)
         self.assertEqual(response.json["interests"][1]["name"], interest_2.name)
+
+
+class TestUsersQueriesUsernameFilterAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = return_canned_user(TEST_USERNAME, TEST_USER_ID)
+        self.user.create()
+        self.user_2 = return_canned_user("user_2", 2222222)
+        self.user_2.create()
+        self.user_3 = return_canned_user("user_3", 3333333)
+        self.user_3.create()
+        self.user_session_token = generate_encoded_token(TEST_USER_ID)
+        self.url = "/api/v2/users/queries/filter/tes/"
+
+    def test_returns_401_without_session_token(self):
+        """ Test that the API returns 401 if no session token is provided """
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_404_if_no_users_found(self):
+        """ Test that the API returns 404 if no users found """
+        # Act
+        response = self.client.get(
+            "/api/v2/users/queries/filter/invalid_username/",
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json["SubCode"], "NotFound")
+
+    def test_returns_users_if_users_found(self):
+        """ Test that the API returns users if users found """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertListEqual(
+            list(response.json.keys()), ["pagination", "usernames", "users"]
+        )
+        self.assertEqual(len(response.json["usernames"]), 1)
+        self.assertEqual(response.json["usernames"][0], self.user.username)
+        self.assertEqual(response.json["pagination"]["page"], 1)
+        self.assertEqual(response.json["pagination"]["perPage"], 20)
+        self.assertEqual(response.json["pagination"]["total"], 1)
+
+    def test_returnns_matching_project_contributors(self):
+        """ Test that the API returns matching project contributors """
+        # Arrange
+        test_project, _ = create_canned_project()
+        task = Task.get(1, test_project.id)
+        task.lock_task_for_mapping(self.user_2.id)
+        task.unlock_task(self.user_2.id, TaskStatus.MAPPED)
+        # Act
+        response = self.client.get(
+            f"/api/v2/users/queries/filter/user_/?projectId={test_project.id}",
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["usernames"]), 2)
+        self.assertEqual(response.json["usernames"][0], self.user_2.username)
+        self.assertEqual(response.json["usernames"][1], self.user_3.username)
+        self.assertEqual(response.json["users"][0]["username"], self.user_2.username)
+        self.assertEqual(response.json["users"][0]["projectId"], test_project.id)
+
+
+class TestUsersAllAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = return_canned_user(TEST_USERNAME, TEST_USER_ID)
+        self.user.create()
+        self.user_session_token = generate_encoded_token(TEST_USER_ID)
+        for i in range(30):
+            user = return_canned_user(f"user_{i}", i)
+            user.create()
+        self.url = "/api/v2/users/"
+
+    def test_returns_401_without_session_token(self):
+        """ Test that the API returns 401 if no session token is provided """
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_400_if_invalid_data(self):
+        """ Test that the API returns 400 if invalid data is provided """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"role": "GOD"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["SubCode"], "InvalidData")
+
+    def test_returns_per_page_20_users_by_default(self):
+        """ Test that the API paginates and returns 20 users by default """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["users"]), 20)
+        self.assertEqual(response.json["pagination"]["page"], 1)
+        self.assertEqual(response.json["pagination"]["perPage"], 20)
+        self.assertEqual(response.json["pagination"]["total"], 31)
+
+    def test_pagination_can_be_disabled(self):
+        """ Test that the API can return all users if pagination is disabled """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"pagination": "false"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["users"]), 31)
+
+    def test_returns_specified_per_page_users(self):
+        """ Test that the API returns specified per page users """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"perPage": 10},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["users"]), 10)
+        self.assertEqual(response.json["pagination"]["page"], 1)
+        self.assertEqual(response.json["pagination"]["perPage"], 10)
+        self.assertEqual(response.json["pagination"]["total"], 31)
+        self.assertEqual(response.json["pagination"]["hasNext"], True)
+        self.assertEqual(response.json["pagination"]["pages"], 4)
+
+    def test_returns_specified_page_users(self):
+        """ Test that the API returns specified page users """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"page": 2},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["users"]), 11)
+        self.assertEqual(response.json["pagination"]["page"], 2)
+        self.assertEqual(response.json["pagination"]["hasNext"], False)
+        self.assertEqual(response.json["pagination"]["hasPrev"], True)
+        self.assertEqual(response.json["pagination"]["pages"], 2)
+
+    def test_returns_users_with_specified_role_(self):
+        """ Test that the API returns users with specified role """
+        # Arrange
+        self.user.role = UserRole.ADMIN.value
+        self.user.save()
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"role": "ADMIN"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["users"]), 1)
+        self.assertEqual(response.json["pagination"]["page"], 1)
+        self.assertEqual(response.json["pagination"]["total"], 1)
+
+    def test_returns_users_with_specified_level(self):
+        """ Test that the API returns users with specified level """
+        # Arrange
+        self.user.mapping_level = MappingLevel.ADVANCED.value
+        self.user.save()
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"level": "ADVANCED"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["users"]), 1)
+        self.assertEqual(response.json["pagination"]["page"], 1)
+        self.assertEqual(response.json["pagination"]["total"], 1)

--- a/tests/backend/integration/api/users/test_resources.py
+++ b/tests/backend/integration/api/users/test_resources.py
@@ -1,4 +1,4 @@
-from backend.models.postgis.task import Task
+from backend.models.postgis.task import Task, TaskStatus
 from backend.models.postgis.statuses import UserGender
 
 from tests.backend.base import BaseTestCase
@@ -6,6 +6,7 @@ from tests.backend.helpers.test_helpers import (
     return_canned_user,
     generate_encoded_token,
     create_canned_project,
+    create_canned_interest,
 )
 
 
@@ -126,3 +127,111 @@ class TestUsersQueriesUsernameAPI(BaseTestCase):
         self.assertIsNone(response.json["emailAddress"])
         self.assertIsNone(response.json["gender"])
         self.assertIsNone(response.json["selfDescriptionGender"])
+
+
+class TestUsersQueriesOwnLockedAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = return_canned_user(TEST_USERNAME, TEST_USER_ID)
+        self.user.create()
+        self.user_session_token = generate_encoded_token(TEST_USER_ID)
+        self.url = "/api/v2/users/queries/tasks/locked/"
+
+    def test_returns_401_without_session_token(self):
+        """ Test that the API returns 401 if no session token is provided """
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_empty_list_if_no_tasks_locked(self):
+        """ Test that the API returns empty list if no task is locked by user"""
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["lockedTasks"], [])
+        self.assertEqual(response.json["projectId"], None)
+        self.assertEqual(response.json["taskStatus"], None)
+
+    def test_returns_locked_task_if_tasks_locked(self):
+        """ Test that the API returns locked task if a task is locked by user """
+        # Arrange
+        # Lock a task
+        test_project, _ = create_canned_project()
+        task = Task.get(1, test_project.id)
+        task.lock_task_for_mapping(self.user.id)
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["lockedTasks"]), 1)
+        self.assertEqual(response.json["lockedTasks"][0], 1)
+        self.assertEqual(response.json["projectId"], test_project.id)
+        self.assertEqual(
+            response.json["taskStatus"], TaskStatus.LOCKED_FOR_MAPPING.name
+        )
+
+
+class UsersQueriesInterestsAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = return_canned_user(TEST_USERNAME, TEST_USER_ID)
+        self.user.create()
+        self.user_session_token = generate_encoded_token(TEST_USER_ID)
+        self.url = f"/api/v2/users/{self.user.username}/queries/interests/"
+
+    def test_returns_401_without_session_token(self):
+        """ Test that the API returns 401 if no session token is provided """
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_empty_list_if_no_interests(self):
+        """ Test that the API returns empty list if user has no interests """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["interests"], [])
+
+    def test_returns_404_if_user_not_found(self):
+        """ Test that the API returns 404 if user is not found """
+        # Act
+        response = self.client.get(
+            "/api/v2/users/invalid_username/queries/interests/",
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json["SubCode"], "NotFound")
+
+    def test_returns_user_interests_if_interest_found(self):
+        """ Test that the API returns user interests if user has interests """
+        # Arrange
+        interest_1 = create_canned_interest("interest_1")
+        interest_2 = create_canned_interest("interest_2")
+        self.user.create_or_update_interests([interest_1.id, interest_2.id])
+        self.user.save()
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["interests"]), 2)
+        self.assertEqual(response.json["interests"][0]["id"], interest_1.id)
+        self.assertEqual(response.json["interests"][0]["name"], interest_1.name)
+        self.assertEqual(response.json["interests"][1]["id"], interest_2.id)
+        self.assertEqual(response.json["interests"][1]["name"], interest_2.name)

--- a/tests/backend/integration/api/users/test_resources.py
+++ b/tests/backend/integration/api/users/test_resources.py
@@ -105,7 +105,7 @@ class TestUsersQueriesUsernameAPI(BaseTestCase):
         else:
             assert response.json["emailAddress"] == email
             assert response.json["gender"] == gender
-            assert response.json["isEmailVerified"] == False
+            assert response.json["isEmailVerified"] is False
 
     def test_returns_email_and_gender_if_own_info_requested(self):
         """ Test response contains email and gender info if user is requesting own info """

--- a/tests/backend/integration/api/users/test_resources.py
+++ b/tests/backend/integration/api/users/test_resources.py
@@ -1,0 +1,57 @@
+from backend.models.postgis.task import Task
+
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import (
+    return_canned_user,
+    generate_encoded_token,
+    create_canned_project,
+)
+
+
+TEST_USERNAME = "test_user"
+TEST_USER_ID = 1111111
+
+
+class TestUsersQueriesOwnLockedDetailsAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = return_canned_user(TEST_USERNAME, TEST_USER_ID)
+        self.user.create()
+        self.user_session_token = generate_encoded_token(TEST_USER_ID)
+        self.url = "/api/v2/users/queries/tasks/locked/details/"
+
+    def test_returns_401_without_session_token(self):
+        """ Test that the API returns 401 if no session token is provided """
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_404_if_no_tasks_locked(self):
+        """ Test that the API returns 404 if no task is locked by user"""
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json["SubCode"], "NotFound")
+
+    def test_returns_200_if_tasks_locked(self):
+        """ Test that the API returns 200 if a task is locked by user """
+        # Arrange
+        # Lock a task
+        test_project, _ = create_canned_project()
+        task = Task.get(1, test_project.id)
+        task.lock_task_for_mapping(self.user.id)
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["tasks"]), 1)
+        self.assertEqual(response.json["tasks"][0]["taskId"], 1)
+        self.assertEqual(response.json["tasks"][0]["projectId"], test_project.id)

--- a/tests/backend/integration/api/users/test_resources.py
+++ b/tests/backend/integration/api/users/test_resources.py
@@ -1,4 +1,5 @@
 from backend.models.postgis.task import Task
+from backend.models.postgis.statuses import UserGender
 
 from tests.backend.base import BaseTestCase
 from tests.backend.helpers.test_helpers import (
@@ -10,6 +11,7 @@ from tests.backend.helpers.test_helpers import (
 
 TEST_USERNAME = "test_user"
 TEST_USER_ID = 1111111
+TEST_EMAIL = "test@hotmail.com"
 
 
 class TestUsersQueriesOwnLockedDetailsAPI(BaseTestCase):
@@ -55,3 +57,72 @@ class TestUsersQueriesOwnLockedDetailsAPI(BaseTestCase):
         self.assertEqual(len(response.json["tasks"]), 1)
         self.assertEqual(response.json["tasks"][0]["taskId"], 1)
         self.assertEqual(response.json["tasks"][0]["projectId"], test_project.id)
+
+
+class TestUsersQueriesUsernameAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = return_canned_user(TEST_USERNAME, TEST_USER_ID)
+        self.user.create()
+        self.user_session_token = generate_encoded_token(TEST_USER_ID)
+        self.url = f"/api/v2/users/queries/{self.user.username}/"
+
+    def test_returns_401_without_session_token(self):
+        """ Test that the API returns 401 if no session token is provided """
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_404_if_user_not_found(self):
+        """ Test that the API returns 404 if user is not found """
+        # Act
+        response = self.client.get(
+            "/api/v2/users/queries/unknown_user/",
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json["SubCode"], "NotFound")
+
+    def test_returns_email_and_gender_if_own_info_requested(self):
+        """ Test response contains email and gender info if user is requesting own info """
+        # Arrange
+        self.user.email_address = TEST_EMAIL
+        self.user.gender = UserGender.MALE.value
+        self.user.save()
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["id"], TEST_USER_ID)
+        self.assertEqual(response.json["username"], TEST_USERNAME)
+        self.assertEqual(response.json["emailAddress"], TEST_EMAIL)
+        self.assertEqual(response.json["gender"], UserGender.MALE.name)
+        self.assertEqual(response.json["isEmailVerified"], False)
+        self.assertEqual(response.json["selfDescriptionGender"], None)
+
+    def test_email_and_gender_not_returned_if_requested_by_other(self):
+        """Test response does not contain email and gender info if user is requesting info for another user"""
+        # Arrange
+        self.user.email_address = TEST_EMAIL
+        self.user.gender = UserGender.FEMALE.value
+        self.user.save()
+        user_2 = return_canned_user("user_2", 2222222)
+        user_2.create()
+        user_2_session_token = generate_encoded_token(user_2.id)
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": user_2_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["id"], TEST_USER_ID)
+        self.assertEqual(response.json["username"], TEST_USERNAME)
+        self.assertIsNone(response.json["emailAddress"])
+        self.assertIsNone(response.json["gender"])
+        self.assertIsNone(response.json["selfDescriptionGender"])

--- a/tests/backend/integration/api/users/test_statistics.py
+++ b/tests/backend/integration/api/users/test_statistics.py
@@ -1,10 +1,13 @@
 import time
+import random
+from datetime import datetime, timedelta
 
 from backend.models.postgis.task import Task, TaskStatus
 from tests.backend.base import BaseTestCase
 from tests.backend.helpers.test_helpers import (
     create_canned_project,
     generate_encoded_token,
+    return_canned_user,
 )
 
 
@@ -16,12 +19,14 @@ class TestUsersStatisticsAPI(BaseTestCase):
         self.url = f"/api/v2/users/{self.test_user.username}/statistics/"
 
     def test_returns_401_if_no_token(self):
+        """ Test that the user needs to be logged in. """
         # Act
         response = self.client.get(self.url)
         # Assert
         self.assertEqual(response.status_code, 401)
 
     def test_return_404_if_user_not_found(self):
+        """ Test returns 404 if user not found. """
         # Act
         response = self.client.get(
             "/api/v2/users/doesntexist/statistics/",
@@ -32,6 +37,7 @@ class TestUsersStatisticsAPI(BaseTestCase):
         self.assertEqual(response.json["SubCode"], "NotFound")
 
     def test_return_200_if_user_found(self):
+        """ Test returns 200 if user found. """
         # Arrange
         task = Task.get(1, self.test_project.id)
         task.lock_task_for_mapping(self.test_user.id)
@@ -43,7 +49,6 @@ class TestUsersStatisticsAPI(BaseTestCase):
         )
         # Assert
         self.assertEqual(response.status_code, 200)
-        print(response.json)
         self.assertEqual(response.json["totalTimeSpent"], 5)
         self.assertEqual(response.json["timeSpentMapping"], 5)
         self.assertEqual(response.json["timeSpentValidating"], 0)
@@ -55,3 +60,97 @@ class TestUsersStatisticsAPI(BaseTestCase):
         self.assertEqual(response.json["tasksInvalidatedByOthers"], 0)
         self.assertEqual(response.json["tasksValidatedByOthers"], 0)
         self.assertEqual(response.json["ContributionsByInterest"], [])
+
+
+class TestUsersStatisticsAllAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_project, self.test_user = create_canned_project()
+        self.user_session_token = generate_encoded_token(self.test_user.id)
+        self.url = "/api/v2/users/statistics/"
+
+    def generate_random_user_level(self):
+        return random.randint(1, 3)
+
+    def test_returns_401_if_no_token(self):
+        """Test that the user needs to be logged in."""
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def returns_400_if_start_date_not_provided(self):
+        """ Test that the start date needs to be provided. """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["SubCode"], "MissingDate")
+
+    def returns_400_if_invalid_date_value(self):
+        """ Test that the date should be in date format """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"startDate": "invalid"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["SubCode"], "InvalidDateValue")
+
+    def returns_400_if_start_date_greater_than_end_date(self):
+        """ Test that the start date cannot be greater than the end date. """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"startDate": "2020-01-01", "endDate": "2019-01-01"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["SubCode"], "InvalidDateRange")
+
+    def test_returns_400_if_date_range_greater_than_3_years(self):
+        """ Test that the date range cannot be greater than 3 years. """
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"startDate": "2017-01-01", "endDate": "2021-01-01"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["SubCode"], "InvalidDateRange")
+
+    def test_returns_all_users_statistics(self):
+        """ Test that the statistics for all users that registerd in the give priod are returned."""
+        # Arrange
+        mapping_level_dict = {1: 0, 2: 0, 3: 0}
+        #  Create 10 users with random mapping levels
+        for i in range(10):
+            user = return_canned_user(f"user_{i}", i)
+            user.mapping_level = self.generate_random_user_level()
+            mapping_level_dict[user.mapping_level] += 1
+            user.date_registered = datetime.today() - timedelta(days=100)
+            user.create()
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={
+                "startDate": (datetime.today() - timedelta(days=100)).strftime(
+                    "%Y-%m-%d"
+                ),
+                "endDate": datetime.now().strftime("%Y-%m-%d"),
+            },
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["total"], 10)
+        self.assertEqual(response.json["beginner"], mapping_level_dict[1])
+        self.assertEqual(response.json["intermediate"], mapping_level_dict[2])
+        self.assertEqual(response.json["advanced"], mapping_level_dict[3])

--- a/tests/backend/integration/api/users/test_statistics.py
+++ b/tests/backend/integration/api/users/test_statistics.py
@@ -1,0 +1,57 @@
+import time
+
+from backend.models.postgis.task import Task, TaskStatus
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import (
+    create_canned_project,
+    generate_encoded_token,
+)
+
+
+class TestUsersStatisticsAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_project, self.test_user = create_canned_project()
+        self.user_session_token = generate_encoded_token(self.test_user.id)
+        self.url = f"/api/v2/users/{self.test_user.username}/statistics/"
+
+    def test_returns_401_if_no_token(self):
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def test_return_404_if_user_not_found(self):
+        # Act
+        response = self.client.get(
+            "/api/v2/users/doesntexist/statistics/",
+            headers={"Authorization": self.user_session_token},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json["SubCode"], "NotFound")
+
+    def test_return_200_if_user_found(self):
+        # Arrange
+        task = Task.get(1, self.test_project.id)
+        task.lock_task_for_mapping(self.test_user.id)
+        time.sleep(5)
+        task.unlock_task(self.test_user.id, TaskStatus.MAPPED)
+        # Act
+        response = self.client.get(
+            self.url, headers={"Authorization": self.user_session_token}
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        print(response.json)
+        self.assertEqual(response.json["totalTimeSpent"], 5)
+        self.assertEqual(response.json["timeSpentMapping"], 5)
+        self.assertEqual(response.json["timeSpentValidating"], 0)
+        self.assertEqual(response.json["projectsMapped"], 0)
+        self.assertEqual(response.json["countriesContributed"]["total"], 0)
+        self.assertEqual(response.json["tasksMapped"], 1)
+        self.assertEqual(response.json["tasksValidated"], 0)
+        self.assertEqual(response.json["tasksInvalidated"], 0)
+        self.assertEqual(response.json["tasksInvalidatedByOthers"], 0)
+        self.assertEqual(response.json["tasksValidatedByOthers"], 0)
+        self.assertEqual(response.json["ContributionsByInterest"], [])

--- a/tests/backend/integration/api/users/test_tasks.py
+++ b/tests/backend/integration/api/users/test_tasks.py
@@ -1,0 +1,193 @@
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import (
+    create_canned_project,
+    generate_encoded_token,
+)
+from backend.models.postgis.task import Task, TaskStatus
+from backend.models.postgis.statuses import ProjectStatus
+
+
+class TetUsersTasksAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_project, self.test_author = create_canned_project()
+        self.user_session_token = generate_encoded_token(self.test_author.id)
+        self.url = f"/api/v2/users/{self.test_author.id}/tasks/"
+
+    def test_returns_401_if_no_token(self):
+        """ Test that the API returns a 401 if no token is provided """
+        # Act
+        response = self.client.get(self.url)
+        # Assert
+        self.assertEqual(response.status_code, 401)
+
+    def change_task_status(self, task_id, status, project_id):
+        """ Helper function to change the status of a task """
+        task = Task.get(task_id, project_id)
+        if status == TaskStatus.MAPPED:
+            task.lock_task_for_mapping(self.test_author.id)
+        elif status == TaskStatus.VALIDATED:
+            task.lock_task_for_validating(self.test_author.id)
+        task.unlock_task(self.test_author.id, status)
+
+    def test_returns_200_on_success(self):
+        """ Test that the API returns a 200 on success """
+        # Arrange
+        self.change_task_status(1, TaskStatus.MAPPED, self.test_project.id)
+        self.change_task_status(2, TaskStatus.VALIDATED, self.test_project.id)
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"project_id": self.test_project.id},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["tasks"]), 2)
+        self.assertEqual(response.json["tasks"][0]["taskId"], 2)
+
+    def test_returns_paginated_results(self):
+        """ Test that the API returns paginated results """
+        # Arrange
+        self.change_task_status(1, TaskStatus.MAPPED, self.test_project.id)
+        self.change_task_status(2, TaskStatus.VALIDATED, self.test_project.id)
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"project_id": self.test_project.id, "page_size": 1},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["tasks"]), 1)
+        self.assertEqual(response.json["pagination"]["total"], 2)
+        self.assertEqual(response.json["pagination"]["page"], 1)
+        self.assertEqual(response.json["pagination"]["perPage"], 1)
+        self.assertEqual(response.json["pagination"]["hasNext"], True)
+
+    def test_filters_by_project_if_project_id_passed(self):
+        """ Test that the API filters by project if project_id is passed """
+        # Arrange
+        test_project_2, _ = create_canned_project()
+        self.change_task_status(1, TaskStatus.MAPPED, self.test_project.id)
+        self.change_task_status(2, TaskStatus.VALIDATED, self.test_project.id)
+        self.change_task_status(1, TaskStatus.MAPPED, test_project_2.id)
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"project_id": test_project_2.id},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["tasks"]), 1)
+        self.assertEqual(response.json["tasks"][0]["taskId"], 1)
+        self.assertEqual(response.json["tasks"][0]["projectId"], test_project_2.id)
+        self.assertEqual(
+            response.json["tasks"][0]["taskStatus"], TaskStatus.MAPPED.name
+        )
+
+    def test_filters_by_status_if_status_passed(self):
+        """ Test that the API filters by status if status is passed """
+        # Arrange
+        self.change_task_status(1, TaskStatus.MAPPED, self.test_project.id)
+        self.change_task_status(2, TaskStatus.VALIDATED, self.test_project.id)
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={
+                "project_id": self.test_project.id,
+                "status": TaskStatus.MAPPED.name,
+            },
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["tasks"]), 1)
+        self.assertEqual(response.json["tasks"][0]["taskId"], 1)
+        self.assertEqual(response.json["tasks"][0]["projectId"], self.test_project.id)
+        self.assertEqual(
+            response.json["tasks"][0]["taskStatus"], TaskStatus.MAPPED.name
+        )
+
+    def test_filters_by_project_status_if_project_status_passed(self):
+        """ Test that the API filters by project status if passed """
+        # Arrange
+        test_project_2, _ = create_canned_project()
+        test_project_2.status = ProjectStatus.PUBLISHED.value
+        test_project_2.save()
+        self.change_task_status(1, TaskStatus.MAPPED, self.test_project.id)
+        self.change_task_status(1, TaskStatus.MAPPED, test_project_2.id)
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"project_status": ProjectStatus.PUBLISHED.name},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["tasks"]), 1)
+        self.assertEqual(response.json["tasks"][0]["taskId"], 1)
+        self.assertEqual(response.json["tasks"][0]["projectId"], test_project_2.id)
+
+    def test_sorts_results_by_project_id_in_defined_order(self):
+        """ Test that the API sorts results by project id in defined order """
+        # Arrange
+        test_project_2, _ = create_canned_project()
+        self.change_task_status(1, TaskStatus.MAPPED, self.test_project.id)
+        self.change_task_status(2, TaskStatus.MAPPED, self.test_project.id)
+        self.change_task_status(1, TaskStatus.MAPPED, test_project_2.id)
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"sort_by": "project_id"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["tasks"]), 3)
+        self.assertEqual(response.json["tasks"][0]["projectId"], self.test_project.id)
+        self.assertEqual(response.json["tasks"][1]["projectId"], self.test_project.id)
+        self.assertEqual(response.json["tasks"][2]["projectId"], test_project_2.id)
+
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"sort_by": "-project_id"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["tasks"]), 3)
+        self.assertEqual(response.json["tasks"][0]["projectId"], test_project_2.id)
+        self.assertEqual(response.json["tasks"][1]["projectId"], self.test_project.id)
+        self.assertEqual(response.json["tasks"][2]["projectId"], self.test_project.id)
+
+    def test_sorts_results_by_action_date_in_defined_order(self):
+        """ Test that the API sorts results by action date in defined order """
+        # Arrange
+        self.change_task_status(1, TaskStatus.MAPPED, self.test_project.id)
+        self.change_task_status(2, TaskStatus.MAPPED, self.test_project.id)
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"sort_by": "action_date"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["tasks"]), 2)
+        self.assertEqual(response.json["tasks"][0]["taskId"], 1)
+        self.assertEqual(response.json["tasks"][1]["taskId"], 2)
+
+        # Act
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.user_session_token},
+            query_string={"sort_by": "-action_date"},
+        )
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json["tasks"]), 2)
+        self.assertEqual(response.json["tasks"][0]["taskId"], 2)
+        self.assertEqual(response.json["tasks"][1]["taskId"], 1)


### PR DESCRIPTION
This PR adds test cases for following endponts:
| Transaction                                                 | Total count (last 3 months) |
| ----------------------------------------------------------- | ----------- |
| backend.api.users.resources:usersqueriesownlockeddetailsapi | 705k        |
| backend.api.users.resources:usersqueriesusernameapi         | 606k        |
| backend.api.users.openstreetmap:usersopenstreetmapapi       | 471k        |
| backend.api.users.resources:usersqueriesownlockedapi        | 336k        |
| backend.api.users.statistics:usersstatisticsapi             | 137k        |
| backend.api.users.resources:usersqueriesinterestsapi        | 41.7k       |
| backend.api.users.tasks:userstasksapi                       | 34.2k       |
| backend.api.users.actions:usersactionsregisteremailapi      | 16.7k       |
| backend.api.users.actions:usersactionssetusersapi           | 16.5k       |
| backend.api.users.resources:usersqueriesusernamefilterapi   | 8.41k       |
| backend.api.users.resources:usersallapi                     | 5.98k       |
| backend.api.users.resources:usersrecommendedprojectsapi     | 3.02k       |
| backend.api.users.actions:create_user_interest              | 2.8k        |
| backend.api.users.actions:usersactionsverifyemailapi        | 2.1k        |
| backend.api.users.statistics:usersstatisticsallapi          | 200         |
| backend.api.users.actions:usersactionssetroleapi            | 4           |
| backend.api.users.resources:usersrestapi                    | 3           |