### PR TITLE
Set mapping level upgrade notifications as system generated

### DIFF
--- a/backend/models/postgis/message.py
+++ b/backend/models/postgis/message.py
@@ -87,6 +87,8 @@ class Message(db.Model):
         dto.task_id = self.task_id
         if self.message_type is not None:
             dto.message_type = MessageType(self.message_type).name
+        else:
+            dto.message_type = MessageType.SYSTEM.name
 
         if self.from_user_id:
             dto.from_username = self.from_user.username

--- a/backend/services/messaging/templates/level_upgrade_message_en.txt
+++ b/backend/services/messaging/templates/level_upgrade_message_en.txt
@@ -1,8 +1,7 @@
 Hi [USERNAME],<br />
 <br />
-Congratulations! You're now an [LEVEL] mapper.<br />
-Thank you very much for mapping with us!<br /><br />
+Congratulations! You're now an <span style="font-weight:bold">[LEVEL]</span> mapper.
 As an [LEVEL] mapper you are now able to contribute in a wide range of projects.<br />
 <br />
-Many thanks,<br />
+Thank you very much for mapping with us!<br /><br />
 [ORG_CODE] Mapping Team

--- a/backend/services/users/user_service.py
+++ b/backend/services/users/user_service.py
@@ -788,14 +788,16 @@ class UserService:
         text_template = get_txt_template("level_upgrade_message_en.txt")
         replace_list = [
             ["[USERNAME]", username],
-            ["[LEVEL]", level],
+            ["[LEVEL]", level.capitalize()],
             ["[ORG_CODE]", current_app.config["ORG_CODE"]],
         ]
         text_template = template_var_replacing(text_template, replace_list)
 
         level_upgrade_message = Message()
         level_upgrade_message.to_user_id = user_id
-        level_upgrade_message.subject = "Mapper level upgrade"
+        level_upgrade_message.subject = (
+            f"Congratulations🎉, You're now an {level} mapper."
+        )
         level_upgrade_message.message = text_template
         level_upgrade_message.message_type = MessageType.SYSTEM.value
         level_upgrade_message.save()

--- a/backend/services/users/user_service.py
+++ b/backend/services/users/user_service.py
@@ -19,7 +19,7 @@ from backend.models.dtos.user_dto import (
 )
 from backend.models.dtos.interests_dto import InterestsListDTO, InterestDTO
 from backend.models.postgis.interests import Interest, project_interests
-from backend.models.postgis.message import Message
+from backend.models.postgis.message import Message, MessageType
 from backend.models.postgis.project import Project
 from backend.models.postgis.user import User, UserRole, MappingLevel, UserEmail
 from backend.models.postgis.task import TaskHistory, TaskAction, Task
@@ -797,6 +797,7 @@ class UserService:
         level_upgrade_message.to_user_id = user_id
         level_upgrade_message.subject = "Mapper level upgrade"
         level_upgrade_message.message = text_template
+        level_upgrade_message.message_type = MessageType.SYSTEM.value
         level_upgrade_message.save()
 
     @staticmethod

--- a/frontend/src/components/dropdown.js
+++ b/frontend/src/components/dropdown.js
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from 'react-router-dom';
 
 import { useOnClickOutside } from '../hooks/UseOnClickOutside';
 import { ChevronDownIcon, CheckIcon } from './svgIcons';
 import { CustomButton } from './button';
 
 const DropdownContent = React.forwardRef((props, ref) => {
-  const navigate = useNavigate()
+  const navigate = useNavigate();
   const isActive = (obj) => {
     return props.value === obj.value;
   };

--- a/frontend/src/components/notifications/notificationBodyCard.js
+++ b/frontend/src/components/notifications/notificationBodyCard.js
@@ -11,6 +11,7 @@ import { useFetch } from '../../hooks/UseFetch';
 import { CloseIcon } from '../svgIcons';
 import { fetchLocalJSONAPI } from '../../network/genericJSONRequest';
 import { DeleteButton } from '../teamsAndOrgs/management';
+import {ORG_NAME} from '../../config';
 import './styles.scss';
 
 export const NotificationBodyModal = (props) => {
@@ -85,7 +86,7 @@ export function NotificationBodyCard({
   const token = useSelector((state) => state.auth.token);
   const { value, unit } = selectUnit(new Date((sentDate && new Date(sentDate)) || new Date()));
   const showASendingUser =
-    fromUsername || (typesThatUseSystemAvatar.indexOf(messageType) !== -1 && 'System');
+    fromUsername || (typesThatUseSystemAvatar.indexOf(messageType) !== -1 && ORG_NAME);
 
   let replacedSubject;
   let replacedMessage;

--- a/frontend/src/components/notifications/notificationBodyCard.js
+++ b/frontend/src/components/notifications/notificationBodyCard.js
@@ -11,7 +11,7 @@ import { useFetch } from '../../hooks/UseFetch';
 import { CloseIcon } from '../svgIcons';
 import { fetchLocalJSONAPI } from '../../network/genericJSONRequest';
 import { DeleteButton } from '../teamsAndOrgs/management';
-import {ORG_NAME} from '../../config';
+import { ORG_NAME } from '../../config';
 import './styles.scss';
 
 export const NotificationBodyModal = (props) => {

--- a/frontend/src/components/notifications/notificationCard.js
+++ b/frontend/src/components/notifications/notificationCard.js
@@ -231,7 +231,7 @@ export function NotificationCardMini({
             </div>
             <div>
               <div
-                className="f7 messageSubjectLinks"
+                className="f7 messageSubjectLinks ws-normal"
                 style={{ lineHeight: 1.21 }}
                 dangerouslySetInnerHTML={rawHtmlNotification(subject)}
               />

--- a/frontend/src/components/projectCard/tests/projectProgressBar.test.js
+++ b/frontend/src/components/projectCard/tests/projectProgressBar.test.js
@@ -10,8 +10,8 @@ describe('test if projectProgressBar', () => {
   const testInstance = element.root;
   it('mapped bar has the correct width', () => {
     expect(
-      testInstance.findByProps({ className: 'absolute bg-mask br-pill hhalf hide-child' })
-        .props.style,
+      testInstance.findByProps({ className: 'absolute bg-mask br-pill hhalf hide-child' }).props
+        .style,
     ).toEqual({ width: '40%' });
   });
   it('validated bar has the correct width', () => {
@@ -49,8 +49,8 @@ describe('test if projectProgressBar with value higher than 100%', () => {
   const testInstance = element.root;
   it('to mapped returns 100% width', () => {
     expect(
-      testInstance.findByProps({ className: 'absolute bg-mask br-pill hhalf hide-child' })
-        .props.style,
+      testInstance.findByProps({ className: 'absolute bg-mask br-pill hhalf hide-child' }).props
+        .style,
     ).toEqual({ width: '100%' });
   });
   it('to validated returns 100% width', () => {

--- a/frontend/src/components/projectDetail/tests/favorites.test.js
+++ b/frontend/src/components/projectDetail/tests/favorites.test.js
@@ -16,7 +16,9 @@ describe('AddToFavorites button', () => {
       </ReduxIntlProviders>,
     );
     const button = screen.getByRole('button');
-    expect(button.className).toBe(' input-reset base-font bg-white blue-dark bn pointer flex nowrap items-center ml3');
+    expect(button.className).toBe(
+      ' input-reset base-font bg-white blue-dark bn pointer flex nowrap items-center ml3',
+    );
     expect(button.className).not.toBe('dn input-reset base-font bg-white blue-dark f6 bn pointer');
     expect(container.querySelector('svg').classList.value).toBe('pr2 v-btm o-50 blue-grey');
     expect(button.textContent).toBe('Add to Favorites');

--- a/frontend/src/components/projects/projectNav.js
+++ b/frontend/src/components/projects/projectNav.js
@@ -79,7 +79,7 @@ const DifficultyDropdown = (props) => {
 };
 
 export const ProjectNav = (props) => {
-  const location = useLocation()
+  const location = useLocation();
   const [fullProjectsQuery, setQuery] = useExploreProjectsQueryParams();
   const encodedParams = stringify(fullProjectsQuery)
     ? ['?', stringify(fullProjectsQuery)].join('')

--- a/frontend/src/components/projects/tests/projectsMap.test.js
+++ b/frontend/src/components/projects/tests/projectsMap.test.js
@@ -1,4 +1,4 @@
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { ReduxIntlProviders } from '../../../utils/testWithIntl';
 import { ProjectsMap } from '../projectsMap';

--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -298,17 +298,18 @@ export function TaskSelection({ project, type, loading }: Object) {
   return (
     <div>
       <div className="cf vh-minus-200-ns">
-        {!userTeamsLoading && ['mappingIsComplete', 'selectAnotherProject'].includes(taskAction) && (
-          <Popup modal open closeOnEscape={true} closeOnDocumentClick={true}>
-            {(close) => (
-              <UserPermissionErrorContent
-                project={project}
-                userLevel={user.mappingLevel}
-                close={close}
-              />
-            )}
-          </Popup>
-        )}
+        {!userTeamsLoading &&
+          ['mappingIsComplete', 'selectAnotherProject'].includes(taskAction) && (
+            <Popup modal open closeOnEscape={true} closeOnDocumentClick={true}>
+              {(close) => (
+                <UserPermissionErrorContent
+                  project={project}
+                  userLevel={user.mappingLevel}
+                  close={close}
+                />
+              )}
+            </Popup>
+          )}
         <div className="w-100 w-50-ns fl pt3 overflow-y-auto-ns vh-minus-200-ns h-100">
           <div className="pl4-l pl2 pr4">
             <ReactPlaceholder

--- a/frontend/src/components/teamsAndOrgs/tests/organisationProjectStats.test.js
+++ b/frontend/src/components/teamsAndOrgs/tests/organisationProjectStats.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { setDayOfYear, format } from 'date-fns';
-import {  screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { IntlProviders, renderWithRouter } from '../../../utils/testWithIntl';

--- a/frontend/src/components/tests/button.test.js
+++ b/frontend/src/components/tests/button.test.js
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom';
 
 import { Button, CustomButton, EditButton } from '../button';
 import { BanIcon } from '../svgIcons';
-import { renderWithRouter } from "../../utils/testWithIntl";
+import { renderWithRouter } from '../../utils/testWithIntl';
 
 describe('Button', () => {
   it('children and onClick props', () => {

--- a/frontend/src/components/user/forms/interests.js
+++ b/frontend/src/components/user/forms/interests.js
@@ -80,7 +80,9 @@ export function UserInterestsForm() {
       )}
       <Button
         onClick={updateInterests}
-        className={`${enableSaveButton ? 'bg-blue-dark' : 'bg-grey-light'} white mv3 dib settings-width`}
+        className={`${
+          enableSaveButton ? 'bg-blue-dark' : 'bg-grey-light'
+        } white mv3 dib settings-width`}
         disabled={!enableSaveButton}
       >
         <FormattedMessage {...messages.save} />

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,7 +4,7 @@ import { PersistGate } from 'redux-persist/integration/react';
 import { Provider } from 'react-redux';
 import WebFont from 'webfontloader';
 import * as Sentry from '@sentry/react';
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from 'react-router-dom';
 import { BrowserTracing } from '@sentry/tracing';
 
 import App from './App';

--- a/frontend/src/views/project.js
+++ b/frontend/src/views/project.js
@@ -52,7 +52,7 @@ export const ProjectsPage = () => {
 
   return (
     <div className="pull-center">
-      <ProjectNav >
+      <ProjectNav>
         <Outlet />
       </ProjectNav>
       <section className={`${searchResultWidth} explore-projects-container`}>

--- a/frontend/src/views/tests/fallback.test.js
+++ b/frontend/src/views/tests/fallback.test.js
@@ -7,7 +7,6 @@ import { FallbackComponent } from '../fallback';
 import { SERVICE_DESK } from '../../config';
 import messages from '../messages';
 
-
 describe('Fallback component', () => {
   it('should render component details', () => {
     renderWithRouter(

--- a/frontend/src/views/tests/users.test.js
+++ b/frontend/src/views/tests/users.test.js
@@ -3,7 +3,11 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 
-import { createComponentWithMemoryRouter, ReduxIntlProviders, renderWithRouter } from '../../utils/testWithIntl';
+import {
+  createComponentWithMemoryRouter,
+  ReduxIntlProviders,
+  renderWithRouter,
+} from '../../utils/testWithIntl';
 import { UsersList } from '../users';
 
 describe('List Users', () => {


### PR DESCRIPTION
Addresses the issue raised in: #5567 
This PR sets mapping level upgrade notifications as system generated notification type and also modifies the notification templete of this notfication type.

Now the mapper level upgrade notifications will look like:
![mapper-Level_upgrade-popup](https://user-images.githubusercontent.com/67958673/222047760-8058774f-8745-4204-9c98-a2de50b5c2ba.png)
![mapper-Level_upgrade](https://user-images.githubusercontent.com/67958673/222047756-34e70d59-8adb-4859-b20e-e8086334922c.png)
