### PR TITLE
Upgrade TLS CipherSuite for the backend API

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -631,7 +631,7 @@ const Resources = {
       LoadBalancerArn: cf.ref('TaskingManagerLoadBalancer'),
       Port: 443,
       Protocol: 'HTTPS',
-      SslPolicy: 'ELBSecurityPolicy-FS-1-2-2019-08'
+      SslPolicy: 'ELBSecurityPolicy-TLS13-1-2-2021-06'
     }
   },
   TaskingManagerLoadBalancerHTTPListener: {


### PR DESCRIPTION
Upgrade TLS CipherSuite to the latest recommended option on AWS.