### PR TITLE
Add tests for endpoints related to the Teams module

### DIFF
--- a/backend/api/teams/actions.py
+++ b/backend/api/teams/actions.py
@@ -12,6 +12,8 @@ from backend.services.team_service import (
 from backend.services.users.authentication_service import token_auth, tm
 from backend.models.postgis.user import User
 
+TEAM_NOT_FOUND = "Team not found"
+
 
 class TeamsActionsJoinAPI(Resource):
     @token_auth.login_required
@@ -53,7 +55,7 @@ class TeamsActionsJoinAPI(Resource):
         except TeamServiceError as e:
             return {"Error": str(e), "SubCode": "InvalidRequest"}, 400
         except NotFound:
-            return {"Error": "Team not found", "SubCode": "NotFound"}, 404
+            return {"Error": TEAM_NOT_FOUND, "SubCode": "NotFound"}, 404
         except Exception as e:
             return {"Error": str(e), "SubCode": "InternalServerError"}, 500
 
@@ -146,7 +148,7 @@ class TeamsActionsJoinAPI(Resource):
                 )
                 return {"Success": "True"}, 200
         except NotFound:
-            return {"Error": "Team not found", "SubCode": "NotFound"}, 404
+            return {"Error": TEAM_NOT_FOUND, "SubCode": "NotFound"}, 404
         except Exception as e:
             error_msg = f"Team Join PUT - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)
@@ -354,7 +356,7 @@ class TeamsActionsMessageMembersAPI(Resource):
                 team = TeamService.get_team_by_id(team_id)
             except NotFound:
                 return {
-                    "Error": "Team not found",
+                    "Error": TEAM_NOT_FOUND,
                     "SubCode": "NotFound",
                 }, 404
 

--- a/backend/api/teams/actions.py
+++ b/backend/api/teams/actions.py
@@ -145,8 +145,8 @@ class TeamsActionsJoinAPI(Resource):
                     team_id, authenticated_user_id, username, role, action
                 )
                 return {"Success": "True"}, 200
-        except NotFound as e:
-            return {"Error": str(e), "SubCode": "NotFound"}, 404
+        except NotFound:
+            return {"Error": "Team not found", "SubCode": "NotFound"}, 404
         except Exception as e:
             error_msg = f"Team Join PUT - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)
@@ -353,7 +353,10 @@ class TeamsActionsMessageMembersAPI(Resource):
             try:
                 team = TeamService.get_team_by_id(team_id)
             except NotFound:
-                return {"Error": "Team not found"}, 404
+                return {
+                    "Error": "Team not found",
+                    "SubCode": "NotFound",
+                }, 404
 
             is_manager = TeamService.is_user_team_manager(
                 team_id, authenticated_user_id

--- a/backend/api/teams/resources.py
+++ b/backend/api/teams/resources.py
@@ -160,12 +160,14 @@ class TeamsRestAPI(Resource):
                         type: boolean
                         default: false
         responses:
-            201:
+            200:
                 description: Team updated successfully
             400:
                 description: Client Error - Invalid Request
             401:
                 description: Unauthorized - Invalid credentials
+            403:
+                description: Forbidden
             500:
                 description: Internal Server Error
         """
@@ -184,7 +186,7 @@ class TeamsRestAPI(Resource):
                 return {
                     "Error": "User is not a admin or a manager for the team",
                     "SubCode": "UserNotTeamManager",
-                }, 401
+                }, 403
         except DataError as e:
             current_app.logger.error(f"error validating request: {str(e)}")
             return {"Error": str(e), "SubCode": "InvalidData"}, 400
@@ -480,7 +482,7 @@ class TeamsAllAPI(Resource):
             return str(e), 400
         except NotFound:
             error_msg = "Team POST - Organisation does not exist"
-            return {"Error": error_msg, "SubCode": "NotFound"}, 400
+            return {"Error": error_msg, "SubCode": "NotFound"}, 404
         except Exception as e:
             error_msg = f"Team POST - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)

--- a/backend/services/team_service.py
+++ b/backend/services/team_service.py
@@ -50,6 +50,7 @@ class TeamJoinNotAllowed(Exception):
 class TeamService:
     @staticmethod
     def request_to_join_team(team_id: int, user_id: int):
+        team = TeamService.get_team_by_id(team_id)
         # If user has team manager permission add directly to the team without request.E.G. Admins, Org managers
         if TeamService.is_user_team_member(team_id, user_id):
             raise TeamServiceError(
@@ -61,7 +62,6 @@ class TeamService:
             )
             return
 
-        team = TeamService.get_team_by_id(team_id)
         # Cannot send join request to BY_INVITE team
         if team.join_method == TeamJoinMethod.BY_INVITE.value:
             raise TeamServiceError(
@@ -535,7 +535,7 @@ class TeamService:
     @staticmethod
     def is_user_team_manager(team_id: int, user_id: int):
         # Admin manages all teams
-        team = Team.get(team_id)
+        team = TeamService.get_team_by_id(team_id)
         if UserService.is_user_an_admin(user_id):
             return True
 

--- a/tests/backend/integration/api/teams/test_actions.py
+++ b/tests/backend/integration/api/teams/test_actions.py
@@ -13,10 +13,12 @@ from backend.models.postgis.statuses import (
     TeamJoinMethod,
     TeamMemberFunctions,
 )
+from backend.api.teams import TEAM_NOT_FOUND
 
 TEST_ADMIN_USERNAME = "Test Admin"
 TEST_MESSAGE = "This is a test message"
 TEST_SUBJECT = "Test Subject"
+NON_EXISTENT_USER = "Random User"
 
 
 class TestTeamsActionsJoinAPI(BaseTestCase):
@@ -61,7 +63,7 @@ class TestTeamsActionsJoinAPI(BaseTestCase):
         )
         response_body = response.get_json()
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response_body["Error"], "Team not found")
+        self.assertEqual(response_body["Error"], TEAM_NOT_FOUND)
 
     def test_request_to_join_team_with_invite_only_request_fails(self):
         """
@@ -153,7 +155,7 @@ class TestTeamsActionsJoinAPI(BaseTestCase):
         )
         response_body = response.get_json()
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response_body["Error"], "Team not found")
+        self.assertEqual(response_body["Error"], TEAM_NOT_FOUND)
         self.assertEqual(response_body["SubCode"], "NotFound")
 
 
@@ -243,7 +245,7 @@ class TestTeamsActionsAddAPI(BaseTestCase):
         response = self.client.post(
             self.endpoint_url,
             json={
-                "username": "Random User",
+                "username": NON_EXISTENT_USER,
                 "role": TeamMemberFunctions.MEMBER.name.lower(),
             },
             headers={"Authorization": self.admin_token},
@@ -259,7 +261,7 @@ class TestTeamsActionsAddAPI(BaseTestCase):
         response = self.client.post(
             "/api/v2/teams/99/actions/add/",
             json={
-                "username": "Random User",
+                "username": NON_EXISTENT_USER,
                 "role": TeamMemberFunctions.MEMBER.name.lower(),
             },
             headers={"Authorization": self.admin_token},
@@ -346,7 +348,7 @@ class TestTeamsActionsLeaveAPI(BaseTestCase):
         response = self.client.post(
             self.endpoint_url,
             json={
-                "username": "Random User",
+                "username": NON_EXISTENT_USER,
             },
             headers={"Authorization": self.admin_token},
         )
@@ -398,7 +400,7 @@ class TestTeamsActionsMessageMembersAPI(BaseTestCase):
         )
         response_body = response.get_json()
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response_body["Error"], "Team not found")
+        self.assertEqual(response_body["Error"], TEAM_NOT_FOUND)
         self.assertEqual(response_body["SubCode"], "NotFound")
 
     def test_message_team_members_by_unauthenticated_user_fails(self):

--- a/tests/backend/integration/api/teams/test_actions.py
+++ b/tests/backend/integration/api/teams/test_actions.py
@@ -1,0 +1,465 @@
+from unittest.mock import patch
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import (
+    return_canned_organisation,
+    generate_encoded_token,
+    create_canned_user,
+    return_canned_user,
+    create_canned_team,
+    add_user_to_team,
+)
+from backend.models.postgis.statuses import (
+    UserRole,
+    TeamJoinMethod,
+    TeamMemberFunctions,
+)
+
+TEST_ADMIN_USERNAME = "Test Admin"
+TEST_MESSAGE = "This is a test message"
+TEST_SUBJECT = "Test Subject"
+
+
+class TestTeamsActionsJoinAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_team = create_canned_team()
+        self.test_user = create_canned_user()
+        self.test_org = return_canned_organisation()
+        self.test_admin = return_canned_user(username=TEST_ADMIN_USERNAME, id=11111)
+        self.test_admin.create()
+        self.test_admin.role = UserRole.ADMIN.value
+        self.admin_token = generate_encoded_token(self.test_admin.id)
+        self.session_token = generate_encoded_token(self.test_user.id)
+        self.endpoint_url = f"/api/v2/teams/{self.test_team.id}/actions/join/"
+
+    # post
+    def test_request_to_join_team_by_unauthenticated_user_fails(self):
+        """
+        Test that endpoint returns 401 when unauthenticated user requests to join a team
+        """
+        response = self.client.post(self.endpoint_url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_request_to_join_team_by_authenticated_user_passes(self):
+        """
+        Test that endpoint returns 200 when authenticated user requests to join a team
+        """
+        response = self.client.post(
+            self.endpoint_url, headers={"Authorization": self.session_token}
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["Success"], "Join request successful")
+
+    def test_request_to_join_non_existent_team_fails(self):
+        """
+        Test that endpoint returns 404 when a user requests to join a non existent team
+        """
+        response = self.client.post(
+            "/api/v2/teams/99/actions/join/",
+            headers={"Authorization": self.session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], "Team not found")
+
+    def test_request_to_join_team_with_invite_only_request_fails(self):
+        """
+        Test that endpoint returns 400 when a user requests to join a team that can only be joined by invite
+        """
+        self.test_team.join_method = TeamJoinMethod.BY_INVITE.value
+        response = self.client.post(
+            self.endpoint_url, headers={"Authorization": self.session_token}
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response_body["Error"], "Team join method is BY_INVITE")
+
+    # patch
+    def test_handle_join_request_by_admin_passes(self):
+        """
+        Test that endpoint returns 200 when admin accepts a join request
+        """
+        add_user_to_team(
+            team=self.test_team,
+            user=self.test_user,
+            role=TeamMemberFunctions.MEMBER.value,
+            is_active=True,
+        )
+        response = self.client.patch(
+            self.endpoint_url,
+            headers={"Authorization": self.admin_token},
+            json={
+                "action": "accept",
+                "role": "member",
+                "type": "join-response",
+                "username": self.test_user.username,
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["Success"], "True")
+
+    def test_handle_join_request_by_unauthenticated_user_fails(self):
+        """
+        Test that endpoint returns 401 when an unauthenticated user tries to accept a join request
+        """
+        response = self.client.patch(
+            self.endpoint_url,
+            json={
+                "action": "accept",
+                "role": "member",
+                "type": "join-response",
+                "username": self.test_user.username,
+            },
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_handle_join_request_by_non_admin_fails(self):
+        """
+        Test that endpoint returns 403 when a non admin tries to accept a join request
+        """
+        response = self.client.patch(
+            self.endpoint_url,
+            headers={"Authorization": self.session_token},
+            json={
+                "action": "accept",
+                "role": "member",
+                "type": "join-response",
+                "username": self.test_user.username,
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response_body["Error"],
+            "You don't have permissions to approve this join team request",
+        )
+        self.assertEqual(response_body["SubCode"], "ApproveJoinError")
+
+    def test_handle_join_request_to_non_existent_team_fails(self):
+        """
+        Test that endpoint returns 404 when handling a join request to a non existent team
+        """
+        response = self.client.patch(
+            "/api/v2/teams/99/actions/join/",
+            headers={"Authorization": self.session_token},
+            json={
+                "action": "accept",
+                "role": "member",
+                "type": "join-response",
+                "username": self.test_user.username,
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], "Team not found")
+        self.assertEqual(response_body["SubCode"], "NotFound")
+
+
+class TestTeamsActionsAddAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_team = create_canned_team()
+        self.test_user = create_canned_user()
+        self.test_org = return_canned_organisation()
+        self.test_admin = return_canned_user(username=TEST_ADMIN_USERNAME, id=11111)
+        self.test_admin.create()
+        self.test_admin.role = UserRole.ADMIN.value
+        self.admin_token = generate_encoded_token(self.test_admin.id)
+        self.session_token = generate_encoded_token(self.test_user.id)
+        self.endpoint_url = f"/api/v2/teams/{self.test_team.id}/actions/add/"
+
+    def test_add_members_to_team_by_admin_passes(self):
+        """
+        Test that endpoint returns 200 when admin adds members to a team successfully
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "username": self.test_user.username,
+                "role": TeamMemberFunctions.MEMBER.name.lower(),
+            },
+            headers={"Authorization": self.admin_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["Success"], "User added to the team")
+
+    def test_add_members_to_team_by_unauthenticated_user_fails(self):
+        """
+        Test that endpoint returns 401 when an unauthenticated user tries to add members to a team
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "username": self.test_user.username,
+                "role": TeamMemberFunctions.MEMBER.name.lower(),
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_body["SubCode"], "InvalidToken")
+
+    def test_add_members_to_team_using_invalid_data_fails(self):
+        """
+        Test that endpoint returns 400 when invalid data is used to add members to a team
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "user_username": self.test_user.username,
+                "team_role": TeamMemberFunctions.MEMBER.name.lower(),
+            },
+            headers={"Authorization": self.admin_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response_body["SubCode"], "InvalidData")
+
+    def test_add_members_to_team_by_non_admin_fails(self):
+        """
+        Test that the endpoint returns 500 when non-admin handles a join request
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "username": self.test_user.username,
+                "role": TeamMemberFunctions.MEMBER.name.lower(),
+            },
+            headers={"Authorization": self.session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response_body["SubCode"], "InternalServerError")
+        self.assertTrue(
+            "User is not allowed to add member to the team" in response_body["Error"]
+        )
+
+    def test_add_non_existent_members_to_team_fails(self):
+        """
+        Test that endpoint returns 500 when adding non existent users to a team
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "username": "Random User",
+                "role": TeamMemberFunctions.MEMBER.name.lower(),
+            },
+            headers={"Authorization": self.admin_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response_body["SubCode"], "InternalServerError")
+
+    def test_add_members_to_non_existent_team_fails(self):
+        """
+        Test that endpoint returns 500 when adding users to a non_existent team
+        """
+        response = self.client.post(
+            "/api/v2/teams/99/actions/add/",
+            json={
+                "username": "Random User",
+                "role": TeamMemberFunctions.MEMBER.name.lower(),
+            },
+            headers={"Authorization": self.admin_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response_body["SubCode"], "InternalServerError")
+
+
+class TestTeamsActionsLeaveAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_team = create_canned_team()
+        self.test_user = create_canned_user()
+        self.test_org = return_canned_organisation()
+        self.test_admin = return_canned_user(username=TEST_ADMIN_USERNAME, id=11111)
+        self.test_admin.create()
+        self.test_admin.role = UserRole.ADMIN.value
+        self.admin_token = generate_encoded_token(self.test_admin.id)
+        self.session_token = generate_encoded_token(self.test_user.id)
+        self.endpoint_url = f"/api/v2/teams/{self.test_team.id}/actions/leave/"
+
+    def test_remove_members_from_team_by_admin_passes(self):
+        """
+        Test that endpoint returns 200 when an admin successfully removes existent member from team
+        """
+        # Act: add member to the team
+        add_user_to_team(
+            team=self.test_team,
+            user=self.test_user,
+            role=TeamMemberFunctions.MEMBER.value,
+            is_active=True,
+        )
+
+        # Test: remove user from team
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "username": self.test_user.username,
+            },
+            headers={"Authorization": self.admin_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["Success"], "User removed from the team")
+
+    def test_remove_members_from_team_by_unauthenticated_user_fails(self):
+        """
+        Test that endpoint returns 401 when an unauthenticated user tries to remove a member from the team
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "username": self.test_user.username,
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_body["SubCode"], "InvalidToken")
+
+    def test_remove_members_from_team_by_non_admin_fails(self):
+        """
+        Test that endpoint returns 403 when a non-admin tries to remove a member from the team
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "username": self.test_admin.username,
+            },
+            headers={"Authorization": self.session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response_body["Error"],
+            f"You don't have permissions to remove {TEST_ADMIN_USERNAME} from this team.",
+        )
+        self.assertEqual(response_body["SubCode"], "RemoveUserError")
+
+    def test_remove_non_existent_members_from_team_fails(self):
+        """
+        Test that endpoint returns 404 when attempting to remove non-existent members from a team
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "username": "Random User",
+            },
+            headers={"Authorization": self.admin_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], "No team member found")
+        self.assertEqual(response_body["SubCode"], "NotFound")
+
+    def test_remove_members_from_non_existent_team_fails(self):
+        """
+        Test that endpoint returns 404 when attempting to remove members from a non-existent team
+        """
+        response = self.client.post(
+            "/api/v2/teams/99/actions/leave/",
+            json={
+                "username": self.test_user.username,
+            },
+            headers={"Authorization": self.admin_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], "No team member found")
+        self.assertEqual(response_body["SubCode"], "NotFound")
+
+
+class TestTeamsActionsMessageMembersAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_team = create_canned_team()
+        self.test_user = create_canned_user()
+        self.test_org = return_canned_organisation()
+        self.test_admin = return_canned_user(username=TEST_ADMIN_USERNAME, id=11111)
+        self.test_admin.create()
+        self.test_admin.role = UserRole.ADMIN.value
+        self.admin_token = generate_encoded_token(self.test_admin.id)
+        self.session_token = generate_encoded_token(self.test_user.id)
+        self.endpoint_url = (
+            f"/api/v2/teams/{self.test_team.id}/actions/message-members/"
+        )
+
+    def test_message_members_non_existent_team_fails(self):
+        """
+        Test that endpoint returns 404 when messaging members of non-existent team
+        """
+        response = self.client.post(
+            "/api/v2/teams/99/actions/message-members/",
+            json={"message": TEST_MESSAGE, "subject": TEST_SUBJECT},
+            headers={"Authorization": self.admin_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], "Team not found")
+        self.assertEqual(response_body["SubCode"], "NotFound")
+
+    def test_message_team_members_by_unauthenticated_user_fails(self):
+        """
+        Test that endpoint returns 401 when messaging members by an unauthenticated user
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={"message": TEST_MESSAGE, "subject": TEST_SUBJECT},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_body["SubCode"], "InvalidToken")
+
+    def test_message_team_members_by_non_admin_fails(self):
+        """
+        Test that endpoint returns 403 when messaging members by a non admin
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={"message": TEST_MESSAGE, "subject": TEST_SUBJECT},
+            headers={"Authorization": self.session_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response_body["Error"], "Unauthorised to send message to team members"
+        )
+        self.assertEqual(response_body["SubCode"], "UserNotPermitted")
+
+    def test_message_team_members_with_invalid_data_fails(self):
+        """
+        Test that endpoint returns 400 when sending invalid request data to the messaging API
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "message": ["Message should be a string type not list"],
+                "subject": "",
+            },
+            headers={"Authorization": self.admin_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response_body["Error"], "Request payload did not match validation"
+        )
+        self.assertEqual(response_body["SubCode"], "InvalidData")
+
+    @patch("threading.Thread.start")
+    def test_message_team_members_with_valid_message_by_admin_passes(self, mock_thread):
+        """
+        Test that endpoint returns 200 when sending vaalid message to team members
+        """
+        # Mock the thread start method to avoid application context issues
+        mock_thread.return_value = None
+        response = self.client.post(
+            self.endpoint_url,
+            json={"message": TEST_MESSAGE, "subject": TEST_SUBJECT},
+            headers={"Authorization": self.admin_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["Success"], "Message sent successfully")

--- a/tests/backend/integration/api/teams/test_resources.py
+++ b/tests/backend/integration/api/teams/test_resources.py
@@ -1,0 +1,266 @@
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import (
+    create_canned_organisation,
+    generate_encoded_token,
+    create_canned_user,
+    return_canned_user,
+    return_canned_team,
+    create_canned_team,
+)
+from backend.models.postgis.statuses import UserRole
+
+TEST_ORGANISATION_NAME = "Kathmandu Living Labs"
+TEST_ORGANISATION_SLUG = "KLL"
+TEST_ORGANISATION_ID = 23
+TEST_TEAM_NAME = "Test Team"
+NEW_TEAM_NAME = "KLL Team"
+
+
+class TestTeamsRestAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_org = create_canned_organisation()
+        self.test_user = create_canned_user()
+        self.test_user_token = generate_encoded_token(self.test_user.id)
+        self.test_team = create_canned_team()
+        self.endpoint_url = f"/api/v2/teams/{self.test_team.id}/"
+
+    # get
+    def test_get_non_existent_team_by_id_fails(self):
+        """
+        Test that endpoint returns 404 if team does not exist
+        """
+        response = self.client.get("/api/v2/teams/99/")
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], "Team Not Found")
+        self.assertEqual(response_body["SubCode"], "NotFound")
+
+    def test_get_team_by_id_passes(self):
+        """
+        Test that endpoint returns 200 when retrieving existing team
+        """
+        response = self.client.get(self.endpoint_url)
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["name"], TEST_TEAM_NAME)
+        self.assertEqual(response_body["organisation_id"], TEST_ORGANISATION_ID)
+        self.assertEqual(response_body["organisationSlug"], TEST_ORGANISATION_SLUG)
+        self.assertEqual(response_body["organisation"], TEST_ORGANISATION_NAME)
+        self.assertEqual(response_body["is_org_admin"], False)
+        self.assertEqual(response_body["team_projects"], [])
+
+    # patch
+    def test_update_team_by_admin_passes(self):
+        """
+        Test that endpoint returns 200 if team update is successful
+        """
+        self.test_user.role = UserRole.ADMIN.value
+        response = self.client.patch(
+            self.endpoint_url,
+            headers={"Authorization": self.test_user_token},
+            json={"name": NEW_TEAM_NAME},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body, {"Status": "Updated"})
+
+    def test_update_team_by_unauthenticated_user_fails(self):
+        """
+        Test that endpoint returns 401 if an unauthenticated user tries to update a team
+        """
+        response = self.client.patch(self.endpoint_url, json={"name": NEW_TEAM_NAME})
+        self.assertEqual(response.status_code, 401)
+
+    def test_update_team_by_non_admin_fails(self):
+        """
+        Test that endpoint returns 403 if a non_admin tries to update a team
+
+        """
+        response = self.client.patch(
+            self.endpoint_url,
+            headers={"Authorization": self.test_user_token},
+            json={"name": NEW_TEAM_NAME},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response_body["Error"], "User is not a admin or a manager for the team"
+        )
+        self.assertEqual(response_body["SubCode"], "UserNotTeamManager")
+
+    def test_update_team_with_invalid_data_fails(self):
+        """
+        Test that endpoint returns 400 if an admin tries to update a team using the wrong request keys/data
+        """
+        response = self.client.patch(
+            self.endpoint_url,
+            headers={"Authorization": self.test_user_token},
+            json={"team_name": NEW_TEAM_NAME},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response_body["SubCode"], "InvalidData")
+
+    # delete
+    def test_delete_team_by_admin_passes(self):
+        """
+        Test that endpoint returns 200 upon successful deletion of a team
+        """
+        self.test_user.role = UserRole.ADMIN.value
+        response = self.client.delete(
+            self.endpoint_url, headers={"Authorization": self.test_user_token}
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["Success"], "Team deleted")
+
+    def test_delete_team_by_unauthenticated_user_fails(self):
+        """
+        Test that endpoint returns 401 if an unauthenticated user tries to delete a team
+        """
+        response = self.client.delete(self.endpoint_url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_delete_team_by_non_admin_fails(self):
+        """
+        Test that endpoint returns 401 if a non_admin tries to delete a team
+        """
+        response = self.client.delete(
+            self.endpoint_url, headers={"Authorization": self.test_user_token}
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_body["Error"], "User is not a manager for the team")
+        self.assertEqual(response_body["SubCode"], "UserNotTeamManager")
+
+    def test_delete_non_existent_team_by_id_fails(self):
+        """
+        Test that endpoint returns 404 while deleting a non-existent team
+        """
+        self.test_user.role = UserRole.ADMIN.value
+        response = self.client.delete(
+            "/api/v2/teams/99/", headers={"Authorization": self.test_user_token}
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], "Team Not Found")
+        self.assertEqual(response_body["SubCode"], "NotFound")
+
+
+class TestTeamsAllPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_org = create_canned_organisation()
+        self.test_admin = return_canned_user("test user", 111111)
+        self.test_admin.create()
+        self.test_admin.role = UserRole.ADMIN.value
+        self.admin_token = generate_encoded_token(self.test_admin.id)
+        self.test_non_admin = create_canned_user()
+        self.non_admin_token = generate_encoded_token(self.test_non_admin.id)
+        self.endpoint_url = "/api/v2/teams/"
+
+    # post
+    def test_create_new_team_for_non_existent_org_fails(self):
+        """
+        Test that endpoint returns 404 when creating a team for a non-existent organisation
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "description": "",
+                "joinMethod": "ANY",
+                "name": "KLL Team",
+                "organisation_id": 99,
+                "visibility": "PUBLIC",
+            },
+            headers={"Authorization": self.admin_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response_body["Error"], "Team POST - Organisation does not exist"
+        )
+        self.assertEqual(response_body["SubCode"], "NotFound")
+
+    def test_create_new_team_non_admin_fails(self):
+        """
+        Test that endpoint returns 403 when creating a team by a non-admin
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "description": None,
+                "joinMethod": "ANY",
+                "name": NEW_TEAM_NAME,
+                "organisation_id": TEST_ORGANISATION_ID,
+                "visibility": "PUBLIC",
+            },
+            headers={"Authorization": self.non_admin_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response_body["Error"],
+            "User not permitted to create team for the Organisation",
+        )
+        self.assertEqual(response_body["SubCode"], "CreateTeamNotPermitted")
+
+    def test_create_new_team_existent_org_passes(self):
+        """
+        Test that endpoint returns 201 when creating a team by admin for an existent organisation
+        """
+        response = self.client.post(
+            self.endpoint_url,
+            json={
+                "description": None,
+                "joinMethod": "ANY",
+                "name": NEW_TEAM_NAME,
+                "organisation_id": TEST_ORGANISATION_ID,
+                "visibility": "PUBLIC",
+            },
+            headers={"Authorization": self.admin_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response_body, {"teamId": 1})
+
+    # get
+    def test_get_teams_authorised_passes(self):
+        """
+        Test that endpoint returns 200 when retrieving teams
+        """
+        self.test_team = return_canned_team(
+            name=TEST_TEAM_NAME, org_name=self.test_org.name
+        )
+        self.test_team.create()
+        response = self.client.get(
+            self.endpoint_url, headers={"Authorization": self.admin_token}
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response_body["teams"]), 1)
+        self.assertEqual(
+            response_body["teams"],
+            [
+                {
+                    "teamId": 2,
+                    "organisationId": 23,
+                    "description": None,
+                    "joinMethod": "ANY",
+                    "logo": None,
+                    "managersCount": 0,
+                    "members": [],
+                    "membersCount": 0,
+                    "name": TEST_TEAM_NAME,
+                    "organisation": TEST_ORGANISATION_NAME,
+                    "visibility": "PUBLIC",
+                }
+            ],
+        )
+
+    def test_get_teams_unauthorised_fails(self):
+        response = self.client.get(
+            self.endpoint_url,
+        )
+        self.assertEqual(response.status_code, 401)


### PR DESCRIPTION
This PR handles teams-related API endpoint tests.

**How to test:**

- create a test database following the instructions [here](https://github.com/hotosm/tasking-manager/blob/develop/docs-old/setup-development.md#create-the-database-user-and-database). The database name is preceded by `test_`
- pull and checkout test branch using `git fetch origin && git checkout chore/add-team-tests`
- run tests using `python3 -m unittest discover tests/backend`