### PR TITLE
Improve security parameters for AWS CloudFront

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -721,6 +721,8 @@ const Resources = {
           cf.ref('TaskingManagerURL')
         ],
         Enabled: true,
+        HttpVersion: "http2",
+        IPV6Enabled: true,
         Origins: [{
           Id: cf.join('-', [cf.stackName, 'react-app']),
           DomainName: cf.getAtt('TaskingManagerReactBucket', 'DomainName'),
@@ -755,7 +757,7 @@ const Resources = {
         },
         ViewerCertificate: {
           AcmCertificateArn: cf.arn('acm', cf.ref('SSLCertificateIdentifier')),
-          MinimumProtocolVersion: 'TLSv1.2_2018',
+          MinimumProtocolVersion: 'TLSv1.2_2021',
           SslSupportMethod: 'sni-only'
         }
       }


### PR DESCRIPTION
AWS Cloudfront properties have been updated to:

1. Enable http2 protocol in the viewer facing side. This might improve performance for users.
2. Improve SSL Cipher suite to the latest version. This might improve performance and security for users.
3. Enable IPv6 for the CDN distribution. This is already the default behaviour in CloudFront. I have just made it explicit.