### PR TITLE
Adjust CircleCI badge style for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tasking Manager
 
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/hotosm/tasking-manager/tree/develop.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/hotosm/tasking-manager/tree/develop)
+[![hotosm](https://dl.circleci.com/status-badge/img/gh/hotosm/tasking-manager/tree/develop.svg?style=shield)](https://dl.circleci.com/status-badge/redirect/gh/hotosm/tasking-manager/tree/develop)
 [![TM Backend on Quay](https://quay.io/repository/hotosm/tasking-manager/status "Tasking Manager Backend Build")](https://quay.io/repository/hotosm/tasking-manager)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=hotosm_tasking-manager&metric=alert_status)](https://sonarcloud.io/dashboard?id=hotosm_tasking-manager)
 


### PR DESCRIPTION
To make the Circle-CI badge style consistent with the rest of the buttons, and to make it clear to the readers that the button represents CI status in Circle-CI, the badge style has been updated to shield.io style.