### PR TITLE
Add IPv6 route to Frontend CloudFront CDN

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -764,16 +764,29 @@ const Resources = {
     }
   },
   TaskingManagerRoute53: {
-    Type: 'AWS::Route53::RecordSet',
+    Type: 'AWS::Route53::RecordSetGroup',
     Condition: 'IsHOTOSMUrl',
     Properties: {
-      Name: cf.ref('TaskingManagerURL'),
-      Type: 'A',
-      AliasTarget: {
-        DNSName: cf.getAtt('TaskingManagerReactCloudfront', 'DomainName'),
-        HostedZoneId: 'Z2FDTNDATAQYW2'
-      },
-      HostedZoneId: 'Z2O929GW6VWG99',
+      Comment: "DNS records pointing to CDN Frontend",
+      HostedZoneId: 'Z2O929GW6VWG99', // This is hotosm.org zone ID
+      RecordSets: [
+        {
+          Name: cf.ref('TaskingManagerURL'),
+          Type: 'A',
+          AliasTarget: {
+            DNSName: cf.getAtt('TaskingManagerReactCloudfront', 'DomainName'),
+            HostedZoneId: 'Z2FDTNDATAQYW2' // This is defined in the AWS Documentation
+          }
+        },
+        {
+          Name: cf.ref('TaskingManagerURL'),
+          Type: 'AAAA',
+          AliasTarget: {
+            DNSName: cf.getAtt('TaskingManagerReactCloudfront', 'DomainName'),
+            HostedZoneId: 'Z2FDTNDATAQYW2' // This is defined in the AWS Documentation
+          },
+        }
+      ]
     }
   }
 };


### PR DESCRIPTION
After enabling IPv6 support on the CDN itself, we need to create DNS AAAA records to be able to reach the frontend CDN using IPv6. This change creates the resource records in AWS Route53 - the DNS service for hotosm.org

Replaces a RecordSet resource with a RecordSetGroup resource