### PR TITLE
Only upload test results to circleci test storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
               --with-coverage --cover-erase --cover-package=./backend
             coverage xml -o ${CIRCLE_WORKING_DIRECTORY}/tests/backend/results/coverage.xml
       - store_test_results:
-          path: tests/backend/results
+          path: tests/backend/results/unitresults.xml
       - store_artifacts:
           path: tests/backend/results
       - save_cache:


### PR DESCRIPTION
Fixes #5673
Both the test storage and the coverage will be uploaded as artifacts, but only test results will be saved for the tests tab.