### PR TITLE
Update tests for the task action page

### DIFF
--- a/frontend/src/components/portal.js
+++ b/frontend/src/components/portal.js
@@ -1,22 +1,24 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-const PORTAL_ROOT = document.getElementById('action-root');
+let portalRoot = document.getElementById('action-root');
+if (!portalRoot) {
+  portalRoot = document.createElement('div');
+  portalRoot.setAttribute('id', 'action-root');
+  document.body.appendChild(portalRoot);
+}
 
 class Portal extends React.Component {
-  constructor(props) {
-    super(props);
-    this.el = document.createElement('div');
-  }
+  el = document.createElement('div');
 
   componentDidMount() {
-    PORTAL_ROOT.style.display = 'block';
-    PORTAL_ROOT.appendChild(this.el);
+    portalRoot.style.display = 'block';
+    portalRoot.appendChild(this.el);
   }
 
   componentWillUnmount() {
-    PORTAL_ROOT.style.display = 'none';
-    PORTAL_ROOT.removeChild(this.el);
+    portalRoot.style.display = 'none';
+    portalRoot.removeChild(this.el);
   }
 
   render() {

--- a/frontend/src/components/taskSelection/action.js
+++ b/frontend/src/components/taskSelection/action.js
@@ -78,7 +78,6 @@ export function TaskMapAction({
   const [validationComments, setValidationComments] = useState({});
   const [validationStatus, setValidationStatus] = useState({});
   const [historyTabChecked, setHistoryTabChecked] = useState(false);
-  const [multipleTasksInfo, setMultipleTasksInfo] = useState({});
   const [showMapChangesModal, setShowMapChangesModal] = useState(false);
   const [showSessionExpiringDialog, setShowSessionExpiringDialog] = useState(false);
   const [showSessionExpiredDialog, setSessionTimeExpiredDialog] = useState(false);
@@ -106,18 +105,6 @@ export function TaskMapAction({
   const historyTabSwitch = () => {
     setHistoryTabChecked(true);
     setActiveSection('history');
-  };
-
-  const handleTaskHistories = (taskIds) => {
-    if (taskIds.length < 1) return;
-
-    taskIds.forEach((id) => {
-      if (!Object.keys(multipleTasksInfo).includes(id.toString())) {
-        fetchLocalJSONAPI(`projects/${project.projectId}/tasks/${id}/`, token).then((data) =>
-          setMultipleTasksInfo({ ...multipleTasksInfo, [id]: data }),
-        );
-      }
-    });
   };
 
   useEffect(() => {
@@ -438,7 +425,6 @@ export function TaskMapAction({
                       )}
                       {action === 'VALIDATION' && activeTasks.length > 1 && (
                         <MultipleTaskHistoriesAccordion
-                          handleChange={handleTaskHistories}
                           tasks={activeTasks}
                           projectId={project.projectId}
                         />

--- a/frontend/src/components/taskSelection/action.js
+++ b/frontend/src/components/taskSelection/action.js
@@ -28,7 +28,6 @@ import {
   ReopenEditor,
   UnsavedMapChangesModalContent,
 } from './actionSidebars';
-import { fetchLocalJSONAPI } from '../../network/genericJSONRequest';
 import { MultipleTaskHistoriesAccordion } from './multipleTaskHistories';
 import { ResourcesTab } from './resourcesTab';
 import { ActionTabsNav } from './actionTabsNav';

--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -572,21 +572,23 @@ const TaskValidationSelector = ({
           <input
             type="radio"
             value="VALIDATED"
+            id={`#${id}-VALIDATED`}
             className="radio-input input-reset pointer v-mid dib h2 w2 mr2 ml3 br-100 ba b--blue-light"
             checked={currentStatus === 'VALIDATED'}
             onChange={() => updateStatus(id, 'VALIDATED')}
           />
-          <label htmlFor="VALIDATED">
+          <label htmlFor={`#${id}-VALIDATED`}>
             <FormattedMessage {...messages.complete} />
           </label>
           <input
             type="radio"
             value="INVALIDATED"
+            id={`#${id}-INVALIDATED`}
             className="radio-input input-reset pointer v-mid dib h2 w2 mr2 ml3 br-100 ba b--blue-light"
             checked={currentStatus === 'INVALIDATED'}
             onChange={() => updateStatus(id, 'INVALIDATED')}
           />
-          <label htmlFor="INVALIDATED">
+          <label htmlFor={`#${id}-INVALIDATED`}>
             <FormattedMessage {...messages.incomplete} />
           </label>
           <CustomButton

--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -400,11 +400,6 @@ export function CompletionTabForValidation({
           },
         );
       });
-    } else if (disabled) {
-      return new Promise((resolve, reject) => {
-        setShowMapChangesModal('unlock');
-        resolve();
-      });
     }
   };
   const submitTaskAsync = useAsync(submitTask);

--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -169,6 +169,7 @@ export function CompletionTabForMapping({
       {showReadCommentsAlert && (
         <div
           className="tc pa2 mb1 bg-grey-light blue-dark pointer"
+          role="button"
           onClick={() => historyTabSwitch()}
         >
           <InfoIcon className="v-mid h1 w1" />
@@ -184,6 +185,8 @@ export function CompletionTabForMapping({
           <QuestionCircleIcon
             className="pointer dib v-mid pl2 pb1 blue-light"
             height="1.25rem"
+            role="button"
+            aria-label="toggle help"
             onClick={() => setShowHelp(!showHelp)}
           />
         </h4>
@@ -671,7 +674,7 @@ function CompletionInstructions({ setVisibility }: Object) {
         className="br-100 bg-grey-light white h1 w1 fr pointer tc v-mid di"
         onClick={() => setVisibility(false)}
       >
-        <CloseIcon className="pv1" />
+        <CloseIcon className="pv1" aria-label="hide instructions" />
       </span>
       <div className="blue-grey">
         <p>
@@ -728,6 +731,8 @@ export function SidebarToggle({ setShowSidebar, activeEditor }: Object) {
         {(msg) => (
           <div className="fr pointer" title={msg}>
             <SidebarIcon
+              role="button"
+              aria-label="Hide sidebar"
               onClick={() => {
                 setShowSidebar(false);
                 activeEditor === 'ID' && iDContext.ui().restart();
@@ -787,7 +792,11 @@ function TaskSpecificInstructions({ instructions, open = true }: Object) {
   const [isOpen, setIsOpen] = useState(open);
   return (
     <>
-      <h4 className="ttu blue-grey mt1 mb0 pointer" onClick={() => setIsOpen(!isOpen)}>
+      <h4
+        className="ttu blue-grey mt1 mb0 pointer"
+        role="button"
+        onClick={() => setIsOpen(!isOpen)}
+      >
         {isOpen ? (
           <ChevronDownIcon style={{ height: '14px' }} className="pr1 pb1 v-mid" />
         ) : (

--- a/frontend/src/components/taskSelection/actionTabsNav.js
+++ b/frontend/src/components/taskSelection/actionTabsNav.js
@@ -25,6 +25,7 @@ export const ActionTabsNav = ({
         className="ttu w-100 barlow-condensed menu-items-container f4 blue-dark nowrap bb b--grey-light fw5 overflow-x-auto"
       >
         <span
+          role="button"
           className={`dib mr4-l mr3 pb2 pointer ${
             activeSection === 'completion' && 'bb b--red bw1'
           }`}
@@ -33,6 +34,7 @@ export const ActionTabsNav = ({
           <FormattedMessage {...messages.completion} />
         </span>
         <span
+          role="button"
           className={`dib mr4-l mr3 pb2 pointer ${
             activeSection === 'instructions' && 'bb b--red bw1'
           }`}
@@ -41,6 +43,7 @@ export const ActionTabsNav = ({
           <FormattedMessage {...messages.instructions} />
         </span>
         <span
+          role="button"
           className={`inline-flex items-center mr4-l mr3 pb2 pointer ${
             activeSection === 'history' && 'bb b--red bw1'
           }`}
@@ -58,6 +61,7 @@ export const ActionTabsNav = ({
         </span>
         {action === 'VALIDATION' && (
           <span
+            role="button"
             className={`dib mr4-l mr3 pb2 pointer ${
               activeSection === 'resources' && 'bb b--red bw1'
             }`}

--- a/frontend/src/components/taskSelection/multipleTaskHistories.js
+++ b/frontend/src/components/taskSelection/multipleTaskHistories.js
@@ -11,9 +11,9 @@ import { FormattedMessage } from 'react-intl';
 import messages from './messages';
 import { TaskHistory } from './taskActivity';
 
-export const MultipleTaskHistoriesAccordion = ({ handleChange, tasks, projectId }) => {
+export const MultipleTaskHistoriesAccordion = ({ tasks, projectId }) => {
   return (
-    <Accordion className="bn" allowMultipleExpanded allowZeroExpanded onChange={handleChange}>
+    <Accordion className="bn" allowMultipleExpanded allowZeroExpanded>
       {tasks
         .sort((n1, n2) => n1.taskId - n2.taskId)
         .map((t) => (

--- a/frontend/src/components/taskSelection/taskList.js
+++ b/frontend/src/components/taskSelection/taskList.js
@@ -50,7 +50,7 @@ export function TaskStatus({ status, lockHolder }: Object) {
   );
 }
 
-function TaskItem({
+export function TaskItem({
   data,
   project,
   setZoomedTaskId,
@@ -134,6 +134,7 @@ function TaskItem({
                 width="18px"
                 height="18px"
                 className="pointer hover-blue-grey"
+                role="button"
                 onClick={() => setZoomedTaskId(data.taskId)}
               />
             </div>

--- a/frontend/src/components/taskSelection/tests/action.test.js
+++ b/frontend/src/components/taskSelection/tests/action.test.js
@@ -24,6 +24,53 @@ const setup = () => {
   );
 };
 
+describe('Task Map Action', () => {
+  it('should display JOSM error', async () => {
+    setupFaultyHandlers();
+    setup();
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole('button', {
+        name: /iD Editor/i,
+      }),
+    );
+    await user.click(screen.getByText('JOSM'));
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', {
+          name: messages.JOSMError.defaultMessage,
+        }),
+      ).toBeInTheDocument(),
+    );
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /close/i,
+      }),
+    );
+    expect(
+      screen.queryByRole('heading', {
+        name: messages.JOSMError.defaultMessage,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should expand accordition to view task details', async () => {
+    setup();
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole('button', {
+        name: /history/i,
+      }),
+    );
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Task 1765',
+      }),
+    );
+    expect(screen.getByRole('radio', { name: /comments/i })).toBeChecked();
+  });
+});
+
 describe('Session Expire Dialogs', () => {
   beforeEach(() => {
     jest.useFakeTimers();

--- a/frontend/src/components/taskSelection/tests/action.test.js
+++ b/frontend/src/components/taskSelection/tests/action.test.js
@@ -1,0 +1,54 @@
+import '@testing-library/jest-dom';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { getProjectSummary } from '../../../network/tests/mockData/projects';
+import { userMultipleLockedTasksDetails } from '../../../network/tests/mockData/userStats';
+import { setupFaultyHandlers } from '../../../network/tests/server';
+import tasksGeojson from '../../../utils/tests/snippets/tasksGeometry';
+import { ReduxIntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
+import { TaskMapAction } from '../action';
+import messages from '../messages';
+
+const setup = () => {
+  renderWithRouter(
+    <ReduxIntlProviders>
+      <TaskMapAction
+        project={getProjectSummary(123)}
+        projectIsReady
+        tasks={tasksGeojson}
+        activeTasks={userMultipleLockedTasksDetails.tasks}
+        action="VALIDATION"
+      />
+    </ReduxIntlProviders>,
+  );
+};
+
+describe('Session Expire Dialogs', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('should display modal to notify user session about to expire', async () => {
+    setup();
+    jest.advanceTimersByTime(6900000);
+    const extendSessionDialog = screen.getByRole('dialog');
+    expect(within(extendSessionDialog).getByRole('heading')).toHaveTextContent(
+      messages.sessionAboutToExpireTitle.defaultMessage,
+    );
+  });
+
+  it('should display modal to notify user session has ended', async () => {
+    setup();
+    jest.advanceTimersByTime(7200000);
+    const extendSessionDialog = screen.getByRole('dialog');
+    expect(within(extendSessionDialog).getByRole('heading')).toHaveTextContent(
+      messages.sessionExpiredTitle.defaultMessage,
+    );
+  });
+});

--- a/frontend/src/components/taskSelection/tests/actionSidebars.test.js
+++ b/frontend/src/components/taskSelection/tests/actionSidebars.test.js
@@ -1,0 +1,158 @@
+import '@testing-library/jest-dom';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { CompletionTabForMapping, CompletionTabForValidation } from '../actionSidebars';
+import { ReduxIntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
+import { setupFaultyHandlers } from '../../../network/tests/server';
+import messages from '../messages';
+
+describe('Appeareance of unsaved map changes to be dealt with while mapping', () => {
+  test('when splitting a task', async () => {
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <CompletionTabForMapping disabled />
+      </ReduxIntlProviders>,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /split task/i }));
+    expect(
+      screen.getByRole('heading', {
+        name: messages.unsavedChanges.defaultMessage,
+      }),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: /close/i,
+      }),
+    );
+    expect(
+      screen.queryByRole('heading', {
+        name: messages.unsavedChanges.defaultMessage,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('when submitting a task', async () => {
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <CompletionTabForMapping disabled />
+      </ReduxIntlProviders>,
+    );
+    expect(screen.getByText(messages.unsavedChangesTooltip.defaultMessage)).toBeInTheDocument();
+  });
+
+  test('when selecting another task', async () => {
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <CompletionTabForMapping disabled />
+      </ReduxIntlProviders>,
+    );
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /select another task/i,
+      }),
+    );
+    expect(
+      screen.getByRole('heading', {
+        name: messages.unsavedChanges.defaultMessage,
+      }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('Miscellaneous modals and prompts', () => {
+  test('should display/hide split task error', async () => {
+    setupFaultyHandlers();
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <CompletionTabForMapping project={{ projectId: 123 }} tasksIds={[1997]} />
+      </ReduxIntlProviders>,
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /split task/i,
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText('It was not possible to split the task')).toBeInTheDocument(),
+    );
+    await userEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {
+        name: /close/i,
+      }),
+    );
+    expect(screen.queryByText('It was not possible to split the task')).not.toBeInTheDocument();
+  });
+
+  test('should prompt the user to read comments', async () => {
+    const historyTabSwitchMock = jest.fn();
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <CompletionTabForMapping showReadCommentsAlert historyTabSwitch={historyTabSwitchMock} />
+      </ReduxIntlProviders>,
+    );
+
+    expect(screen.getByText(messages.readTaskComments.defaultMessage)).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: messages.readTaskComments.defaultMessage,
+      }),
+    );
+    expect(historyTabSwitchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('should display/hide help text', async () => {
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <CompletionTabForMapping showReadCommentsAlert />
+      </ReduxIntlProviders>,
+    );
+    await userEvent.click(screen.getByLabelText('toggle help'));
+    expect(screen.getByText(messages.instructionsSelect.defaultMessage)).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText('hide instructions'));
+    expect(screen.queryByText(messages.instructionsSelect.defaultMessage)).not.toBeInTheDocument();
+  });
+
+  test('should display/hide task specific instructions', async () => {
+    const instruction = 'this is a sample instruction';
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <CompletionTabForMapping taskInstructions={instruction} />
+      </ReduxIntlProviders>,
+    );
+
+    expect(screen.getByText(instruction)).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: messages.taskExtraInfo.defaultMessage,
+      }),
+    );
+    expect(screen.queryByText(instruction)).not.toBeInTheDocument();
+  });
+});
+
+describe('Appeareance of unsaved map changes to be dealt with while validating', () => {
+  test('when stopping validation session', async () => {
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <CompletionTabForValidation disabled validationStatus={{}} tasksIds={[]} />
+      </ReduxIntlProviders>,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /stop validation/i }));
+    expect(
+      screen.getByRole('heading', {
+        name: messages.unsavedChanges.defaultMessage,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('when submitting a task', async () => {
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <CompletionTabForValidation disabled validationStatus={{}} tasksIds={[]} />
+      </ReduxIntlProviders>,
+    );
+    expect(screen.getByText(messages.unsavedChangesTooltip.defaultMessage)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/taskSelection/tests/extendSession.test.js
+++ b/frontend/src/components/taskSelection/tests/extendSession.test.js
@@ -1,0 +1,86 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { setupFaultyHandlers } from '../../../network/tests/server';
+
+import { IntlProviders } from '../../../utils/testWithIntl';
+import { SessionAboutToExpire, SessionExpired } from '../extendSession';
+import messages from '../messages';
+
+describe('Session About To Expire Dialog', () => {
+  it('should display error when session could not be extended', async () => {
+    setupFaultyHandlers();
+    render(
+      <IntlProviders>
+        <SessionAboutToExpire showSessionExpiringDialog projectId={123} />
+      </IntlProviders>,
+    );
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /extend session/i,
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByText(messages.sessionExtensionError.defaultMessage)).toBeInTheDocument();
+    });
+  });
+
+  it('should close the modal', async () => {
+    const setShowSessionExpiryDialogMock = jest.fn();
+    const { container } = render(
+      <IntlProviders>
+        <SessionAboutToExpire
+          showSessionExpiringDialog
+          projectId={123}
+          setShowSessionExpiryDialog={setShowSessionExpiryDialogMock}
+        />
+      </IntlProviders>,
+    );
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /close/i,
+      }),
+    );
+    expect(setShowSessionExpiryDialogMock).toHaveBeenCalled();
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('Session Expired Dialog', () => {
+  it('should display error when task cannot be relocked', async () => {
+    setupFaultyHandlers();
+    render(
+      <IntlProviders>
+        <SessionExpired showSessionExpiredDialog projectId={123} tasksIds={[12, 13]} />
+      </IntlProviders>,
+    );
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /relock tasks/i,
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByText('An error occurred while relocking your tasks.')).toBeInTheDocument();
+    });
+  });
+
+  it('should close the modal', async () => {
+    const setShowSessionExpiredDialogMock = jest.fn();
+    const { container } = render(
+      <IntlProviders>
+        <SessionAboutToExpire
+          showSessionExpiringDialog
+          projectId={123}
+          setShowSessionExpiryDialog={setShowSessionExpiredDialogMock}
+        />
+      </IntlProviders>,
+    );
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /close/i,
+      }),
+    );
+    expect(setShowSessionExpiredDialogMock).toHaveBeenCalled();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/taskSelection/tests/index.test.js
+++ b/frontend/src/components/taskSelection/tests/index.test.js
@@ -14,7 +14,12 @@ describe('Contributions', () => {
     act(() => {
       store.dispatch({ type: 'SET_TOKEN', token: null });
       store.dispatch({ type: 'SET_LOCALE', locale: 'en-US' });
+      store.dispatch({
+        type: 'SET_USER_DETAILS',
+        userDetails: { id: 420, username: 'somebodyWhoHasntContributed', isExpert: true },
+      });
     });
+
     renderWithRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <ReduxIntlProviders>
@@ -23,23 +28,16 @@ describe('Contributions', () => {
       </QueryParamProvider>,
     );
 
-    await screen.findAllByText(/last updated by/i);
-
+    await waitFor(() =>
+      expect(screen.getByText(/Project Specific Mapping Notes/i)).toBeInTheDocument(),
+    );
     await userEvent.click(
       screen.getByRole('button', {
         name: /contributions/i,
       }),
     );
-
-    await waitFor(() =>
-      expect(
-        screen.getByRole('button', {
-          name: 'Select tasks mapped by user_3',
-        }),
-      ).toBeInTheDocument(),
-    );
     await userEvent.click(
-      screen.getByRole('button', {
+      await screen.findByRole('button', {
         name: 'Select tasks mapped by user_3',
       }),
     );
@@ -59,23 +57,16 @@ describe('Contributions', () => {
       </QueryParamProvider>,
     );
 
-    await screen.findAllByText(/last updated by/i);
-
+    await waitFor(() =>
+      expect(screen.getByText(/Project Specific Mapping Notes/i)).toBeInTheDocument(),
+    );
     await userEvent.click(
-      screen.getByRole('button', {
+      await screen.findByRole('button', {
         name: /contributions/i,
       }),
     );
-
-    await waitFor(() =>
-      expect(
-        screen.getByRole('button', {
-          name: 'Select tasks validated by user_3',
-        }),
-      ).toBeInTheDocument(),
-    );
     await userEvent.click(
-      screen.getByRole('button', {
+      await screen.findByRole('button', {
         name: 'Select tasks validated by user_3',
       }),
     );
@@ -86,7 +77,7 @@ describe('Contributions', () => {
     ).toHaveClass('ba b--blue-dark bw1');
   });
 
-  it('should sort tasks by their relevant options', async () => {
+  it('should sort tasks by their task number', async () => {
     renderWithRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <ReduxIntlProviders>
@@ -95,7 +86,14 @@ describe('Contributions', () => {
       </QueryParamProvider>,
     );
 
-    await screen.findAllByText(/last updated by/i);
+    await waitFor(() =>
+      expect(screen.getByText(/Project Specific Mapping Notes/i)).toBeInTheDocument(),
+    );
+    await userEvent.click(
+      await screen.findByRole('button', {
+        name: /tasks/i,
+      }),
+    );
 
     await userEvent.click(
       screen.getByRole('button', {
@@ -121,7 +119,14 @@ describe('Contributions', () => {
       </QueryParamProvider>,
     );
 
-    await screen.findAllByText(/last updated by/i);
+    await waitFor(() =>
+      expect(screen.getByText(/Project Specific Mapping Notes/i)).toBeInTheDocument(),
+    );
+    await userEvent.click(
+      await screen.findByRole('button', {
+        name: /tasks/i,
+      }),
+    );
     const userQueryText = screen.getByRole('textbox');
     await userEvent.type(userQueryText, 'hello');
     expect(userQueryText).toHaveValue('hello');

--- a/frontend/src/components/taskSelection/tests/multipleTaskHistories.test.js
+++ b/frontend/src/components/taskSelection/tests/multipleTaskHistories.test.js
@@ -6,17 +6,14 @@ import { MultipleTaskHistoriesAccordion } from '../multipleTaskHistories';
 import { ReduxIntlProviders } from '../../../utils/testWithIntl';
 
 describe('MultipleTaskHistories Accordion', () => {
-  let handleChange = jest.fn();
-
   it('does not render accordion with task history items if there are no tasks', () => {
     render(
       <ReduxIntlProviders>
-        <MultipleTaskHistoriesAccordion handleChange={handleChange} tasks={[]} projectId={1} />
+        <MultipleTaskHistoriesAccordion tasks={[]} projectId={1} />
       </ReduxIntlProviders>,
     );
 
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
-    expect(handleChange).not.toHaveBeenCalled();
     expect(screen.queryByText(/Comments/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Activities/i)).not.toBeInTheDocument();
   });
@@ -56,7 +53,7 @@ describe('MultipleTaskHistories Accordion', () => {
     ];
     render(
       <ReduxIntlProviders>
-        <MultipleTaskHistoriesAccordion handleChange={handleChange} tasks={tasks} projectId={1} />
+        <MultipleTaskHistoriesAccordion tasks={tasks} projectId={1} />
       </ReduxIntlProviders>,
     );
 
@@ -68,7 +65,6 @@ describe('MultipleTaskHistories Accordion', () => {
       fireEvent.click(taskBtn);
     });
 
-    expect(handleChange).toHaveBeenCalledTimes(2);
     expect(screen.getAllByText(/Comments/i)).toHaveLength(2);
     expect(screen.getAllByText(/Activities/i)).toHaveLength(2);
   });

--- a/frontend/src/components/taskSelection/tests/taskList.test.js
+++ b/frontend/src/components/taskSelection/tests/taskList.test.js
@@ -1,0 +1,90 @@
+import '@testing-library/jest-dom';
+import { act, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { getProjectSummary } from '../../../network/tests/mockData/projects';
+import { store } from '../../../store';
+import tasksGeojson from '../../../utils/tests/snippets/tasksGeometry';
+import { IntlProviders, ReduxIntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
+import { TaskFilter, TaskItem } from '../taskList';
+
+describe('Task Item', () => {
+  const task = {
+    lockedBy: null,
+    taskId: 8,
+    taskStatus: 'READY',
+    actionDate: '2023-03-22T05:28:15.257341Z',
+    actionBy: 'helnershingthapa',
+  };
+
+  it('should set the clicked task', async () => {
+    const selectTaskMock = jest.fn();
+    renderWithRouter(
+      <IntlProviders>
+        <TaskItem data={task} selectTask={selectTaskMock} />
+      </IntlProviders>,
+    );
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /Task #8 helnershingthap/i,
+      }),
+    );
+    expect(selectTaskMock).toHaveBeenCalledWith(8, 'READY');
+  });
+
+  it('should set the zoom task ID of the task to be zoomed', async () => {
+    const setZoomedTaskIdMock = jest.fn();
+    renderWithRouter(
+      <IntlProviders>
+        <TaskItem data={task} selectTask={jest.fn()} setZoomedTaskId={setZoomedTaskIdMock} />
+      </IntlProviders>,
+    );
+    await userEvent.click(screen.getAllByRole('button')[1]);
+    expect(setZoomedTaskIdMock).toHaveBeenCalledWith(8);
+  });
+
+  it('should display task detail modal', async () => {
+    act(() => {
+      store.dispatch({ type: 'SET_TOKEN', token: 'validToken' });
+    });
+    renderWithRouter(
+      <ReduxIntlProviders>
+        <TaskItem
+          taskId={1}
+          data={task}
+          tasks={[tasksGeojson.features[7]]}
+          selectTask={jest.fn()}
+          project={getProjectSummary(123)}
+        />
+      </ReduxIntlProviders>,
+    );
+    await userEvent.click(screen.getByTitle(/See task history/i));
+    expect(
+      within(screen.getByRole('dialog')).getByRole('radio', { name: /activities/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('Task Filter', () => {
+  it('should not show mapped option if user cannot validate', async () => {
+    renderWithRouter(
+      <IntlProviders>
+        <TaskFilter userCanValidate={false} />
+      </IntlProviders>,
+    );
+    await userEvent.click(screen.getByRole('button'));
+    expect(screen.queryByText(/mapped/i)).not.toBeInTheDocument();
+  });
+
+  it('should show mapped option if user can validate', async () => {
+    const setStatusFn = jest.fn();
+    renderWithRouter(
+      <IntlProviders>
+        <TaskFilter userCanValidate setStatusFn={setStatusFn} />
+      </IntlProviders>,
+    );
+    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByText(/ready for validation/i));
+    expect(setStatusFn).toHaveBeenCalledWith('MAPPED');
+  });
+});

--- a/frontend/src/network/tests/mockData/projects.js
+++ b/frontend/src/network/tests/mockData/projects.js
@@ -295,8 +295,8 @@ export const userTouchedProjects = {
   ],
 };
 
-export const taskDetail = {
-  taskId: 1809,
+export const taskDetail = (taskId) => ({
+  taskId: taskId,
   projectId: 5871,
   taskStatus: 'LOCKED_FOR_MAPPING',
   lockHolder: 'helnershingthapa',
@@ -318,7 +318,7 @@ export const taskDetail = {
   autoUnlockSeconds: 7200,
   lastUpdated: formatISO(new Date()),
   numberOfComments: null,
-};
+});
 
 export const projectComments = {
   chat: [
@@ -456,28 +456,29 @@ export const stopMapping = {
 };
 
 export const stopValidation = {
-  "tasks": [
+  tasks: [
     {
-      "taskId": 1997,
-      "projectId": 123,
-      "taskStatus": "MAPPED",
-      "taskHistory": [
+      taskId: 1997,
+      projectId: 123,
+      taskStatus: 'MAPPED',
+      taskHistory: [
         {
-          "historyId": 10764833,
-          "taskId": null,
-          "action": "LOCKED_FOR_VALIDATION",
-          "actionText": "00:06:58.832787",
-          "actionDate": "2023-03-21T04:42:04.868220Z",
-          "actionBy": "helnershingthapa",
-          "pictureUrl": "https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXQ2Q3c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fe41f1b2a5d6cf492a7133f15c81f105dec06ff7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBPZ2h3Ym1jNkZISmxjMmw2WlY5MGIxOXNhVzFwZEZzSGFXbHBhUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--058ac785867b32287d598a314311e2253bd879a3/unnamed.webp",
-          "issues": null
+          historyId: 10764833,
+          taskId: null,
+          action: 'LOCKED_FOR_VALIDATION',
+          actionText: '00:06:58.832787',
+          actionDate: '2023-03-21T04:42:04.868220Z',
+          actionBy: 'helnershingthapa',
+          pictureUrl:
+            'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXQ2Q3c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fe41f1b2a5d6cf492a7133f15c81f105dec06ff7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBPZ2h3Ym1jNkZISmxjMmw2WlY5MGIxOXNhVzFwZEZzSGFXbHBhUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--058ac785867b32287d598a314311e2253bd879a3/unnamed.webp',
+          issues: null,
         },
       ],
-      "taskAnnotation": [],
-      "perTaskInstructions": "",
-      "autoUnlockSeconds": 7200,
-      "lastUpdated": "2023-03-21T04:42:04.868220Z",
-      "numberOfComments": null
-    }
-  ]
-}
+      taskAnnotation: [],
+      perTaskInstructions: '',
+      autoUnlockSeconds: 7200,
+      lastUpdated: '2023-03-21T04:42:04.868220Z',
+      numberOfComments: null,
+    },
+  ],
+};

--- a/frontend/src/network/tests/mockData/projects.js
+++ b/frontend/src/network/tests/mockData/projects.js
@@ -1,5 +1,6 @@
 import { TM_DEFAULT_CHANGESET_COMMENT } from '../../../config';
 import nextDay from 'date-fns/nextDay';
+import { formatISO } from 'date-fns';
 
 export const PROJECT_ID_WITH_RANDOM_TASK_ENFORCED = 963;
 export const PROJECT_ID_ALL_VALIDATED = 6;
@@ -294,6 +295,31 @@ export const userTouchedProjects = {
   ],
 };
 
+export const taskDetail = {
+  taskId: 1809,
+  projectId: 5871,
+  taskStatus: 'LOCKED_FOR_MAPPING',
+  lockHolder: 'helnershingthapa',
+  taskHistory: [
+    {
+      historyId: 10764790,
+      taskId: null,
+      action: 'LOCKED_FOR_MAPPING',
+      actionText: null,
+      actionDate: '2023-03-16T16:49:29.977470Z',
+      actionBy: 'helnershingthapa',
+      pictureUrl:
+        'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXQ2Q3c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fe41f1b2a5d6cf492a7133f15c81f105dec06ff7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBPZ2h3Ym1jNkZISmxjMmw2WlY5MGIxOXNhVzFwZEZzSGFXbHBhUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--058ac785867b32287d598a314311e2253bd879a3/unnamed.webp',
+      issues: null,
+    },
+  ],
+  taskAnnotation: [],
+  perTaskInstructions: '',
+  autoUnlockSeconds: 7200,
+  lastUpdated: formatISO(new Date()),
+  numberOfComments: null,
+};
+
 export const projectComments = {
   chat: [
     {
@@ -403,4 +429,28 @@ export const activities = (id) => {
       },
     ],
   };
+};
+
+export const stopMapping = {
+  taskId: 1997,
+  projectId: 123,
+  taskStatus: 'READY',
+  taskHistory: [
+    {
+      historyId: 10764792,
+      taskId: null,
+      action: 'LOCKED_FOR_MAPPING',
+      actionText: '00:00:29.484161',
+      actionDate: '2023-03-19T14:57:58.038417Z',
+      actionBy: 'helnershingthapa',
+      pictureUrl:
+        'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXQ2Q3c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fe41f1b2a5d6cf492a7133f15c81f105dec06ff7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBPZ2h3Ym1jNkZISmxjMmw2WlY5MGIxOXNhVzFwZEZzSGFXbHBhUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--058ac785867b32287d598a314311e2253bd879a3/unnamed.webp',
+      issues: null,
+    },
+  ],
+  taskAnnotation: [],
+  perTaskInstructions: '',
+  autoUnlockSeconds: 7200,
+  lastUpdated: '2023-03-19T14:57:58.038417Z',
+  numberOfComments: null,
 };

--- a/frontend/src/network/tests/mockData/projects.js
+++ b/frontend/src/network/tests/mockData/projects.js
@@ -454,3 +454,30 @@ export const stopMapping = {
   lastUpdated: '2023-03-19T14:57:58.038417Z',
   numberOfComments: null,
 };
+
+export const stopValidation = {
+  "tasks": [
+    {
+      "taskId": 1997,
+      "projectId": 123,
+      "taskStatus": "MAPPED",
+      "taskHistory": [
+        {
+          "historyId": 10764833,
+          "taskId": null,
+          "action": "LOCKED_FOR_VALIDATION",
+          "actionText": "00:06:58.832787",
+          "actionDate": "2023-03-21T04:42:04.868220Z",
+          "actionBy": "helnershingthapa",
+          "pictureUrl": "https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXQ2Q3c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fe41f1b2a5d6cf492a7133f15c81f105dec06ff7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBPZ2h3Ym1jNkZISmxjMmw2WlY5MGIxOXNhVzFwZEZzSGFXbHBhUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--058ac785867b32287d598a314311e2253bd879a3/unnamed.webp",
+          "issues": null
+        },
+      ],
+      "taskAnnotation": [],
+      "perTaskInstructions": "",
+      "autoUnlockSeconds": 7200,
+      "lastUpdated": "2023-03-21T04:42:04.868220Z",
+      "numberOfComments": null
+    }
+  ]
+}

--- a/frontend/src/network/tests/mockData/taskHistory.js
+++ b/frontend/src/network/tests/mockData/taskHistory.js
@@ -306,3 +306,7 @@ export const splitTask = {
     },
   ],
 };
+
+export const extendTask = {
+  Success: 'Successfully extended task expiry',
+};

--- a/frontend/src/network/tests/mockData/taskHistory.js
+++ b/frontend/src/network/tests/mockData/taskHistory.js
@@ -199,3 +199,108 @@ export const lockForValidation = {
     },
   ],
 };
+
+export const submitMappingTask = lockForMapping;
+
+export const userLockedTasks = {
+  lockedTasks: [],
+  projectId: null,
+  taskStatus: null,
+};
+
+export const splitTask = {
+  tasks: [
+    {
+      taskId: 1836,
+      projectId: 5871,
+      taskStatus: 'READY',
+      taskHistory: [
+        {
+          historyId: 10764804,
+          taskId: null,
+          action: 'STATE_CHANGE',
+          actionText: 'READY',
+          actionDate: '2023-03-20T05:16:58.686069Z',
+          actionBy: 'helnershingthapa',
+          pictureUrl:
+            'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXQ2Q3c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fe41f1b2a5d6cf492a7133f15c81f105dec06ff7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBPZ2h3Ym1jNkZISmxjMmw2WlY5MGIxOXNhVzFwZEZzSGFXbHBhUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--058ac785867b32287d598a314311e2253bd879a3/unnamed.webp',
+          issues: null,
+        },
+      ],
+      taskAnnotation: [],
+      perTaskInstructions: '',
+      autoUnlockSeconds: 7200,
+      lastUpdated: '2023-03-20T05:16:58.686069Z',
+      numberOfComments: null,
+    },
+    {
+      taskId: 1837,
+      projectId: 5871,
+      taskStatus: 'READY',
+      taskHistory: [
+        {
+          historyId: 10764813,
+          taskId: null,
+          action: 'STATE_CHANGE',
+          actionText: 'READY',
+          actionDate: '2023-03-20T05:16:58.760333Z',
+          actionBy: 'helnershingthapa',
+          pictureUrl:
+            'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXQ2Q3c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fe41f1b2a5d6cf492a7133f15c81f105dec06ff7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBPZ2h3Ym1jNkZISmxjMmw2WlY5MGIxOXNhVzFwZEZzSGFXbHBhUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--058ac785867b32287d598a314311e2253bd879a3/unnamed.webp',
+          issues: null,
+        },
+      ],
+      taskAnnotation: [],
+      perTaskInstructions: '',
+      autoUnlockSeconds: 7200,
+      lastUpdated: '2023-03-20T05:16:58.760333Z',
+      numberOfComments: null,
+    },
+    {
+      taskId: 1838,
+      projectId: 5871,
+      taskStatus: 'READY',
+      taskHistory: [
+        {
+          historyId: 10764822,
+          taskId: null,
+          action: 'STATE_CHANGE',
+          actionText: 'READY',
+          actionDate: '2023-03-20T05:16:58.832135Z',
+          actionBy: 'helnershingthapa',
+          pictureUrl:
+            'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXQ2Q3c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fe41f1b2a5d6cf492a7133f15c81f105dec06ff7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBPZ2h3Ym1jNkZISmxjMmw2WlY5MGIxOXNhVzFwZEZzSGFXbHBhUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--058ac785867b32287d598a314311e2253bd879a3/unnamed.webp',
+          issues: null,
+        },
+      ],
+      taskAnnotation: [],
+      perTaskInstructions: '',
+      autoUnlockSeconds: 7200,
+      lastUpdated: '2023-03-20T05:16:58.832135Z',
+      numberOfComments: null,
+    },
+    {
+      taskId: 1839,
+      projectId: 5871,
+      taskStatus: 'READY',
+      taskHistory: [
+        {
+          historyId: 10764831,
+          taskId: null,
+          action: 'STATE_CHANGE',
+          actionText: 'READY',
+          actionDate: '2023-03-20T05:16:58.923338Z',
+          actionBy: 'helnershingthapa',
+          pictureUrl:
+            'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXQ2Q3c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fe41f1b2a5d6cf492a7133f15c81f105dec06ff7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBPZ2h3Ym1jNkZISmxjMmw2WlY5MGIxOXNhVzFwZEZzSGFXbHBhUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--058ac785867b32287d598a314311e2253bd879a3/unnamed.webp',
+          issues: null,
+        },
+      ],
+      taskAnnotation: [],
+      perTaskInstructions: '',
+      autoUnlockSeconds: 7200,
+      lastUpdated: '2023-03-20T05:16:58.923338Z',
+      numberOfComments: null,
+    },
+  ],
+};

--- a/frontend/src/network/tests/mockData/taskHistory.js
+++ b/frontend/src/network/tests/mockData/taskHistory.js
@@ -202,6 +202,8 @@ export const lockForValidation = {
 
 export const submitMappingTask = lockForMapping;
 
+export const submitValidationTask = lockForValidation;
+
 export const userLockedTasks = {
   lockedTasks: [],
   projectId: null,

--- a/frontend/src/network/tests/mockData/userStats.js
+++ b/frontend/src/network/tests/mockData/userStats.js
@@ -1,3 +1,5 @@
+import { formatISO } from 'date-fns';
+
 export const newUsersStats = {
   total: 1044,
   beginner: 1034,
@@ -187,4 +189,33 @@ export const osmStatsProject = {
   edits: 123456789,
   latest: '2020-10-05T23:21:22.000Z',
   hashtag: `hotosm-project-1`,
+};
+
+export const userLockedTasksDetails = {
+  tasks: [
+    {
+      taskId: 1997,
+      projectId: 123,
+      taskStatus: 'LOCKED_FOR_MAPPING',
+      lockHolder: 'helnershingthapa',
+      taskHistory: [
+        {
+          historyId: 10764790,
+          taskId: null,
+          action: 'LOCKED_FOR_MAPPING',
+          actionText: null,
+          actionDate: '2023-03-16T16:49:29.977470Z',
+          actionBy: 'helnershingthapa',
+          pictureUrl:
+            'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXQ2Q3c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fe41f1b2a5d6cf492a7133f15c81f105dec06ff7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBPZ2h3Ym1jNkZISmxjMmw2WlY5MGIxOXNhVzFwZEZzSGFXbHBhUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--058ac785867b32287d598a314311e2253bd879a3/unnamed.webp',
+          issues: null,
+        },
+      ],
+      taskAnnotation: [],
+      perTaskInstructions: '',
+      autoUnlockSeconds: 7200,
+      lastUpdated: formatISO(new Date()),
+      numberOfComments: null,
+    },
+  ],
 };

--- a/frontend/src/network/tests/mockData/userStats.js
+++ b/frontend/src/network/tests/mockData/userStats.js
@@ -219,3 +219,66 @@ export const userLockedTasksDetails = {
     },
   ],
 };
+
+export const userMultipleLockedTasksDetails = {
+  tasks: [
+    {
+      taskId: 1765,
+      projectId: 5871,
+      taskStatus: 'LOCKED_FOR_VALIDATION',
+      lockHolder: 'helnershingthapa',
+      taskHistory: [
+        {
+          historyId: 10764882,
+          taskId: null,
+          action: 'LOCKED_FOR_VALIDATION',
+          actionText: null,
+          actionDate: '2023-03-27T06:04:11.910738Z',
+          actionBy: 'helnershingthapa',
+          pictureUrl:
+            'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXQ2Q3c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fe41f1b2a5d6cf492a7133f15c81f105dec06ff7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBPZ2h3Ym1jNkZISmxjMmw2WlY5MGIxOXNhVzFwZEZzSGFXbHBhUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--058ac785867b32287d598a314311e2253bd879a3/unnamed.webp',
+          issues: null,
+        },
+        {
+          historyId: 10534983,
+          taskId: null,
+          action: 'COMMENT',
+          actionText: 'This is a sample comment.',
+          actionDate: '2020-04-18T12:28:34.889677Z',
+          actionBy: 'commenter',
+          pictureUrl: null,
+          issues: null,
+        },
+      ],
+      taskAnnotation: [],
+      perTaskInstructions: '',
+      autoUnlockSeconds: 7200,
+      lastUpdated: formatISO(new Date()),
+      numberOfComments: null,
+    },
+    {
+      taskId: 1829,
+      projectId: 5871,
+      taskStatus: 'LOCKED_FOR_VALIDATION',
+      lockHolder: 'helnershingthapa',
+      taskHistory: [
+        {
+          historyId: 10764881,
+          taskId: null,
+          action: 'LOCKED_FOR_VALIDATION',
+          actionText: null,
+          actionDate: '2023-03-27T06:04:11.844339Z',
+          actionBy: 'helnershingthapa',
+          pictureUrl:
+            'https://www.openstreetmap.org/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBNXQ2Q3c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--fe41f1b2a5d6cf492a7133f15c81f105dec06ff7/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCem9MWm05eWJXRjBPZ2h3Ym1jNkZISmxjMmw2WlY5MGIxOXNhVzFwZEZzSGFXbHBhUT09IiwiZXhwIjpudWxsLCJwdXIiOiJ2YXJpYXRpb24ifX0=--058ac785867b32287d598a314311e2253bd879a3/unnamed.webp',
+          issues: null,
+        },
+      ],
+      taskAnnotation: [],
+      perTaskInstructions: '',
+      autoUnlockSeconds: 7200,
+      lastUpdated: '2023-03-27T06:04:11.844339Z',
+      numberOfComments: null,
+    },
+  ],
+};

--- a/frontend/src/network/tests/server-handlers.js
+++ b/frontend/src/network/tests/server-handlers.js
@@ -66,6 +66,7 @@ import { API_URL } from '../../config';
 import { notifications, ownCountUnread } from './mockData/notifications';
 import { authLogin, setUser, userRegister } from './mockData/auth';
 import {
+  extendTask,
   lockForMapping,
   lockForValidation,
   splitTask,
@@ -304,6 +305,9 @@ const handlers = [
   rest.post(API_URL + 'projects/:projectId/tasks/actions/split/:taskId/', (req, res, ctx) => {
     return res(ctx.json(splitTask));
   }),
+  rest.post(API_URL + 'projects/:projectId/tasks/actions/extend/', (req, res, ctx) => {
+    return res(ctx.json(extendTask));
+  }),
   // EXTERNAL API
   rest.get('https://osmstats-api.hotosm.org/wildcard', (req, res, ctx) => {
     return res(ctx.json(homepageStats));
@@ -347,6 +351,9 @@ const faultyHandlers = [
     },
   ),
   rest.post(API_URL + 'projects/:projectId/tasks/actions/lock-for-validation', (req, res, ctx) => {
+    return res.networkError('Failed to connect');
+  }),
+  rest.post(API_URL + 'projects/:projectId/tasks/actions/extend/', (req, res, ctx) => {
     return res.networkError('Failed to connect');
   }),
   rest.post(API_URL + 'projects/:projectId/tasks/actions/split/:taskId/', (req, res, ctx) => {

--- a/frontend/src/network/tests/server-handlers.js
+++ b/frontend/src/network/tests/server-handlers.js
@@ -10,9 +10,17 @@ import {
   userFavorite,
   favoritePost,
   activities,
+  taskDetail,
+  stopMapping,
 } from './mockData/projects';
 import { featuredProjects } from './mockData/featuredProjects';
-import { newUsersStats, osmStatsProd, osmStatsProject, userStats } from './mockData/userStats';
+import {
+  newUsersStats,
+  osmStatsProd,
+  osmStatsProject,
+  userLockedTasksDetails,
+  userStats,
+} from './mockData/userStats';
 import { projectContributions, projectContributionsByDay } from './mockData/contributions';
 import {
   usersList,
@@ -56,7 +64,13 @@ import tasksGeojson from '../../utils/tests/snippets/tasksGeometry';
 import { API_URL } from '../../config';
 import { notifications, ownCountUnread } from './mockData/notifications';
 import { authLogin, setUser, userRegister } from './mockData/auth';
-import { lockForMapping, lockForValidation } from './mockData/taskHistory';
+import {
+  lockForMapping,
+  lockForValidation,
+  splitTask,
+  submitMappingTask,
+  userLockedTasks,
+} from './mockData/taskHistory';
 
 const handlers = [
   rest.get(API_URL + 'projects/:id/queries/summary/', async (req, res, ctx) => {
@@ -105,6 +119,15 @@ const handlers = [
   rest.get(API_URL + 'projects/queries/:username/touched', async (req, res, ctx) => {
     return res(ctx.json(userTouchedProjects));
   }),
+  rest.get(API_URL + 'projects/:projectId/tasks/:taskId/', async (req, res, ctx) => {
+    return res(ctx.json(taskDetail));
+  }),
+  rest.post(
+    API_URL + 'projects/:projectId/tasks/actions/stop-mapping/:taskId/',
+    async (req, res, ctx) => {
+      return res(ctx.json(stopMapping));
+    },
+  ),
   // AUTHENTICATION
   rest.get(API_URL + 'system/authentication/login/', async (req, res, ctx) => {
     return res(ctx.json(authLogin));
@@ -152,6 +175,9 @@ const handlers = [
   }),
   rest.get(API_URL + 'users/:username/statistics/', async (req, res, ctx) => {
     return res(ctx.json(userStats));
+  }),
+  rest.get(API_URL + 'users/queries/tasks/locked/details/', async (req, res, ctx) => {
+    return res(ctx.json(userLockedTasksDetails));
   }),
   // ORGANIZATIONS
   rest.get(API_URL + 'organisations', (req, res, ctx) => {
@@ -251,6 +277,18 @@ const handlers = [
   ),
   rest.post(API_URL + 'projects/:projectId/tasks/actions/lock-for-validation/', (req, res, ctx) => {
     return res(ctx.json(lockForValidation));
+  }),
+  rest.post(
+    API_URL + 'projects/:projectId/tasks/actions/unlock-after-mapping/:taskId',
+    (req, res, ctx) => {
+      return res(ctx.json(submitMappingTask));
+    },
+  ),
+  rest.get(API_URL + 'users/queries/tasks/locked/', (req, res, ctx) => {
+    return res(ctx.json(userLockedTasks));
+  }),
+  rest.post(API_URL + 'projects/:projectId/tasks/actions/split/:taskId/', (req, res, ctx) => {
+    return res(ctx.json(splitTask));
   }),
   // EXTERNAL API
   rest.get('https://osmstats-api.hotosm.org/wildcard', (req, res, ctx) => {

--- a/frontend/src/network/tests/server-handlers.js
+++ b/frontend/src/network/tests/server-handlers.js
@@ -123,7 +123,7 @@ const handlers = [
     return res(ctx.json(userTouchedProjects));
   }),
   rest.get(API_URL + 'projects/:projectId/tasks/:taskId/', async (req, res, ctx) => {
-    return res(ctx.json(taskDetail));
+    return res(ctx.json(taskDetail(Number(req.params.taskId))));
   }),
   rest.post(
     API_URL + 'projects/:projectId/tasks/actions/stop-mapping/:taskId/',

--- a/frontend/src/network/tests/server-handlers.js
+++ b/frontend/src/network/tests/server-handlers.js
@@ -349,6 +349,9 @@ const faultyHandlers = [
   rest.post(API_URL + 'projects/:projectId/tasks/actions/lock-for-validation', (req, res, ctx) => {
     return res.networkError('Failed to connect');
   }),
+  rest.post(API_URL + 'projects/:projectId/tasks/actions/split/:taskId/', (req, res, ctx) => {
+    return res.networkError('Failed to connect');
+  }),
 ];
 
 export { handlers, faultyHandlers };

--- a/frontend/src/network/tests/server-handlers.js
+++ b/frontend/src/network/tests/server-handlers.js
@@ -12,6 +12,7 @@ import {
   activities,
   taskDetail,
   stopMapping,
+  stopValidation,
 } from './mockData/projects';
 import { featuredProjects } from './mockData/featuredProjects';
 import {
@@ -69,6 +70,7 @@ import {
   lockForValidation,
   splitTask,
   submitMappingTask,
+  submitValidationTask,
   userLockedTasks,
 } from './mockData/taskHistory';
 
@@ -126,6 +128,12 @@ const handlers = [
     API_URL + 'projects/:projectId/tasks/actions/stop-mapping/:taskId/',
     async (req, res, ctx) => {
       return res(ctx.json(stopMapping));
+    },
+  ),
+  rest.post(
+    API_URL + 'projects/:projectId/tasks/actions/stop-validation/',
+    async (req, res, ctx) => {
+      return res(ctx.json(stopValidation));
     },
   ),
   // AUTHENTICATION
@@ -282,6 +290,12 @@ const handlers = [
     API_URL + 'projects/:projectId/tasks/actions/unlock-after-mapping/:taskId',
     (req, res, ctx) => {
       return res(ctx.json(submitMappingTask));
+    },
+  ),
+  rest.post(
+    API_URL + 'projects/:projectId/tasks/actions/unlock-after-validation/',
+    (req, res, ctx) => {
+      return res(ctx.json(submitValidationTask));
     },
   ),
   rest.get(API_URL + 'users/queries/tasks/locked/', (req, res, ctx) => {

--- a/frontend/src/utils/testWithIntl.js
+++ b/frontend/src/utils/testWithIntl.js
@@ -37,7 +37,10 @@ export const IntlProviders = ({ children, props = { locale: 'en' } }: Object) =>
   <IntlProvider {...props}>{children}</IntlProvider>
 );
 
-export const createComponentWithMemoryRouter = (component, { route = '/starting/path' } = {}) => {
+export const createComponentWithMemoryRouter = (
+  component,
+  { route = '/starting/path', entryRoute = route } = {},
+) => {
   const router = createMemoryRouter(
     [
       {
@@ -46,7 +49,7 @@ export const createComponentWithMemoryRouter = (component, { route = '/starting/
       },
       {
         path: route,
-        // Render the component causing the navigate to '/'
+        // Render the component causing the navigate to route
         element: component,
       },
       {
@@ -55,10 +58,8 @@ export const createComponentWithMemoryRouter = (component, { route = '/starting/
       },
     ],
     {
-      // Set for where you want to start in the routes. Remember, KISS (Keep it simple, stupid) the routes.
-      initialEntries: [route],
-      // We don't need to explicitly set this, but it's nice to have.
-      initialIndex: 0,
+      initialEntries: ['/', entryRoute],
+      initialIndex: 1,
     },
   );
 

--- a/frontend/src/views/tests/taskAction.test.js
+++ b/frontend/src/views/tests/taskAction.test.js
@@ -4,7 +4,7 @@ import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import { QueryParamProvider } from 'use-query-params';
 import userEvent from '@testing-library/user-event';
 
-import { MapTask, TaskAction } from '../taskAction';
+import { MapTask, TaskAction, ValidateTask } from '../taskAction';
 import {
   createComponentWithMemoryRouter,
   ReduxIntlProviders,
@@ -12,7 +12,7 @@ import {
 } from '../../utils/testWithIntl';
 import { store } from '../../store';
 
-describe('Mapping Task Action Page', () => {
+describe('Submitting Mapping Status for a Task', () => {
   const setup = () => {
     const { router } = createComponentWithMemoryRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
@@ -246,4 +246,39 @@ describe('Submitting Validation Status for Tasks', () => {
     expect(router.state.location.search).toBe('?filter=MAPPED');
   });
 });
+
+describe('Tabs in Task Action Page', () => {
+  const setup = async () => {
+    const { router } = createComponentWithMemoryRouter(
+      <QueryParamProvider adapter={ReactRouter6Adapter}>
+        <ReduxIntlProviders>
+          <ValidateTask />
+        </ReduxIntlProviders>
+      </QueryParamProvider>,
+      {
+        route: '/projects/:id/validate/',
+        entryRoute: '/projects/123/validate',
+      },
+    );
+    await screen.findByRole('button', { name: /submit task/i });
+    return { router };
+  };
+
+  it('should display project instructions on the instruction tab', async () => {
+    await setup();
+    await userEvent.click(screen.getByRole('button', { name: /instructions/i }));
+    expect(screen.getByText(/Project Specific Mapping Notes:/i)).toBeInTheDocument();
+  });
+
+  it('should display task history on the history tab', async () => {
+    await setup();
+    await userEvent.click(screen.getByRole('button', { name: /history/i }));
+    expect(screen.getByRole('radio', { name: /comments/i })).toBeChecked();
+  });
+
+  it('should display resources on the resources tab', async () => {
+    await setup();
+    await userEvent.click(screen.getByRole('button', { name: /resources/i }));
+    expect(screen.getByRole('button', { name: 'Download Tasks Grid' })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/views/tests/taskAction.test.js
+++ b/frontend/src/views/tests/taskAction.test.js
@@ -1,0 +1,167 @@
+import '@testing-library/jest-dom';
+import { screen, act, waitFor } from '@testing-library/react';
+import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
+import { QueryParamProvider } from 'use-query-params';
+import userEvent from '@testing-library/user-event';
+
+import { MapTask, TaskAction } from '../taskAction';
+import {
+  createComponentWithMemoryRouter,
+  ReduxIntlProviders,
+  renderWithRouter,
+} from '../../utils/testWithIntl';
+import { store } from '../../store';
+
+describe('Mapping Task Action Page', () => {
+  const setup = () => {
+    const { router } = createComponentWithMemoryRouter(
+      <QueryParamProvider adapter={ReactRouter6Adapter}>
+        <ReduxIntlProviders>
+          <MapTask />
+        </ReduxIntlProviders>
+      </QueryParamProvider>,
+      {
+        route: '/projects/:id/map/',
+        entryRoute: '/projects/123/map/',
+      },
+    );
+
+    return { router };
+  };
+
+  it('should stop mapping and direct to tasks selection page', async () => {
+    act(() => {
+      store.dispatch({ type: 'SET_LOCALE', locale: 'en-US' });
+      store.dispatch({ type: 'SET_TOKEN', token: 'validToken' });
+      store.dispatch({
+        type: 'SET_USER_DETAILS',
+        userDetails: { id: 123 },
+      });
+    });
+
+    const { router } = setup();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {
+          name: /submit task/i,
+        }),
+      ).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByRole('button', { name: /select another task/i }));
+    await waitFor(() => expect(router.state.location.pathname).toBe('/projects/123/tasks/'));
+  });
+
+  it('should suggest the user to update status of previously locked task', async () => {
+    // Not using the setup function here to have different result for project detail
+    renderWithRouter(
+      <QueryParamProvider adapter={ReactRouter6Adapter}>
+        <ReduxIntlProviders>
+          <TaskAction project={555} action="MAPPING" />
+        </ReduxIntlProviders>
+      </QueryParamProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading')).toHaveTextContent(
+        'We found another mapping task already locked by you',
+      ),
+    );
+  });
+
+  it('should submit task mapping status (YES option) and direct to tasks selection page', async () => {
+    const { router } = setup();
+    const submitBtn = await screen.findByRole('button', {
+      name: /submit task/i,
+    });
+    expect(submitBtn).toBeDisabled();
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole('radio', {
+        name: /yes/i,
+      }),
+    );
+    expect(submitBtn).toBeEnabled();
+    await user.click(submitBtn);
+    await waitFor(() => expect(router.state.location.pathname).toBe('/projects/123/tasks/'));
+  });
+
+  it('should submit task mapping status (NO option) and direct to tasks selection page', async () => {
+    const { router } = setup();
+    const submitBtn = await screen.findByRole('button', {
+      name: /submit task/i,
+    });
+    expect(submitBtn).toBeDisabled();
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole('radio', {
+        name: /no/i,
+      }),
+    );
+    expect(submitBtn).toBeEnabled();
+    await user.click(submitBtn);
+    await waitFor(() => expect(router.state.location.pathname).toBe('/projects/123/tasks/'));
+  });
+
+  it('should submit task mapping status (bad imagery option) and direct to tasks selection page', async () => {
+    // The button requires either the user's mapping level to be advanced
+    act(() => {
+      store.dispatch({
+        type: 'SET_USER_DETAILS',
+        userDetails: { id: 123, mappingLevel: 'ADVANCED' },
+      });
+    });
+
+    const { router } = setup();
+    const submitBtn = await screen.findByRole('button', {
+      name: /submit task/i,
+    });
+    expect(submitBtn).toBeDisabled();
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole('radio', {
+        name: /the imagery is bad/i,
+      }),
+    );
+    expect(submitBtn).toBeEnabled();
+    await user.click(submitBtn);
+    await waitFor(() => expect(router.state.location.pathname).toBe('/projects/123/tasks/'));
+  });
+
+  it('should submit task mapping status (bad imagery option) and direct to tasks selection page', async () => {
+    // The button requires either the user's mapping level to be advanced
+    act(() => {
+      store.dispatch({
+        type: 'SET_USER_DETAILS',
+        userDetails: { id: 123, mappingLevel: 'ADVANCED' },
+      });
+    });
+
+    const { router } = setup();
+    const submitBtn = await screen.findByRole('button', {
+      name: /submit task/i,
+    });
+    expect(submitBtn).toBeDisabled();
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole('radio', {
+        name: /the imagery is bad/i,
+      }),
+    );
+    expect(submitBtn).toBeEnabled();
+    await user.click(submitBtn);
+    await waitFor(() => expect(router.state.location.pathname).toBe('/projects/123/tasks/'));
+  });
+
+  it('should split the task and direct to tasks selection page', async () => {
+    const { router } = setup();
+    await screen.findByRole('button', {
+      name: /submit task/i,
+    });
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /split task/i,
+      }),
+    );
+    await waitFor(() => expect(router.state.location.pathname).toBe('/projects/123/tasks/'));
+  });
+});

--- a/frontend/src/views/tests/taskSelection.test.js
+++ b/frontend/src/views/tests/taskSelection.test.js
@@ -147,9 +147,10 @@ describe('Task Selection Page', () => {
       });
     });
     setup();
+    const user = userEvent.setup();
     await screen.findAllByText(/last updated by/i);
     // Selecting a single task that is available for validation
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /Task #5 Aadesh Baral/i,
       }),
@@ -160,7 +161,7 @@ describe('Task Selection Page', () => {
       }),
     ).toBeInTheDocument();
     // Selecting a single task that is available for validation
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /Task #6 Patrik_B/i,
       }),
@@ -171,7 +172,7 @@ describe('Task Selection Page', () => {
       }),
     ).toBeInTheDocument();
     // Unselecting selected tasks one by one
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /Task #5 Aadesh Baral/i,
       }),
@@ -181,7 +182,7 @@ describe('Task Selection Page', () => {
         name: /validate selected task/i,
       }),
     ).toBeInTheDocument();
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /Task #6 Patrik_B/i,
       }),


### PR DESCRIPTION
This PR updates test cases for the task action page.

### Things to do to consider this PR done:
- Handle the `<Portal>` wrapper while running tests to render its children in place. Without this being handled, tests wrapped with the `TaskMapAction` component would fail, as the added tests didn't account for the wrapper.

**Challenges Encountered in Testing Certain Functionalities**
- Testing functionality that uses timeouts (setInterval and createInterval).
- Unable to find a workaround to generate map contexts for tests, so conditional functionalities requiring an editors ID or RAPID couldn't be tested.
