### PR TITLE
Replace textarea in message contributors section with the markdown editor

### DIFF
--- a/frontend/src/components/comments/commentInput.js
+++ b/frontend/src/components/comments/commentInput.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import MDEditor from '@uiw/react-md-editor';
 import Tribute from 'tributejs';
@@ -16,20 +16,22 @@ import { DROPZONE_SETTINGS } from '../../config';
 import { htmlFromMarkdown, formatUserNamesToLink } from '../../utils/htmlFromMarkdown';
 import { iconConfig } from './editorIconConfig';
 import messages from './messages';
+import { CurrentUserAvatar } from '../user/avatar';
 
 export const CommentInputField = ({
   comment,
   setComment,
   contributors,
   enableHashtagPaste = false,
-  autoFocus,
-  isShowPreview = false,
-  isProjectDetailCommentSection = false,
+  isShowTabNavs = false,
+  isShowFooter = false,
   enableContributorsHashtag = false,
+  isShowUserPicture = false,
 }: Object) => {
   const token = useSelector((state) => state.auth.token);
   const textareaRef = useRef();
   const isBundle = useRef(false);
+  const [isShowPreview, setIsShowPreview] = useState(false);
 
   const appendImgToComment = (url) => setComment(`${comment}\n![image](${url})\n`);
   const [uploadError, uploading, onDrop] = useOnDrop(appendImgToComment);
@@ -79,6 +81,31 @@ export const CommentInputField = ({
 
   return (
     <div {...getRootProps()}>
+      {isShowTabNavs && (
+        <div className={`flex items-center gap-1 ${isShowUserPicture ? 'mb3' : ''}`}>
+          {isShowUserPicture && <CurrentUserAvatar className="w3 h3" />}
+          <div className="pv3-ns ph3 ph3-m bg-grey-light dib">
+            <span
+              role="button"
+              className={`pointer db dib-ns pb1 bb bw1 ${
+                !isShowPreview ? 'b--blue-dark' : 'b--grey-light'
+              }`}
+              onClick={() => setIsShowPreview(false)}
+            >
+              <FormattedMessage {...messages.write} />
+            </span>
+            <span
+              role="button"
+              className={`pointer ml3 db dib-ns pb1 bb bw1 ${
+                isShowPreview ? 'b--blue-dark' : 'b--grey-light'
+              }`}
+              onClick={() => setIsShowPreview(true)}
+            >
+              <FormattedMessage {...messages.preview} />
+            </span>
+          </div>
+        </div>
+      )}
       <div className={`${isShowPreview ? 'dn' : ''}`} data-color-mode="light">
         <FormattedMessage {...messages.leaveAComment}>
           {(val) => (
@@ -106,7 +133,7 @@ export const CommentInputField = ({
           accept="image/*"
           onChange={handleImagePick}
         />
-        {isProjectDetailCommentSection && (
+        {isShowFooter && (
           <div className="dn flex-ns justify-between ba bt-0 w-100 ph2 pv1 relative b--blue-grey textareaDetail">
             <span className="f7 lh-copy gray">
               <FormattedMessage {...messages.attachImage} />
@@ -118,7 +145,7 @@ export const CommentInputField = ({
         )}
       </div>
       {isShowPreview && (
-        <div className="cf db">
+        <div className="db" style={{ minHeight: 200 }}>
           {comment && (
             <div
               style={{ wordWrap: 'break-word' }}
@@ -127,14 +154,14 @@ export const CommentInputField = ({
             />
           )}
           {!comment && (
-            <span className="mt5">
+            <span className="db mt3">
               <FormattedMessage {...messages.nothingToPreview} />
             </span>
           )}
         </div>
       )}
       {comment && enableHashtagPaste && !isShowPreview && (
-        <span className="blue-grey f6 pt2">
+        <span className="db blue-grey f6 pt2">
           <HashtagPaste text={comment} setFn={setComment} hashtag="#managers" />
           <span>, </span>
           <HashtagPaste text={comment} setFn={setComment} hashtag="#author" />

--- a/frontend/src/components/comments/messages.js
+++ b/frontend/src/components/comments/messages.js
@@ -44,6 +44,14 @@ export default defineMessages({
     id: 'comment.preview.leaveAComment',
     defaultMessage: 'Leave a comment...',
   },
+  write: {
+    id: 'textarea.write',
+    defaultMessage: 'Write',
+  },
+  preview: {
+    id: 'textarea.preview',
+    defaultMessage: 'Preview',
+  },
   attachImage: {
     id: 'comment.write.attachImage',
     defaultMessage: 'Attach image by dragging and dropping',

--- a/frontend/src/components/projectDetail/messages.js
+++ b/frontend/src/components/projectDetail/messages.js
@@ -133,14 +133,6 @@ export default defineMessages({
     id: 'project.detail.questionsAndComments.login',
     defaultMessage: 'Log in to be able to post comments.',
   },
-  write: {
-    id: 'project.detail.questionsAndComments.write',
-    defaultMessage: 'Write',
-  },
-  preview: {
-    id: 'project.detail.questionsAndComments.preview',
-    defaultMessage: 'Preview',
-  },
   post: {
     id: 'project.detail.questionsAndComments.button',
     defaultMessage: 'Post',

--- a/frontend/src/components/projectDetail/questionsAndComments.js
+++ b/frontend/src/components/projectDetail/questionsAndComments.js
@@ -10,7 +10,7 @@ import { Button } from '../button';
 import { Alert } from '../alert';
 import { CommentInputField } from '../comments/commentInput';
 import { MessageStatus } from '../comments/status';
-import { CurrentUserAvatar, UserAvatar } from '../user/avatar';
+import { UserAvatar } from '../user/avatar';
 import { htmlFromMarkdown, formatUserNamesToLink } from '../../utils/htmlFromMarkdown';
 import { pushToLocalJSONAPI, fetchLocalJSONAPI } from '../../network/genericJSONRequest';
 
@@ -19,7 +19,6 @@ import './styles.scss';
 export const PostProjectComment = ({ projectId, updateComments, contributors }) => {
   const token = useSelector((state) => state.auth.token);
   const [comment, setComment] = useState('');
-  const [isShowPreview, setIsShowPreview] = useState(false);
 
   const saveComment = () => {
     return pushToLocalJSONAPI(
@@ -35,36 +34,14 @@ export const PostProjectComment = ({ projectId, updateComments, contributors }) 
 
   return (
     <div className="w-100 cf mh4 pv4 bg-white center shadow-7 ba0 br1 post-comment-ctr">
-      <div className="cf w-100 flex mb3">
-        <CurrentUserAvatar className="w3 h3 fr ph2 br-100" />
-        <div className="pt3-ns ph3 ph3-m ml3 bg-grey-light dib">
-          <span
-            role="button"
-            className={`pointer db dib-ns pb1 bb bw1 ${
-              !isShowPreview ? 'b--blue-dark' : 'b--grey-light'
-            }`}
-            onClick={() => setIsShowPreview(false)}
-          >
-            <FormattedMessage {...messages.write} />
-          </span>
-          <span
-            role="button"
-            className={`pointer ml3 db dib-ns pb1 bb bw1 ${
-              isShowPreview ? 'b--blue-dark' : 'b--grey-light'
-            }`}
-            onClick={() => setIsShowPreview(true)}
-          >
-            <FormattedMessage {...messages.preview} />
-          </span>
-        </div>
-      </div>
       <div className={`w-100 h-100`} style={{ position: 'relative', display: 'block' }}>
         <CommentInputField
           comment={comment}
           setComment={setComment}
-          enableHashtagPaste={true}
-          isShowPreview={isShowPreview}
-          isProjectDetailCommentSection={true}
+          enableHashtagPaste
+          isShowUserPicture
+          isShowFooter
+          isShowTabNavs
           contributors={contributors?.userContributions?.map((user) => user.username)}
         />
       </div>

--- a/frontend/src/components/projectEdit/actionsForm.js
+++ b/frontend/src/components/projectEdit/actionsForm.js
@@ -323,7 +323,7 @@ const MessageContributorsModal = ({ projectId, close }: Object) => {
               <CommentInputField
                 comment={message}
                 setComment={setMessage}
-                enableHashtagPaste={true}
+                enableHashtagPaste={false}
                 contributors={[]}
                 isShowTabNavs
               />


### PR DESCRIPTION
Closes #5566 

- Replaces textarea in message contributors section with CommentInput markdown editor.
- Enhancements to the CommentInput component to make it more reusable.
- Removes selection tabs from the Questions and Comments component and adds it to the CommentInput component where a flag controls its visibility.


![contributors-msg](https://user-images.githubusercontent.com/51614993/221472109-9f0d7b70-705d-40f0-a90b-baf5ade59097.gif)
