### PR TITLE
Use createBrowserRouter from React Router

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,7 +54,7 @@
     "react-meta-elements": "^1.0.0",
     "react-placeholder": "^4.1.0",
     "react-redux": "^7.2.4",
-    "react-router-dom": "^6.8.1",
+    "react-router-dom": "^6.10.0",
     "react-scripts": "^4.0.3",
     "react-select": "^5.7.0",
     "react-tooltip": "^4.2.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,7 +68,7 @@
     "slug": "^8.2.2",
     "tachyons": "^4.12.0",
     "tributejs": "^5.1.3",
-    "use-query-params": "^2.1.2",
+    "use-query-params": "^2.2.1",
     "webfontloader": "^1.6.28",
     "workbox-core": "^6.1.5",
     "workbox-expiration": "^6.1.5",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,79 +1,21 @@
 import React, { Suspense, useEffect } from 'react';
-import { Routes, Route, useNavigate } from 'react-router-dom';
-import { QueryParamProvider } from 'use-query-params';
-import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
-
+import { RouterProvider } from 'react-router-dom';
 import ReactPlaceholder from 'react-placeholder';
 import { useMeta } from 'react-meta-elements';
 import { useSelector } from 'react-redux';
 import * as Sentry from '@sentry/react';
 
+import './assets/styles/index.scss';
+
 import { getUserDetails } from './store/actions/auth';
 import { store } from './store';
-import './assets/styles/index.scss';
 import { ORG_NAME, MATOMO_ID } from './config';
-import { Header } from './components/header';
-import { Footer } from './components/footer';
 import { Preloader } from './components/preloader';
-import { Home } from './views/home';
 import { FallbackComponent } from './views/fallback';
-import { AboutPage } from './views/about';
-import { LearnPage } from './views/learn';
-import { QuickstartPage } from './views/quickstart';
-import { UserDetail } from './views/userDetail';
-import {
-  UserProjectsPage,
-  ManageProjectsPage,
-  CreateProject,
-  ProjectsPage,
-  ProjectsPageIndex,
-  MoreFilters,
-  ProjectDetailPage,
-} from './views/project';
-import { Authorized } from './views/authorized';
-import { Login } from './views/login';
-import { Welcome } from './views/welcome';
-import { Settings } from './views/settings';
-import { ManagementPageIndex, ManagementSection } from './views/management';
-import {
-  ListOrganisations,
-  CreateOrganisation,
-  EditOrganisation,
-} from './views/organisationManagement';
-import { OrganisationDetail } from './views/organisationDetail';
-import { OrganisationStats } from './views/organisationStats';
-import { MyTeams, ManageTeams, CreateTeam, EditTeam, TeamDetail } from './views/teams';
-import { ListCampaigns, CreateCampaign, EditCampaign } from './views/campaigns';
-import { ListInterests, CreateInterest, EditInterest } from './views/interests';
-import { ListLicenses, CreateLicense, EditLicense } from './views/licenses';
-import { Stats } from './views/stats';
-import { UsersList } from './views/users';
-import { NotFound } from './views/notFound';
-import { SelectTask } from './views/taskSelection';
-import { MapTask, ValidateTask } from './views/taskAction';
-import { EmailVerification } from './views/verifyEmail';
-import { ProjectStats } from './views/projectStats';
-import { ContactPage } from './views/contact';
-import { SwaggerView } from './views/swagger';
-import { ContributionsPage, ContributionsPageIndex, UserStats } from './views/contributions';
-import { NotificationsPage } from './views/notifications';
 import { Banner, ArchivalNotificationBanner } from './components/banner/index';
-import { TopBanner } from './components/banner/topBanner';
+import { router } from './routes';
 
-const ProjectEdit = React.lazy(() =>
-  import('./views/projectEdit' /* webpackChunkName: "projectEdit" */),
-);
-
-// Use this to Redirect to intended page
-function Redirect({ to }) {
-  let navigate = useNavigate();
-  useEffect(() => {
-    navigate(to);
-  });
-  return null;
-}
-
-let App = (props) => {
+const App = () => {
   useMeta({ property: 'og:url', content: process.env.REACT_APP_BASE_URL });
   useMeta({ name: 'author', content: ORG_NAME });
   const isLoading = useSelector((state) => state.loader.isLoading);
@@ -89,78 +31,14 @@ let App = (props) => {
       {isLoading ? (
         <Preloader />
       ) : (
-        <div className="w-100 base-font bg-white" lang={props.locale}>
-          <TopBanner />
-          <Header />
+        <div className="w-100 base-font bg-white" lang={locale}>
           <main className="cf w-100 base-font">
             <Suspense
               fallback={<ReactPlaceholder showLoadingAnimation={true} rows={30} delay={300} />}
             >
-              <QueryParamProvider adapter={ReactRouter6Adapter}>
-                <Routes>
-                  <Route path="/" element={<Home />} />
-                  <Route path="explore" element={<ProjectsPage />}>
-                    <Route index element={<ProjectsPageIndex />} />
-                    <Route path="filters/*" element={<MoreFilters />} />
-                  </Route>
-                  <Route path="projects/:id" element={<ProjectDetailPage />} />
-                  <Route path="projects/:id/tasks" element={<SelectTask />} />
-                  <Route path="projects/:id/map" element={<MapTask />} />
-                  <Route path="projects/:id/validate" element={<ValidateTask />} />
-                  <Route path="projects/:id/stats" element={<ProjectStats />} />
-                  <Route path="organisations/:id/stats/" element={<OrganisationStats />} />
-                  <Route path="organisations/:slug/" element={<OrganisationDetail />} />
-                  <Route path="learn" element={<Redirect to="map" />} />
-                  <Route path="learn/:type" element={<LearnPage />} />
-                  <Route path="learn/quickstart" element={<QuickstartPage />} />
-                  <Route path="about" element={<AboutPage />} />
-                  <Route path="contact/" element={<ContactPage />} />
-                  <Route path="contributions" element={<ContributionsPageIndex />}>
-                    <Route index element={<UserStats />} />
-                    <Route path="tasks/*" element={<ContributionsPage />} />
-                    <Route path="projects/*" element={<UserProjectsPage />} />
-                    <Route path="teams/*" element={<MyTeams />} />
-                  </Route>
-                  {/* <Route path="/contributions" element={<UserStats />} /> */}
-                  <Route path="users/:username" element={<UserDetail />} />
-                  <Route path="inbox" element={<NotificationsPage />} />
-                  <Route path="authorized" element={<Authorized />} />
-                  <Route path="login" element={<Login />} />
-                  <Route path="welcome" element={<Welcome />} />
-                  <Route path="settings" element={<Settings />} />
-                  <Route path="verify-email" element={<EmailVerification />} />
-                  <Route path="manage" element={<ManagementSection />}>
-                    <Route index element={<ManagementPageIndex />} />
-                    <Route path="stats/" element={<Stats />} />
-                    <Route path="organisations/" element={<ListOrganisations />} />
-                    <Route path="organisations/new/" element={<CreateOrganisation />} />
-                    <Route path="organisations/:id/" element={<EditOrganisation />} />
-                    <Route path="teams/" element={<ManageTeams />} />
-                    <Route path="users/" element={<UsersList />} />
-                    <Route path="teams/new" element={<CreateTeam />} />
-                    <Route path="teams/:id" element={<EditTeam />} />
-                    <Route path="campaigns/" element={<ListCampaigns />} />
-                    <Route path="campaigns/new" element={<CreateCampaign />} />
-                    <Route path="campaigns/:id" element={<EditCampaign />} />
-                    <Route path="projects/new" element={<CreateProject />} />
-                    <Route path="projects/:id" element={<ProjectEdit />} />
-                    <Route path="projects/*" element={<ManageProjectsPage />} />
-                    <Route path="categories/" element={<ListInterests />} />
-                    <Route path="categories/:id" element={<EditInterest />} />
-                    <Route path="categories/new" element={<CreateInterest />} />
-                    <Route path="licenses/new" element={<CreateLicense />} />
-                    <Route path="licenses/" element={<ListLicenses />} />
-                    <Route path="licenses/:id" element={<EditLicense />} />
-                  </Route>
-                  <Route path="teams/:id/membership" element={<TeamDetail />} />
-                  <Route path="/api-docs/" element={<SwaggerView />} />
-                  <Route path="project/:id" element={<Redirect to="/projects/:id" />} />
-                  <Route path="*" element={<NotFound />} />
-                </Routes>
-              </QueryParamProvider>
+              <RouterProvider router={router} />
             </Suspense>
           </main>
-          <Footer />
           <ArchivalNotificationBanner />
           {MATOMO_ID && <Banner />}
         </div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,7 +5,7 @@ import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
 import ReactPlaceholder from 'react-placeholder';
 import { useMeta } from 'react-meta-elements';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import * as Sentry from '@sentry/react';
 
 import { getUserDetails } from './store/actions/auth';
@@ -76,7 +76,8 @@ function Redirect({ to }) {
 let App = (props) => {
   useMeta({ property: 'og:url', content: process.env.REACT_APP_BASE_URL });
   useMeta({ name: 'author', content: ORG_NAME });
-  const { isLoading } = props;
+  const isLoading = useSelector((state) => state.loader.isLoading);
+  const locale = useSelector((state) => state.preferences.locale);
 
   useEffect(() => {
     // fetch user details endpoint when the user is returning to a logged in session
@@ -167,12 +168,5 @@ let App = (props) => {
     </Sentry.ErrorBoundary>
   );
 };
-
-const mapStateToProps = (state) => ({
-  isLoading: state.loader.isLoading,
-  locale: state.preferences.locale,
-});
-
-App = connect(mapStateToProps)(App);
 
 export default App;

--- a/frontend/src/components/footer/index.js
+++ b/frontend/src/components/footer/index.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { useSelector } from 'react-redux';
-import { Link, useMatch as matchPath } from 'react-router-dom';
+import { Link, matchRoutes, useLocation } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import {
   TwitterIcon,
@@ -31,6 +31,7 @@ const socialNetworks = [
 ];
 
 export function Footer() {
+  const location = useLocation();
   const userDetails = useSelector((state) => state.auth.userDetails);
 
   const footerDisabledPaths = [
@@ -46,15 +47,15 @@ export function Footer() {
     'teams/:id/membership',
     '/api-docs/',
   ];
-  let isFooterEnabled = true;
-  footerDisabledPaths.forEach((path) => {
-    const match = matchPath(path);
-    if (match !== null) {
-      isFooterEnabled = false;
-    }
-  });
 
-  if (!isFooterEnabled) {
+  const matchedRoute = matchRoutes(
+    footerDisabledPaths.map((path) => ({
+      path,
+    })),
+    location,
+  );
+
+  if (matchedRoute) {
     return null;
   } else {
     return (

--- a/frontend/src/components/userDetail/headerProfile.js
+++ b/frontend/src/components/userDetail/headerProfile.js
@@ -117,7 +117,7 @@ export const MyContributionsNav = ({ username, authUser }) => {
   const items = [
     { url: `/contributions`, label: <FormattedMessage {...messages.myStats} /> },
     {
-      url: '/contributions/projects?mappedByMe=1&action=any',
+      url: '/contributions/projects/?mappedByMe=1&action=any',
       label: <FormattedMessage {...messages.myProjects} />,
     },
     { url: '/contributions/tasks', label: <FormattedMessage {...messages.myTasks} /> },

--- a/frontend/src/components/userDetail/tests/headerProfile.test.js
+++ b/frontend/src/components/userDetail/tests/headerProfile.test.js
@@ -99,7 +99,7 @@ test('section menu should render display menus for contributions tab', () => {
     screen.getByRole('link', {
       name: 'My projects',
     }),
-  ).toHaveAttribute('href', '/contributions/projects?mappedByMe=1&action=any');
+  ).toHaveAttribute('href', '/contributions/projects/?mappedByMe=1&action=any');
   expect(
     screen.getByRole('link', {
       name: 'My tasks',

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,7 +4,6 @@ import { PersistGate } from 'redux-persist/integration/react';
 import { Provider } from 'react-redux';
 import WebFont from 'webfontloader';
 import * as Sentry from '@sentry/react';
-import { BrowserRouter } from 'react-router-dom';
 import { BrowserTracing } from '@sentry/tracing';
 
 import App from './App';
@@ -32,9 +31,7 @@ ReactDOM.render(
   <Provider store={store}>
     <PersistGate loading={null} persistor={persistor}>
       <ConnectedIntl>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
+        <App />
       </ConnectedIntl>
     </PersistGate>
   </Provider>,

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -1,0 +1,124 @@
+import { useEffect, lazy } from 'react';
+import {
+  createBrowserRouter,
+  createRoutesFromElements,
+  Route,
+  useNavigate,
+} from 'react-router-dom';
+
+import { Root } from './views/root';
+import { Home } from './views/home';
+import { AboutPage } from './views/about';
+import { LearnPage } from './views/learn';
+import { QuickstartPage } from './views/quickstart';
+import { UserDetail } from './views/userDetail';
+import {
+  UserProjectsPage,
+  ManageProjectsPage,
+  CreateProject,
+  ProjectsPage,
+  ProjectsPageIndex,
+  MoreFilters,
+  ProjectDetailPage,
+} from './views/project';
+import { Authorized } from './views/authorized';
+import { Login } from './views/login';
+import { Welcome } from './views/welcome';
+import { Settings } from './views/settings';
+import { ManagementPageIndex, ManagementSection } from './views/management';
+import {
+  ListOrganisations,
+  CreateOrganisation,
+  EditOrganisation,
+} from './views/organisationManagement';
+import { OrganisationDetail } from './views/organisationDetail';
+import { OrganisationStats } from './views/organisationStats';
+import { MyTeams, ManageTeams, CreateTeam, EditTeam, TeamDetail } from './views/teams';
+import { ListCampaigns, CreateCampaign, EditCampaign } from './views/campaigns';
+import { ListInterests, CreateInterest, EditInterest } from './views/interests';
+import { ListLicenses, CreateLicense, EditLicense } from './views/licenses';
+import { Stats } from './views/stats';
+import { UsersList } from './views/users';
+import { NotFound } from './views/notFound';
+import { SelectTask } from './views/taskSelection';
+import { MapTask, ValidateTask } from './views/taskAction';
+import { EmailVerification } from './views/verifyEmail';
+import { ProjectStats } from './views/projectStats';
+import { ContactPage } from './views/contact';
+import { SwaggerView } from './views/swagger';
+import { ContributionsPage, ContributionsPageIndex, UserStats } from './views/contributions';
+import { NotificationsPage } from './views/notifications';
+const ProjectEdit = lazy(() => import('./views/projectEdit' /* webpackChunkName: "projectEdit" */));
+
+export const router = createBrowserRouter(
+  createRoutesFromElements(
+    <Route path="/" element={<Root />}>
+      <Route index element={<Home />} />
+      <Route path="explore" element={<ProjectsPage />}>
+        <Route index element={<ProjectsPageIndex />} />
+        <Route path="filters/*" element={<MoreFilters />} />
+      </Route>
+      <Route path="projects/:id" element={<ProjectDetailPage />} />
+      <Route path="projects/:id/tasks" element={<SelectTask />} />
+      <Route path="projects/:id/map" element={<MapTask />} />
+      <Route path="projects/:id/validate" element={<ValidateTask />} />
+      <Route path="projects/:id/stats" element={<ProjectStats />} />
+      <Route path="organisations/:id/stats/" element={<OrganisationStats />} />
+      <Route path="organisations/:slug/" element={<OrganisationDetail />} />
+      <Route path="learn" element={<Redirect to="map" />} />
+      <Route path="learn/:type" element={<LearnPage />} />
+      <Route path="learn/quickstart" element={<QuickstartPage />} />
+      <Route path="about" element={<AboutPage />} />
+      <Route path="contact/" element={<ContactPage />} />
+      <Route path="contributions" element={<ContributionsPageIndex />}>
+        <Route index element={<UserStats />} />
+        <Route path="tasks/*" element={<ContributionsPage />} />
+        <Route path="projects/*" element={<UserProjectsPage />} />
+        <Route path="teams/*" element={<MyTeams />} />
+      </Route>
+      <Route path="users/:username" element={<UserDetail />} />
+      <Route path="inbox" element={<NotificationsPage />} />
+      <Route path="authorized" element={<Authorized />} />
+      <Route path="login" element={<Login />} />
+      <Route path="welcome" element={<Welcome />} />
+      <Route path="settings" element={<Settings />} />
+      <Route path="verify-email" element={<EmailVerification />} />
+      <Route path="manage" element={<ManagementSection />}>
+        <Route index element={<ManagementPageIndex />} />
+        <Route path="stats/" element={<Stats />} />
+        <Route path="organisations/" element={<ListOrganisations />} />
+        <Route path="organisations/new/" element={<CreateOrganisation />} />
+        <Route path="organisations/:id/" element={<EditOrganisation />} />
+        <Route path="teams/" element={<ManageTeams />} />
+        <Route path="users/" element={<UsersList />} />
+        <Route path="teams/new" element={<CreateTeam />} />
+        <Route path="teams/:id" element={<EditTeam />} />
+        <Route path="campaigns/" element={<ListCampaigns />} />
+        <Route path="campaigns/new" element={<CreateCampaign />} />
+        <Route path="campaigns/:id" element={<EditCampaign />} />
+        <Route path="projects/new" element={<CreateProject />} />
+        <Route path="projects/:id" element={<ProjectEdit />} />
+        <Route path="projects/*" element={<ManageProjectsPage />} />
+        <Route path="categories/" element={<ListInterests />} />
+        <Route path="categories/:id" element={<EditInterest />} />
+        <Route path="categories/new" element={<CreateInterest />} />
+        <Route path="licenses/new" element={<CreateLicense />} />
+        <Route path="licenses/" element={<ListLicenses />} />
+        <Route path="licenses/:id" element={<EditLicense />} />
+      </Route>
+      <Route path="teams/:id/membership" element={<TeamDetail />} />
+      <Route path="/api-docs/" element={<SwaggerView />} />
+      <Route path="project/:id" element={<Redirect to="/projects/:id" />} />
+      <Route path="*" element={<NotFound />} />
+    </Route>,
+  ),
+);
+
+// Use this to Redirect to intended page
+function Redirect({ to }) {
+  let navigate = useNavigate();
+  useEffect(() => {
+    navigate(to);
+  });
+  return null;
+}

--- a/frontend/src/views/root.js
+++ b/frontend/src/views/root.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import { QueryParamProvider } from 'use-query-params';
+import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
+
+import { TopBanner } from '../components/banner/topBanner';
+import { Header } from '../components/header';
+import { Footer } from '../components/footer';
+
+// Including components that use React Router hooks here
+// Components common to all routes can be included in <App>
+export function Root() {
+  return (
+    <>
+      <TopBanner />
+      <Header />
+      <QueryParamProvider adapter={ReactRouter6Adapter}>
+        <Outlet />
+      </QueryParamProvider>
+      <Footer />
+    </>
+  );
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3032,10 +3032,10 @@
   resolved "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.2.0.tgz"
   integrity sha512-lVK/svL2HuQdp7jgvlrLkFsUx50Az9chAhxpiPwBqcS83I2pVWvXp98FOcSCCJCV++l115QmzHhFd+ycw1zLBg==
 
-"@remix-run/router@1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.3.2.tgz#58cd2bd25df2acc16c628e1b6f6150ea6c7455bc"
-  integrity sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==
+"@remix-run/router@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.5.0.tgz#57618e57942a5f0131374a9fdb0167e25a117fdc"
+  integrity sha512-bkUDCp8o1MvFO+qxkODcbhSqRa6P2GXgrGZVpt0dCXNW2HCSCqYI0ZoAqEOSAjRWmmlKcYgFvN4B4S+zo/f8kg==
 
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"
@@ -13541,20 +13541,20 @@ react-refresh@^0.8.3:
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react-router-dom@^6.8.1:
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.8.1.tgz#7e136b67d9866f55999e9a8482c7008e3c575ac9"
-  integrity sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==
+react-router-dom@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.10.0.tgz#090ddc5c84dc41b583ce08468c4007c84245f61f"
+  integrity sha512-E5dfxRPuXKJqzwSe/qGcqdwa18QiWC6f3H3cWXM24qj4N0/beCIf/CWTipop2xm7mR0RCS99NnaqPNjHtrAzCg==
   dependencies:
-    "@remix-run/router" "1.3.2"
-    react-router "6.8.1"
+    "@remix-run/router" "1.5.0"
+    react-router "6.10.0"
 
-react-router@6.8.1:
-  version "6.8.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.8.1.tgz#e362caf93958a747c649be1b47cd505cf28ca63e"
-  integrity sha512-Jgi8BzAJQ8MkPt8ipXnR73rnD7EmZ0HFFb7jdQU24TynGW1Ooqin2KVDN9voSC+7xhqbbCd2cjGUepb6RObnyg==
+react-router@6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.10.0.tgz#230f824fde9dd0270781b5cb497912de32c0a971"
+  integrity sha512-Nrg0BWpQqrC3ZFFkyewrflCud9dio9ME3ojHCF/WLsprJVzkq3q3UeEhMCAW1dobjeGbWgjNn/PVF6m46ANxXQ==
   dependencies:
-    "@remix-run/router" "1.3.2"
+    "@remix-run/router" "1.5.0"
 
 react-scripts@^4.0.3:
   version "4.0.3"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16048,10 +16048,10 @@ use-isomorphic-layout-effect@^1.1.2:
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
   integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
 
-use-query-params@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/use-query-params/-/use-query-params-2.1.2.tgz#0bd100a0839e5195106cfb291b43d2159618ca9d"
-  integrity sha512-evg64srKaILvKyRQ1zpXvekTC7rktAT7OAekU7x6naHrOMqLHtq0MHR/PtKIQAP4d7HrkYNVOS8exHhiWy7m3A==
+use-query-params@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/use-query-params/-/use-query-params-2.2.1.tgz#c558ab70706f319112fbccabf6867b9f904e947d"
+  integrity sha512-i6alcyLB8w9i3ZK3caNftdb+UnbfBRNPDnc89CNQWkGRmDrm/gfydHvMBfVsQJRq3NoHOM2dt/ceBWG2397v1Q==
   dependencies:
     serialize-query-params "^2.0.2"
 


### PR DESCRIPTION
Closes #5672. Does the following:

- Bump use-query-params from 2.1.2 to 2.2.1
- Bump react-router-dom from 6.8.1 to 6.10.0
- Replace mapStateToProps with the useSelector hook
- Replace BrowserRouter with the newly introduced createBrowserRouter
