### PR TITLE
Use previously used color for mapped progress bar

### DIFF
--- a/frontend/src/components/progressBar.js
+++ b/frontend/src/components/progressBar.js
@@ -18,7 +18,7 @@ export const ProgressBar = ({
     <div className={`cf db ${className || ''}`}>
       <div className="relative" ref={hoverRef}>
         <div
-          className={`absolute bg-mask br-pill ${small ? heightClassname : 'h-pill'} hide-child`}
+          className={`absolute bg-blue-grey br-pill ${small ? heightClassname : 'h-pill'} hide-child`}
           style={{ width: `${firstBarValue > 100 ? 100 : firstBarValue}%` }}
           role="progressbar"
           aria-valuenow={firstBarValue}

--- a/frontend/src/components/projectCard/tests/projectProgressBar.test.js
+++ b/frontend/src/components/projectCard/tests/projectProgressBar.test.js
@@ -10,8 +10,8 @@ describe('test if projectProgressBar', () => {
   const testInstance = element.root;
   it('mapped bar has the correct width', () => {
     expect(
-      testInstance.findByProps({ className: 'absolute bg-mask br-pill hhalf hide-child' }).props
-        .style,
+      testInstance.findByProps({ className: 'absolute bg-blue-grey br-pill hhalf hide-child' })
+        .props.style,
     ).toEqual({ width: '40%' });
   });
   it('validated bar has the correct width', () => {
@@ -49,8 +49,8 @@ describe('test if projectProgressBar with value higher than 100%', () => {
   const testInstance = element.root;
   it('to mapped returns 100% width', () => {
     expect(
-      testInstance.findByProps({ className: 'absolute bg-mask br-pill hhalf hide-child' }).props
-        .style,
+      testInstance.findByProps({ className: 'absolute bg-blue-grey br-pill hhalf hide-child' })
+        .props.style,
     ).toEqual({ width: '100%' });
   });
   it('to validated returns 100% width', () => {


### PR DESCRIPTION
The color for the mapped progress bar was revised from the Figma design in #5516. Following the [remarks on Slack](https://hotosm.slack.com/archives/C319P09PB/p1680076639458289), this PR reverses the change to use the previously used color `b--blue-grey` instead of `bg-mask`.

![bg-mask](https://user-images.githubusercontent.com/51614993/228508006-7f9ae698-b636-415e-942f-85fdff26c7bb.png) ![bg-blue-grey](https://user-images.githubusercontent.com/51614993/228508032-6cb44d7c-8e47-4828-ad89-648c7dc97a58.png)
