### PR TITLE
Add IPv6 route to Frontend CloudFront CDN

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -767,13 +767,40 @@ const Resources = {
     Type: 'AWS::Route53::RecordSet',
     Condition: 'IsHOTOSMUrl',
     Properties: {
-      Name: cf.ref('TaskingManagerURL'),
+      Name: 't0.hotosm.org',
       Type: 'A',
       AliasTarget: {
         DNSName: cf.getAtt('TaskingManagerReactCloudfront', 'DomainName'),
         HostedZoneId: 'Z2FDTNDATAQYW2'
       },
       HostedZoneId: 'Z2O929GW6VWG99',
+    }
+  }
+
+  TaskingManagerDNSEntries: {
+    Type: "AWS::Route53::RecordSetGroup",
+    Condition: "IsHOTOSMUrl",
+    Properties: {
+      Comment: "DNS records pointing to CDN Frontend",
+      HostedZoneId: 'Z2O929GW6VWG99', // This is hotosm.org hosted Zone ID on Route53
+      RecordSets: [
+        {
+          Name: cf.ref('TaskingManagerURL'),
+          Type: 'A',
+          AliasTarget: {
+            DNSName: cf.getAtt('TaskingManagerReactCloudfront', 'DomainName'),
+            HostedZoneId: 'Z2FDTNDATAQYW2' // TODO: This is defined in the AWS Documentation
+          }
+        },
+        {
+          Name: cf.ref('TaskingManagerURL'),
+          Type: 'AAAA',
+          AliasTarget: {
+            DNSName: cf.getAtt('TaskingManagerReactCloudfront', 'DomainName'),
+            HostedZoneId: 'Z2FDTNDATAQYW2' // TODO: This is defined in the AWS Documentation
+          },
+        }
+      ]
     }
   }
 };


### PR DESCRIPTION
After enabling IPv6 support on the CDN itself, we need to create DNS AAAA records to be able to reach the frontend CDN using IPv6. This change creates the resource records in AWS Route53 - the DNS service for hotosm.org for both IPv4 and IPv6 routing.

Adds a RecordSetGroup resource along with the RecordSet resource