### PR TITLE
Add Licenses endpoint tests

### DIFF
--- a/backend/api/licenses/actions.py
+++ b/backend/api/licenses/actions.py
@@ -41,11 +41,11 @@ class LicensesActionsAcceptAPI(Resource):
             UserService.accept_license_terms(token_auth.current_user(), license_id)
             return {"Success": "Terms Accepted"}, 200
         except NotFound:
-            return {"Error": "User or mapping not found", "SubCode": "NotFound"}, 404
+            return {"Error": "User or License not found", "SubCode": "NotFound"}, 404
         except Exception as e:
-            error_msg = f"User GET - unhandled error: {str(e)}"
+            error_msg = f"License Accept - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)
             return {
-                "Error": "Unable to update license terms",
+                "Error": "Unable to accept license terms",
                 "SubCode": "InternalServerError",
             }, 500

--- a/backend/api/licenses/resources.py
+++ b/backend/api/licenses/resources.py
@@ -41,7 +41,7 @@ class LicensesRestAPI(Resource):
                           type: string
                           default: This imagery is in the public domain.
         responses:
-            200:
+            201:
                 description: New license created
             400:
                 description: Invalid Request
@@ -62,7 +62,7 @@ class LicensesRestAPI(Resource):
 
         try:
             new_license_id = LicenseService.create_licence(license_dto)
-            return {"licenseId": new_license_id}, 200
+            return {"licenseId": new_license_id}, 201
         except Exception as e:
             error_msg = f"License PUT - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)

--- a/backend/models/postgis/licenses.py
+++ b/backend/models/postgis/licenses.py
@@ -1,5 +1,6 @@
-from backend.models.dtos.licenses_dto import LicenseDTO, LicenseListDTO
 from backend import db
+from backend.models.dtos.licenses_dto import LicenseDTO, LicenseListDTO
+from backend.models.postgis.utils import NotFound
 
 # Secondary table defining the many-to-many join
 user_licenses_table = db.Table(
@@ -28,7 +29,12 @@ class License(db.Model):
     @staticmethod
     def get_by_id(license_id: int):
         """ Get license by id """
-        return License.query.get(license_id)
+        map_license = License.query.get(license_id)
+
+        if map_license is None:
+            raise NotFound()
+
+        return map_license
 
     @classmethod
     def create_from_dto(cls, dto: LicenseDTO) -> int:

--- a/tests/backend/integration/api/licenses/test_actions.py
+++ b/tests/backend/integration/api/licenses/test_actions.py
@@ -1,0 +1,50 @@
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import (
+    create_canned_user,
+    generate_encoded_token,
+    create_canned_license,
+)
+
+
+class TestLicensesActionsAcceptAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_user = create_canned_user()
+        self.test_user_token = generate_encoded_token(self.test_user.id)
+        self.test_license_id = create_canned_license()
+        self.endpoint_url = (
+            f"/api/v2/licenses/{self.test_license_id}/actions/accept-for-me/"
+        )
+
+    def test_accept_license_terms_by_unauthenticated_user_fails(self):
+        """
+        Test that endpoint returns 401 when an unauthenticated user accepts license terms
+        """
+        response = self.client.post(self.endpoint_url)
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_body["SubCode"], "InvalidToken")
+
+    def test_accept_terms_of_non_existent_license_fails(self):
+        """
+        Test that endpoint returns 404 when user accepts terms of a non-existent license
+        """
+        response = self.client.post(
+            "/api/v2/licenses/99/actions/accept-for-me/",
+            headers={"Authorization": self.test_user_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], "User or License not found")
+        self.assertEqual(response_body["SubCode"], "NotFound")
+
+    def test_accept_license_terms_by_authenticated_user_passes(self):
+        """
+        Test that endpoint returns 200 when authenticated user accepts existing license terms
+        """
+        response = self.client.post(
+            self.endpoint_url, headers={"Authorization": self.test_user_token}
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["Success"], "Terms Accepted")

--- a/tests/backend/integration/api/licenses/test_resources.py
+++ b/tests/backend/integration/api/licenses/test_resources.py
@@ -1,0 +1,235 @@
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import (
+    create_canned_user,
+    generate_encoded_token,
+    create_canned_license,
+)
+
+TEST_LICENSE_NAME = "test_license"
+TEST_LICENSE_DESCRIPTION = "test license"
+TEST_LICENSE_PLAINTEXT = "test license"
+NEW_LICENSE_DESCRIPTION = "A new test license"
+NEW_LICENSE_NAME = "New License"
+LICENSE_NOT_FOUND = "License Not Found"
+
+
+class TestLicensesRestAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_user = create_canned_user()
+        self.test_user_token = generate_encoded_token(self.test_user.id)
+        self.test_license_id = create_canned_license()
+        self.single_licence_url = f"/api/v2/licenses/{self.test_license_id}/"
+        self.all_licences_url = "/api/v2/licenses/"
+        self.non_existent_url = "/api/v2/licenses/99/"
+
+    # post
+    def test_create_new_license_by_unauthenticated_user_fails(self):
+        """
+        Test that endpoint returns 401 when unauthenticated user creates a new license
+        """
+        response = self.client.post(
+            self.all_licences_url,
+            json={
+                "description": NEW_LICENSE_DESCRIPTION,
+                "name": NEW_LICENSE_NAME,
+                "plainText": "",
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_body["SubCode"], "InvalidToken")
+
+    def test_create_new_license_with_invalid_request_fails(self):
+        """
+        Test that endpoint returns 400 when creating a new license with invalid data
+        """
+        response = self.client.post(
+            self.all_licences_url,
+            headers={"Authorization": self.test_user_token},
+            json={
+                "license_description": [NEW_LICENSE_DESCRIPTION],
+                "license_name": NEW_LICENSE_NAME,
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response_body["Error"], "Unable to create new mapping license")
+        self.assertEqual(response_body["SubCode"], "InvalidData")
+
+    def test_create_new_license_by_authenticated_user_passes(self):
+        """
+        Test that endoint returns 201 when authenticated user creates new license
+        """
+        response = self.client.post(
+            self.all_licences_url,
+            headers={"Authorization": self.test_user_token},
+            json={
+                "description": NEW_LICENSE_DESCRIPTION,
+                "name": NEW_LICENSE_NAME,
+                "plainText": "",
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response_body, {"licenseId": 2})
+
+    # get
+    def test_get_non_existent_license_fails(self):
+        """
+        Test that endpoint returns 404 when retrieving a non existent license
+        """
+        response = self.client.get(self.non_existent_url)
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], LICENSE_NOT_FOUND)
+        self.assertEqual(response_body["SubCode"], "NotFound")
+
+    def test_get_license_passes(self):
+        """
+        Test that endpoint returns 200 when retrieving an existing license
+        """
+        response = self.client.get(self.single_licence_url)
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["name"], TEST_LICENSE_NAME)
+        self.assertEqual(response_body["description"], TEST_LICENSE_DESCRIPTION)
+        self.assertEqual(response_body["plainText"], TEST_LICENSE_PLAINTEXT)
+
+    # patch
+    def test_update_license_by_unauthenticated_user_fails(self):
+        """
+        Test that endpoint returns 401 when unauthenticated user updates a license
+        """
+        response = self.client.patch(
+            self.single_licence_url,
+            json={
+                "description": NEW_LICENSE_DESCRIPTION,
+                "name": NEW_LICENSE_NAME,
+                "plainText": "",
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_body["SubCode"], "InvalidToken")
+
+    def test_update_license_with_invalid_request_fails(self):
+        """
+        Test that endpoint returns 400 when user updates a license with invalid request data
+        """
+        response = self.client.patch(
+            self.single_licence_url,
+            headers={"Authorization": self.test_user_token},
+            json={
+                "license_description": [NEW_LICENSE_DESCRIPTION],
+                "license_name": NEW_LICENSE_NAME,
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response_body["SubCode"], "InvalidData")
+
+    def test_update_non_existent_license_by_authenticated_user_fails(self):
+        """
+        Test that endoint returns 404 when authenticated user updates non-existent license
+        """
+        response = self.client.patch(
+            self.non_existent_url,
+            headers={"Authorization": self.test_user_token},
+            json={
+                "description": NEW_LICENSE_DESCRIPTION,
+                "name": NEW_LICENSE_NAME,
+                "plainText": "",
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], LICENSE_NOT_FOUND)
+        self.assertEqual(response_body["SubCode"], "NotFound")
+
+    def test_update_license_by_authenticated_user_passes(self):
+        """
+        Test that endoint returns 200 when authenticated user updates existing license
+        """
+        response = self.client.patch(
+            self.single_licence_url,
+            headers={"Authorization": self.test_user_token},
+            json={
+                "description": NEW_LICENSE_DESCRIPTION,
+                "name": NEW_LICENSE_NAME,
+                "plainText": "",
+            },
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertNotEqual(response_body["name"], TEST_LICENSE_NAME)
+        self.assertNotEqual(response_body["description"], TEST_LICENSE_DESCRIPTION)
+        self.assertNotEqual(response_body["plainText"], TEST_LICENSE_PLAINTEXT)
+        # updated info
+        self.assertEqual(response_body["name"], NEW_LICENSE_NAME)
+        self.assertEqual(response_body["description"], NEW_LICENSE_DESCRIPTION)
+        self.assertEqual(response_body["plainText"], "")
+
+    # delete
+    def test_delete_license_by_unauthenticated_user_fails(self):
+        """
+        Test that endpoint returns 401 when unauthenticated user deletes a license
+        """
+        response = self.client.delete(self.single_licence_url)
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_body["SubCode"], "InvalidToken")
+
+    def test_delete_non_existent_license_by_authenticated_user_fails(self):
+        """
+        Test that endoint returns 404 when authenticated user deletes non-existent license
+        """
+        response = self.client.delete(
+            self.non_existent_url,
+            headers={"Authorization": self.test_user_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], LICENSE_NOT_FOUND)
+        self.assertEqual(response_body["SubCode"], "NotFound")
+
+    def test_delete_license_by_authenticated_user_passes(self):
+        """
+        Test that endoint returns 200 when authenticated user deletes existing license
+        """
+        response = self.client.delete(
+            self.single_licence_url,
+            headers={"Authorization": self.test_user_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["Success"], "License deleted")
+
+
+class TestLicensesAllAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_user = create_canned_user()
+        self.test_user_token = generate_encoded_token(self.test_user.id)
+        self.endpoint_url = "/api/v2/licenses/"
+
+    def test_get_all_licenses_(self):
+        """
+        Test that endoint returns 200 when retrieving existing licenses
+        """
+        response = self.client.get(self.endpoint_url)
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response_body["licenses"]), 0)
+        self.assertEqual(response_body["licenses"], [])
+        # setup: add license
+        self.test_license_id = create_canned_license()
+        response = self.client.get(self.endpoint_url)
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response_body["licenses"]), 1)
+        licenses = response_body["licenses"][0]
+        self.assertEqual(licenses["licenseId"], 1)
+        self.assertEqual(licenses["name"], TEST_LICENSE_NAME)
+        self.assertEqual(licenses["description"], TEST_LICENSE_DESCRIPTION)
+        self.assertEqual(licenses["plainText"], TEST_LICENSE_PLAINTEXT)


### PR DESCRIPTION
This PR handles the Licenses module-related API endpoint tests.

**How to test:**

- create a test database following the instructions [here](https://github.com/hotosm/tasking-manager/blob/develop/docs-old/setup-development.md#create-the-database-user-and-database). The database name is preceded by `test_`
- pull and checkout test branch using `git fetch origin && git checkout chore/add-licence-tests`
- run tests using `python3 -m unittest discover tests/backend`