### PR TITLE
Restart editor context on side panel toggle

### DIFF
--- a/frontend/src/components/taskSelection/action.js
+++ b/frontend/src/components/taskSelection/action.js
@@ -288,7 +288,7 @@ export function TaskMapAction({
                 ready={typeof project.projectId === 'number' && project.projectId > 0}
               >
                 {(activeEditor === 'ID' || activeEditor === 'RAPID') && (
-                  <SidebarToggle setShowSidebar={setShowSidebar} />
+                  <SidebarToggle setShowSidebar={setShowSidebar} activeEditor={activeEditor} />
                 )}
                 <HeaderLine
                   author={project.author}

--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -713,8 +713,10 @@ export function ReopenEditor({ project, action, editor, callEditor }: Object) {
   );
 }
 
-export function SidebarToggle({ setShowSidebar }: Object) {
+export function SidebarToggle({ setShowSidebar, activeEditor }: Object) {
   const iDContext = useSelector((state) => state.editor.context);
+  const rapidContext = useSelector((state) => state.editor.rapidContext);
+
   return (
     <div>
       <FormattedMessage {...messages.hideSidebar}>
@@ -723,7 +725,8 @@ export function SidebarToggle({ setShowSidebar }: Object) {
             <SidebarIcon
               onClick={() => {
                 setShowSidebar(false);
-                iDContext.ui().restart();
+                activeEditor === 'ID' && iDContext.ui().restart();
+                activeEditor === 'RAPID' && rapidContext.ui().restart();
               }}
             />
           </div>


### PR DESCRIPTION
Closes #5564 

_Updates SidebarToggle to accept active editor and restarts editor context accordingly_

_Screenshot_
![restart-rapid-context](https://user-images.githubusercontent.com/51614993/221573053-48d6b35f-26f5-4b6d-bfef-d46245046a17.gif)
