### PR TITLE
Allow public access to S3 bucket

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -698,9 +698,7 @@ const Resources = {
           {
             Action: [ 's3:GetObject'],
             Effect: 'Allow',
-            Principal: {
-              "Service": [ "cloudfront.amazonaws.com" ]
-            },
+            Principal: "*",
             Resource: [
               cf.join("/",
                 [


### PR DESCRIPTION
Reverted all changes made to S3 bucket and restoring access to public for the S3 bucket.

TODO: Restrict access by header set in CloudFront.