### PR TITLE
Add Countries Module endpoint tests

### DIFF
--- a/backend/api/countries/resources.py
+++ b/backend/api/countries/resources.py
@@ -21,6 +21,6 @@ class CountriesRestAPI(Resource):
             tags = TagsService.get_all_countries()
             return tags.to_primitive(), 200
         except Exception as e:
-            error_msg = f"User GET - unhandled error: {str(e)}"
+            error_msg = f"Country Tags GET - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)
             return {"Error": error_msg, "SubCode": "InternalServerError"}, 500

--- a/tests/backend/integration/api/countries/test_resources.py
+++ b/tests/backend/integration/api/countries/test_resources.py
@@ -1,0 +1,28 @@
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import create_canned_project
+
+TEST_COUNTRY = "Test Country"
+
+
+class TestCountriesRestAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_project, _ = create_canned_project()
+        self.endpoint_url = "/api/v2/countries/"
+
+    def test_get_all_country_tags_passes(self):
+        """
+        Test that endpoint returns 200 when getting all country tags successfully
+        """
+        response1 = self.client.get(self.endpoint_url)
+        response_body1 = response1.get_json()
+        self.assertEqual(response1.status_code, 200)
+        self.assertEqual(len(response_body1["tags"]), 0)
+        self.assertEqual(response_body1["tags"], [])
+        # set up: add at least one country tag and test that
+        self.test_project.country = [TEST_COUNTRY]
+        response2 = self.client.get(self.endpoint_url)
+        response_body2 = response2.get_json()
+        self.assertEqual(response2.status_code, 200)
+        self.assertEqual(len(response_body2["tags"]), 1)
+        self.assertEqual(response_body2["tags"], [TEST_COUNTRY])


### PR DESCRIPTION
This PR handles the countries module-related API endpoint tests.

**How to test**:
- create a test database following the instructions [here](https://github.com/hotosm/tasking-manager/blob/develop/docs-old/setup-development.md#create-the-database-user-and-database). The database name is preceded by `test_`
- pull and checkout test branch using `git fetch origin && git checkout chore/add-countries-tests`
- run tests using `python3 -m unittest discover tests/backend`