### PR TITLE
Fix OpsGenie HTTP 422 error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,6 +331,3 @@ workflows:
           context:
             - org-global
             - tasking-manager-tm4-production
-notify:
-  webhooks:
-    - url: https://api.opsgenie.com/v1/json/circleci?apiKey=${OPSGENIE_API}


### PR DESCRIPTION
Removed OpsGenie notification block since the curly braces added in an earlier commit did not fix the problem. We can bring back the notification once Opsgenie ORB is able to work as expected.