### PR TITLE
Remove redundant TeamsRestAPI Post method

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -671,7 +671,7 @@ def add_api_endpoints(app):
     api.add_resource(
         TeamsRestAPI,
         format_url("teams/<int:team_id>/"),
-        methods=["GET", "PUT", "DELETE", "PATCH"],
+        methods=["GET", "DELETE", "PATCH"],
     )
 
     # Teams actions endpoints


### PR DESCRIPTION
**What does this PR do?** 
Under the TeamsRestAPI, we have two methods doing the same job, i.e. POST and PATCH. This PR removes the redundant POST method that is not in use anywhere and is essentially a copy of what the PATCH method does. 
The PATCH method is retained since the RFC standards dictate that the PATCH method is what is used to update a resource and not POST. 