### PR TITLE
Use horizontal scroll buttons for tabs in task action page

### DIFF
--- a/frontend/src/assets/styles/_extra.scss
+++ b/frontend/src/assets/styles/_extra.scss
@@ -48,8 +48,8 @@ html {
     height: calc(100vh - 122px);
   }
 
-  .vh-minus-77-ns {
-    height: calc(100vh - 77px);
+  .vh-minus-69-ns {
+    height: calc(100vh - 69px); // nice
   }
 
   .popup-content {

--- a/frontend/src/components/editor.js
+++ b/frontend/src/components/editor.js
@@ -108,5 +108,5 @@ export default function Editor({ setDisable, comment, presets, imagery, gpxUrl }
     }
   }, [session, iDContext, setDisable, presets, locale, gpxUrl]);
 
-  return <div className="w-100 vh-minus-77-ns" id="id-container"></div>;
+  return <div className="w-100 vh-minus-69-ns" id="id-container"></div>;
 }

--- a/frontend/src/components/horizontalScroll/index.js
+++ b/frontend/src/components/horizontalScroll/index.js
@@ -45,23 +45,29 @@ export function HorizontalScroll({
 
   return (
     <div className={`relative overflow-hidden ${className || ''}`} style={style}>
-      <ChevronRightIcon
-        role="button"
-        className={`bg-white absolute left-0 rotate-180 z-1 pointer pa2 translate-icon-btm ${
-          scrollLeft > 0 ? 'db' : 'dn'
+      <div
+        className={`bg-white left-icon absolute h-100 left-0 top-0 rotate-180 z-1 h-100 pointer pa2 translate-icon-btm ${
+          scrollLeft > 0 ? 'flex items-center' : 'dn'
         }`}
-        onClick={() => handleScroll('left')}
-      />
-      <ChevronRightIcon
         role="button"
-        className={`translate-icon bg-white absolute right-0 z-1 pointer pa2 translate-icon ${
+        onClick={() => handleScroll('left')}
+      >
+        <ChevronRightIcon />
+      </div>
+      <div
+        role="button"
+        className={`translate-icon bg-white absolute h-100 right-0 top-0 z-1 pointer pa2 translate-icon ${
           scrollLeft <
-          menuItemsContainerRef.current?.scrollWidth - menuItemsContainerRef.current?.clientWidth
-            ? 'db'
+          menuItemsContainerRef.current?.scrollWidth -
+            menuItemsContainerRef.current?.clientWidth -
+            1
+            ? 'flex items-center'
             : 'dn'
         }`}
         onClick={() => handleScroll('right')}
-      />
+      >
+        <ChevronRightIcon />
+      </div>
       {children}
     </div>
   );

--- a/frontend/src/components/horizontalScroll/styles.scss
+++ b/frontend/src/components/horizontalScroll/styles.scss
@@ -1,9 +1,3 @@
-.translate-icon {
-  top: 50%;
-  transform: translateY(-50%);
-}
-
 .translate-icon-btm {
-  top: 50%;
-  transform: translateY(-50%) rotate(180deg);
+  transform: rotate(180deg);
 }

--- a/frontend/src/components/rapidEditor.js
+++ b/frontend/src/components/rapidEditor.js
@@ -116,5 +116,5 @@ export default function RapidEditor({
     }
   }, [session, RapiDContext, setDisable, presets, locale, gpxUrl, powerUser]);
 
-  return <div className="w-100 vh-minus-77-ns" id="rapid-container"></div>;
+  return <div className="w-100 vh-minus-69-ns" id="rapid-container"></div>;
 }

--- a/frontend/src/components/taskSelection/action.js
+++ b/frontend/src/components/taskSelection/action.js
@@ -227,7 +227,7 @@ export function TaskMapAction({
   return (
     <>
       <Portal>
-        <div className="cf w-100 vh-minus-77-ns overflow-y-hidden">
+        <div className="cf w-100 vh-minus-69-ns overflow-y-hidden">
           <div className={`fl h-100 relative ${showSidebar ? 'w-70' : 'w-100-minus-4rem'}`}>
             {['ID', 'RAPID'].includes(editor) ? (
               <React.Suspense
@@ -297,7 +297,7 @@ export function TaskMapAction({
                 />
                 <div className="cf pb3">
                   <h3
-                    className="f2 fw6 mt2 mb1 ttu barlow-condensed blue-dark"
+                    className="f2 fw5 lh-title mt2 mb1 ttu barlow-condensed blue-dark"
                     lang={project.projectInfo && project.projectInfo.locale}
                   >
                     {project.projectInfo && project.projectInfo.name}
@@ -330,7 +330,7 @@ export function TaskMapAction({
                     action={action}
                   />
                 </div>
-                <div className="pt1">
+                <div className="pt0">
                   {activeSection === 'completion' && (
                     <>
                       {action === 'MAPPING' && (

--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -179,7 +179,7 @@ export function CompletionTabForMapping({
       )}
       <div className="cf">
         {taskInstructions && <TaskSpecificInstructions instructions={taskInstructions} />}
-        <h4 className="ttu blue-grey f5">
+        <h4 className="ttu blue-grey f6 fw5">
           <FormattedMessage {...messages.editStatus} />
           <QuestionCircleIcon
             className="pointer dib v-mid pl2 pb1 blue-light"
@@ -238,7 +238,7 @@ export function CompletionTabForMapping({
         )}
       </div>
       <div className="cf">
-        <h4 className="ttu blue-grey f5">
+        <h4 className="ttu blue-grey f6 fw5">
           <FormattedMessage {...messages.comment} />
         </h4>
         <p>

--- a/frontend/src/components/taskSelection/actionTabsNav.js
+++ b/frontend/src/components/taskSelection/actionTabsNav.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 
+import { HorizontalScroll } from '../horizontalScroll';
 import messages from './messages';
 
 export const ActionTabsNav = ({
@@ -11,44 +12,61 @@ export const ActionTabsNav = ({
   taskHistoryLength,
   action,
 }) => {
+  const tabContainerRef = useRef(null);
+
   return (
-    <div className="cf ttu barlow-condensed f4 pt2 pb3 blue-dark nowrap overflow-x-auto">
-      <span
-        className={`mr4-l mr3 pb1 pointer ${activeSection === 'completion' && 'bb b--blue-dark'}`}
-        onClick={() => setActiveSection('completion')}
+    <HorizontalScroll
+      menuItemsContainerRef={tabContainerRef}
+      containerClass=".menu-items-container"
+      className="mb3"
+    >
+      <div
+        ref={tabContainerRef}
+        className="ttu w-100 barlow-condensed menu-items-container f4 blue-dark nowrap bb b--grey-light fw5 overflow-x-auto"
       >
-        <FormattedMessage {...messages.completion} />
-      </span>
-      <span
-        className={`mr4-l mr3 pb1 pointer ${activeSection === 'instructions' && 'bb b--blue-dark'}`}
-        onClick={() => setActiveSection('instructions')}
-      >
-        <FormattedMessage {...messages.instructions} />
-      </span>
-      <span
-        className={`mr4-l mr3 pb1 pointer truncate ${
-          activeSection === 'history' && 'bb b--blue-dark'
-        }`}
-        onClick={() => historyTabSwitch()}
-      >
-        <FormattedMessage {...messages.history} />
-        {activeTasks.length === 1 && taskHistoryLength > 1 && (
+        <span
+          className={`dib mr4-l mr3 pb2 pointer ${
+            activeSection === 'completion' && 'bb b--red bw1'
+          }`}
+          onClick={() => setActiveSection('completion')}
+        >
+          <FormattedMessage {...messages.completion} />
+        </span>
+        <span
+          className={`dib mr4-l mr3 pb2 pointer ${
+            activeSection === 'instructions' && 'bb b--red bw1'
+          }`}
+          onClick={() => setActiveSection('instructions')}
+        >
+          <FormattedMessage {...messages.instructions} />
+        </span>
+        <span
+          className={`inline-flex items-center mr4-l mr3 pb2 pointer ${
+            activeSection === 'history' && 'bb b--red bw1'
+          }`}
+          onClick={() => historyTabSwitch()}
+        >
+          <FormattedMessage {...messages.history} />
+          {activeTasks.length === 1 && taskHistoryLength > 1 && (
+            <span
+              className="bg-red white br-100 f6 ml1 flex items-center justify-center"
+              style={{ height: '1.125rem', width: '1.125rem' }}
+            >
+              {taskHistoryLength}
+            </span>
+          )}
+        </span>
+        {action === 'VALIDATION' && (
           <span
-            className="bg-red white dib br-100 tc f6 ml1 mb1 v-mid"
-            style={{ height: '1.125rem', width: '1.125rem' }}
+            className={`dib mr4-l mr3 pb2 pointer ${
+              activeSection === 'resources' && 'bb b--red bw1'
+            }`}
+            onClick={() => setActiveSection('resources')}
           >
-            {taskHistoryLength}
+            <FormattedMessage {...messages.resources} />
           </span>
         )}
-      </span>
-      {action === 'VALIDATION' && (
-        <span
-          className={`mr4-l mr3 pb1 pointer ${activeSection === 'resources' && 'bb b--blue-dark'}`}
-          onClick={() => setActiveSection('resources')}
-        >
-          <FormattedMessage {...messages.resources} />
-        </span>
-      )}
-    </div>
+      </div>
+    </HorizontalScroll>
   );
 };

--- a/frontend/src/components/taskSelection/tests/actionsTabsNav.test.js
+++ b/frontend/src/components/taskSelection/tests/actionsTabsNav.test.js
@@ -22,10 +22,10 @@ describe('ActionTabsNav', () => {
         />
       </ReduxIntlProviders>,
     );
-    expect(screen.getByText('Completion').className).toContain('bb b--blue-dark');
-    expect(screen.getByText('Instructions').className).not.toContain('bb b--blue-dark');
-    expect(screen.getByText('History').className).not.toContain('bb b--blue-dark');
-    expect(screen.getByText('3').className).toBe('bg-red white dib br-100 tc f6 ml1 mb1 v-mid');
+    expect(screen.getByText('Completion').className).toContain('dib mr4-l mr3 pb2 pointer bb b--red bw1');
+    expect(screen.getByText('Instructions').className).not.toContain('dib mr4-l mr3 pb2 pointer bb b--red bw1');
+    expect(screen.getByText('History').className).not.toContain('dib mr4-l mr3 pb2 pointer bb b--red bw1');
+    expect(screen.getByText('3').className).toBe('bg-red white br-100 f6 ml1 flex items-center justify-center');
     expect(screen.queryByText('Resources')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('Instructions'));
     expect(setActiveSection).toHaveBeenLastCalledWith('instructions');
@@ -80,7 +80,7 @@ describe('ActionTabsNav', () => {
     expect(screen.getByText('Instructions').className).not.toContain('bb b--blue-dark');
     expect(screen.getByText('History').className).not.toContain('bb b--blue-dark');
     expect(screen.queryByText('4')).not.toBeInTheDocument();
-    expect(screen.getByText('Resources').className).toContain('bb b--blue-dark');
+    expect(screen.getByText('Resources').className).toContain('dib mr4-l mr3 pb2 pointer bb b--red bw1');
     fireEvent.click(screen.getByText('History'));
     expect(historyTabSwitch).toHaveBeenCalled();
     fireEvent.click(screen.getByText('Completion'));


### PR DESCRIPTION
This PR does the following:

- Closes #4047; also adds a bottom border to the tab container and changes the color of the active tab indicator to red.
![scroll btn](https://user-images.githubusercontent.com/51614993/224943843-516cb79f-4caa-40c8-b288-dd1ca48daeb6.gif)
- Adjust map height to fit the screen's bottom edge.
- Slenderize some tilte.