### PR TITLE
Fix project completion issues with project summary caching

### DIFF
--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -803,7 +803,9 @@ class Project(db.Model):
 
         return project_stats
 
-    def get_project_summary(self, preferred_locale) -> ProjectSummary:
+    def get_project_summary(
+        self, preferred_locale, calculate_completion=True
+    ) -> ProjectSummary:
         """Create Project Summary model for postgis project object"""
         summary = ProjectSummary()
         summary.project_id = self.id
@@ -880,9 +882,10 @@ class Project(db.Model):
         centroid_geojson = db.session.scalar(self.centroid.ST_AsGeoJSON())
         summary.aoi_centroid = geojson.loads(centroid_geojson)
 
-        summary.percent_mapped = self.calculate_tasks_percent("mapped")
-        summary.percent_validated = self.calculate_tasks_percent("validated")
-        summary.percent_bad_imagery = self.calculate_tasks_percent("bad_imagery")
+        if calculate_completion:
+            summary.percent_mapped = self.calculate_tasks_percent("mapped")
+            summary.percent_validated = self.calculate_tasks_percent("validated")
+            summary.percent_bad_imagery = self.calculate_tasks_percent("bad_imagery")
 
         summary.project_teams = [
             ProjectTeamDTO(

--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -120,6 +120,7 @@ class ProjectSearchService:
         project_info_dto = ProjectInfo.get_dto_for_locale(
             project.id, preferred_locale, project.default_locale
         )
+        project_obj = Project.get(project.id)
         list_dto = ListSearchResultDTO()
         list_dto.project_id = project.id
         list_dto.locale = project_info_dto.locale
@@ -129,19 +130,11 @@ class ProjectSearchService:
         list_dto.short_description = project_info_dto.short_description
         list_dto.last_updated = project.last_updated
         list_dto.due_date = project.due_date
-        list_dto.percent_mapped = Project.calculate_tasks_percent(
+        list_dto.percent_mapped = project_obj.calculate_tasks_percent(
             "mapped",
-            project.total_tasks,
-            project.tasks_mapped,
-            project.tasks_validated,
-            project.tasks_bad_imagery,
         )
-        list_dto.percent_validated = Project.calculate_tasks_percent(
+        list_dto.percent_validated = project_obj.calculate_tasks_percent(
             "validated",
-            project.total_tasks,
-            project.tasks_mapped,
-            project.tasks_validated,
-            project.tasks_bad_imagery,
         )
         list_dto.status = ProjectStatus(project.status).name
         list_dto.active_mappers = Project.get_active_mappers(project.id)

--- a/backend/services/project_service.py
+++ b/backend/services/project_service.py
@@ -576,13 +576,7 @@ class ProjectService:
             return
         project = ProjectService.get_project_by_id(project_id)
 
-        project_completion = Project.calculate_tasks_percent(
-            "project_completion",
-            project.total_tasks,
-            project.tasks_mapped,
-            project.tasks_validated,
-            project.tasks_bad_imagery,
-        )
+        project_completion = project.calculate_tasks_percent("project_completion")
         if project_completion == 50 and project.progress_email_sent:
             return  # Don't send progress email if it's already sent
         if project_completion in [50, 100]:

--- a/backend/services/project_service.py
+++ b/backend/services/project_service.py
@@ -479,12 +479,27 @@ class ProjectService:
 
     @staticmethod
     @cached(summary_cache)
-    def get_project_summary(
+    def get_cached_project_summary(
         project_id: int, preferred_locale: str = "en"
     ) -> ProjectSummary:
         """Gets the project summary DTO"""
         project = ProjectService.get_project_by_id(project_id)
         return project.get_project_summary(preferred_locale)
+
+    @staticmethod
+    def get_project_summary(
+        project_id: int, preferred_locale: str = "en"
+    ) -> ProjectSummary:
+        """Gets the project summary DTO"""
+        project = ProjectService.get_project_by_id(project_id)
+        summary = ProjectService.get_cached_project_summary(
+            project_id, preferred_locale
+        )
+        # Since we don't want to cache the project stats, we need to update them
+        summary.percent_mapped = project.calculate_tasks_percent("mapped")
+        summary.percent_validated = project.calculate_tasks_percent("validated")
+        summary.percent_bad_imagery = project.calculate_tasks_percent("bad_imagery")
+        return summary
 
     @staticmethod
     def set_project_as_featured(project_id: int):

--- a/backend/services/project_service.py
+++ b/backend/services/project_service.py
@@ -484,7 +484,8 @@ class ProjectService:
     ) -> ProjectSummary:
         """Gets the project summary DTO"""
         project = ProjectService.get_project_by_id(project_id)
-        return project.get_project_summary(preferred_locale)
+        # We don't want to cache the project stats, so we set calculate_completion to False
+        return project.get_project_summary(preferred_locale, calculate_completion=False)
 
     @staticmethod
     def get_project_summary(


### PR DESCRIPTION
closes #5578 and #3841

**#5578**
With this PR, we moved the function used to compute project completion out of cache, allowing it to be updated in real time. This will fix a number of side effects, including the issue described in #5578 and the difference in completeness between the project card and the project detail page.

**#3841**
Furthermore, the function to compute project completion has been set as an instance method rather than a static method, so that all project task statistics do not need to be supplied as arguments to calculate project completion statistics. When this is set as the instance method, all of the project tasks' statistics can be retrieved via the project instance itself.

How to test **locally**? _**(Caution: Do not do this in live instance)**_
- Go to any tasks view of any project. i.e. `/projects/:id/tasks` and note the project completion percentages.
- Go to project edit.
- Go to action.
- Click on map all tasks.
- Go to tasks view of same project. The project completion should indicate that project is 100% mapped. This should display live completion stats.