### PR TITLE
Fix issue on teams all api for non admin users

### DIFF
--- a/backend/api/teams/resources.py
+++ b/backend/api/teams/resources.py
@@ -414,7 +414,7 @@ class TeamsAllAPI(Resource):
             teams = TeamService.get_all_teams(search_dto)
             return teams.to_primitive(), 200
         except Exception as e:
-            error_msg = f"User GET - unhandled error: {str(e)}"
+            error_msg = f"Teams GET - unhandled error: {str(e)}"
             current_app.logger.critical(error_msg)
             return {"Error": error_msg, "SubCode": "InternalServerError"}, 500
 

--- a/backend/services/team_service.py
+++ b/backend/services/team_service.py
@@ -277,12 +277,13 @@ class TeamService:
         if orgs_query:
             query = query.union(orgs_query)
 
-        # Only show public teams or teams that the user is a member of
+        # Only show public teams and teams that the user is a member of
         if not is_admin:
             query = query.filter(
                 or_(
                     Team.visibility == TeamVisibility.PUBLIC.value,
-                    Team.id.in_([team.id for team in user.teams]),
+                    # Since user.teams returns TeamMembers, we need to get the team_id
+                    Team.id.in_([team.team_id for team in user.teams]),
                 )
             )
         teams_list_dto = TeamsListDTO()


### PR DESCRIPTION
TeamsAllAPI was not working because user.teams returns the TeamMembers table and there is no column named id. During the loop on user.teams, id is replaced by team_id.