### PR TITLE
Display tabs for markdown editor in message team members section and section to provide validation status for task(s)

### DIFF
--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -611,8 +611,8 @@ const TaskValidationSelector = ({
               setComment={setComment}
               contributors={contributors.length ? contributors : contributorsList}
               enableHashtagPaste
-              autoFocus
               enableContributorsHashtag
+              isShowTabNavs
             />
           </div>
           {isValidatingMultipleTasks && comment && (

--- a/frontend/src/components/teamsAndOrgs/messageMembers.js
+++ b/frontend/src/components/teamsAndOrgs/messageMembers.js
@@ -63,6 +63,7 @@ export function MessageMembers({ teamId, members }: Object) {
             comment={message}
             setComment={setMessage}
             contributors={members?.map((member) => member.username)}
+            isShowTabNavs
           />
         </div>
         {!message && <MessageStatus status={status} />}


### PR DESCRIPTION
Screenshots:
_Task status for validation_
![validation-cmnt](https://user-images.githubusercontent.com/51614993/224955753-68cefad0-734e-4a68-bc84-dd0ad5506b37.png)

_Message team members section:_
![msg-tream](https://user-images.githubusercontent.com/51614993/224955761-d3e83465-5318-4708-8d2d-bcdf3e9839a5.png)
