### PR TITLE
Display preview tabs in task action and task detail modal

### DIFF
--- a/frontend/src/components/comments/commentInput.js
+++ b/frontend/src/components/comments/commentInput.js
@@ -163,7 +163,7 @@ export const CommentInputField = ({
           )}
         </div>
       )}
-      {comment && enableHashtagPaste && !isShowPreview && (
+      {enableHashtagPaste && !isShowPreview && (
         <span className="db blue-grey f6 pt2">
           <HashtagPaste text={comment} setFn={setComment} hashtag="#managers" />
           <span>, </span>

--- a/frontend/src/components/comments/commentInput.js
+++ b/frontend/src/components/comments/commentInput.js
@@ -148,7 +148,7 @@ export const CommentInputField = ({
         )}
       </div>
       {isShowPreview && (
-        <div className="db" style={{ minHeight: 200 }}>
+        <div className="db ba ph3" style={{ minHeight: 200, borderColor: '#F0EEEE' }}>
           {comment && (
             <div
               style={{ wordWrap: 'break-word' }}

--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -248,6 +248,7 @@ export function CompletionTabForMapping({
             contributors={contributors}
             enableHashtagPaste={true}
             enableContributorsHashtag
+            isShowTabNavs
           />
         </p>
       </div>

--- a/frontend/src/components/taskSelection/taskActivity.js
+++ b/frontend/src/components/taskSelection/taskActivity.js
@@ -15,7 +15,7 @@ import { getTaskContributors } from '../../utils/getTaskContributors';
 import { getIdUrl, sendJosmCommands } from '../../utils/openEditor';
 import { formatOverpassLink } from '../../utils/overpassLink';
 import { pushToLocalJSONAPI, fetchLocalJSONAPI } from '../../network/genericJSONRequest';
-import { CurrentUserAvatar, UserAvatar } from '../user/avatar';
+import { UserAvatar } from '../user/avatar';
 import { CloseIcon } from '../svgIcons';
 import { ID_EDITOR_URL } from '../../config';
 import { Button, CustomButton } from '../button';
@@ -44,20 +44,17 @@ const PostComment = ({ projectId, taskId, contributors, setCommentPayload }) => 
   };
 
   return (
-    <div className="w-100 pt3 ph3-ns ph1">
-      <div className="fl w-10">
-        <CurrentUserAvatar className="h2 w2 fr mr2 br-100" />
-      </div>
-      <div className="fl w-70 f6">
-        <CommentInputField
-          comment={comment}
-          setComment={setComment}
-          enableHashtagPaste
-          contributors={contributors}
-          enableContributorsHashtag
-        />
-      </div>
-      <div className="w-20 fr pt3 tr">
+    <div className="w-100 pt3 ph3-ns ph1 flex flex-column">
+      <CommentInputField
+        comment={comment}
+        setComment={setComment}
+        enableHashtagPaste
+        contributors={contributors}
+        enableContributorsHashtag
+        isShowUserPicture
+        isShowTabNavs
+      />
+      <div className="ml-auto mb5">
         <Button onClick={() => saveComment()} className="bg-red white f6">
           <FormattedMessage {...messages.comment} />
         </Button>


### PR DESCRIPTION
This PR displays preview tabs in the task action and task detail modal, among other things.

- Gives the preview container a boundary.
- Removes the requirement for a comment value to display hashtag options.

Screenshots:
_Task Action page_
![task-status](https://user-images.githubusercontent.com/51614993/224652450-0004e501-768a-4926-945c-91a547b4ff51.png)

_Task Detail modal_
![screencapture-127-0-0-1-3000-projects-5871-tasks-2023-03-13-14_37_32](https://user-images.githubusercontent.com/51614993/224652461-166ca49d-09c3-4438-be61-5cd16ddbc9d4.png)
