### PR TITLE
Fix OpsGenie API Key ENVVAR interpolation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,4 +335,4 @@ workflows:
             - tasking-manager-tm4-production
 notify:
   webhooks:
-    - url: https://api.opsgenie.com/v1/json/circleci?apiKey=$OPSGENIE_API
+    - url: https://api.opsgenie.com/v1/json/circleci?apiKey=${OPSGENIE_API}


### PR DESCRIPTION
Addresses issue #5492

Currently, OpsGenie integration does not work. The issue is being addressed separately. But there is another issue where Circle-CI does not expand the variable `$OPSGENIE_API` into its value and instead simply converts the exact string into URL safe ASCII instead of evaluating it as an ENVVAR.

This change fixes it by adding curly braces per Circle-CI documentation.