### PR TITLE
Display TopBanner only on the home page

### DIFF
--- a/frontend/src/components/banner/tests/topBanner.test.js
+++ b/frontend/src/components/banner/tests/topBanner.test.js
@@ -1,11 +1,11 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { banner } from '../../../network/tests/mockData/miscellaneous';
-import { ReduxIntlProviders } from '../../../utils/testWithIntl';
+import { ReduxIntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
 import { TopBanner } from '../topBanner';
 
 it('should render the banner text ', async () => {
-  render(
+  renderWithRouter(
     <ReduxIntlProviders>
       <TopBanner />
     </ReduxIntlProviders>,

--- a/frontend/src/components/banner/topBanner.js
+++ b/frontend/src/components/banner/topBanner.js
@@ -1,14 +1,16 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import { useFetchWithAbort } from '../../hooks/UseFetch';
 import { htmlFromMarkdown } from '../../utils/htmlFromMarkdown';
 import './styles.scss';
 
 export function TopBanner() {
+  const location = useLocation();
   const [, error, data] = useFetchWithAbort(`system/banner/`);
 
   return (
     <>
-      {data.visible && !error && (
+      {location.pathname === '/' && data.visible && !error && (
         <div className="ph3 b--grey-light bb bg-tan top-banner-container">
           <div
             className="fw6 flex justify-center"


### PR DESCRIPTION
This PR revises the TopBanner component to use a location hook for visibility check to display it only on the landing page. I got a warning while using multiple good old <Routes> components, so I included a route pathname check inside the component itself.