### PR TITLE
Add notification API tests

### DIFF
--- a/backend/api/notifications/resources.py
+++ b/backend/api/notifications/resources.py
@@ -129,7 +129,11 @@ class NotificationsAllAPI(Resource):
             - in: query
               name: messageType
               type: string
-              description: Optional message-type filter; leave blank to retrieve all
+              description: Optional message-type filter; leave blank to retrieve all\n
+                Accepted values are 1 (System), 2 (Broadcast), 3 (Mention), 4 (Validation),
+                5 (Invalidation), 6 (Request team), \n
+                7 (Invitation), 8 (Task comment), 9 (Project chat),
+                10 (Project Activity), and 11 (Team broadcast)
             - in: query
               name: from
               description: Optional from username filter

--- a/backend/services/notification_service.py
+++ b/backend/services/notification_service.py
@@ -13,6 +13,7 @@ class NotificationService:
             raise NotFound()
 
         notifications.update()
+        return notifications.unread_count
 
     @staticmethod
     def get_unread_message_count(user_id: int):

--- a/tests/backend/helpers/test_helpers.py
+++ b/tests/backend/helpers/test_helpers.py
@@ -17,6 +17,8 @@ from backend.models.dtos.project_dto import (
 from backend.models.postgis.project import Project, ProjectTeams
 from backend.models.postgis.campaign import Campaign
 from backend.models.postgis.statuses import MappingLevel, TaskStatus
+from backend.models.postgis.message import Message
+from backend.models.postgis.notification import Notification
 from backend.models.postgis.task import Task
 from backend.models.postgis.team import Team, TeamMembers
 from backend.models.postgis.user import User
@@ -39,6 +41,8 @@ TEST_PROJECT_NAME = "Test"
 TEST_TEAM_NAME = "Test Team"
 TEST_CAMPAIGN_NAME = "Test Campaign"
 TEST_CAMPAIGN_ID = 1
+TEST_MESSAGE_SUBJECT = "Test subject"
+TEST_MESSAGE_DETAILS = "This is a test message"
 
 
 def get_canned_osm_user_details():
@@ -364,3 +368,24 @@ def create_canned_mapping_issue(name="Test Issue") -> int:
     issue_dto.name = name
     test_issue_id = MappingIssueCategoryService.create_mapping_issue_category(issue_dto)
     return test_issue_id
+
+
+def create_canned_message(
+    subject=TEST_MESSAGE_SUBJECT, message=TEST_MESSAGE_DETAILS
+) -> Message:
+    """"""
+    test_message = Message()
+    test_message.subject = subject
+    test_message.message = message
+    test_message.save()
+    return test_message
+
+
+def create_canned_notification(user_id, unread_count, date) -> Notification:
+    """"""
+    test_notification = Notification()
+    test_notification.user_id = user_id
+    test_notification.unread_count = unread_count
+    test_notification.date = date
+    test_notification.save()
+    return test_notification

--- a/tests/backend/helpers/test_helpers.py
+++ b/tests/backend/helpers/test_helpers.py
@@ -17,7 +17,7 @@ from backend.models.dtos.project_dto import (
 from backend.models.postgis.project import Project, ProjectTeams
 from backend.models.postgis.campaign import Campaign
 from backend.models.postgis.statuses import MappingLevel, TaskStatus
-from backend.models.postgis.message import Message
+from backend.models.postgis.message import Message, MessageType
 from backend.models.postgis.notification import Notification
 from backend.models.postgis.task import Task
 from backend.models.postgis.team import Team, TeamMembers
@@ -363,7 +363,6 @@ def create_canned_license(name="test_license") -> int:
 
 
 def create_canned_mapping_issue(name="Test Issue") -> int:
-    """"""
     issue_dto = MappingIssueCategoryDTO()
     issue_dto.name = name
     test_issue_id = MappingIssueCategoryService.create_mapping_issue_category(issue_dto)
@@ -371,18 +370,19 @@ def create_canned_mapping_issue(name="Test Issue") -> int:
 
 
 def create_canned_message(
-    subject=TEST_MESSAGE_SUBJECT, message=TEST_MESSAGE_DETAILS
+    subject=TEST_MESSAGE_SUBJECT,
+    message=TEST_MESSAGE_DETAILS,
+    message_type=MessageType.SYSTEM.value,
 ) -> Message:
-    """"""
     test_message = Message()
     test_message.subject = subject
     test_message.message = message
+    test_message.message_type = message_type
     test_message.save()
     return test_message
 
 
 def create_canned_notification(user_id, unread_count, date) -> Notification:
-    """"""
     test_notification = Notification()
     test_notification.user_id = user_id
     test_notification.unread_count = unread_count

--- a/tests/backend/integration/api/notifications/test_actions.py
+++ b/tests/backend/integration/api/notifications/test_actions.py
@@ -1,0 +1,52 @@
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import (
+    create_canned_user,
+    generate_encoded_token,
+    create_canned_message,
+)
+
+TEST_SUBJECT = "Test subject"
+TEST_MESSAGE = "This is a test message"
+
+
+class TestNotificationsActionsDeleteMultipleAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_user = create_canned_user()
+        self.test_message_one = create_canned_message(
+            subject=TEST_SUBJECT, message=TEST_MESSAGE
+        )
+        self.test_message_two = create_canned_message(
+            subject=TEST_SUBJECT, message=TEST_MESSAGE
+        )
+        self.test_message_one.from_user_id = self.test_user.id
+        self.test_message_two.from_user_id = self.test_user.id
+        self.test_user_token = generate_encoded_token(self.test_user.id)
+        self.url = "/api/v2/notifications/delete-multiple/"
+
+    # delete
+    def test_delete_multiple_messages_returns_401(self):
+        """
+        Test that endpoint returns 401 for unauthenticated user deleting multiple messages
+        """
+        response = self.client.delete(
+            self.url,
+            json={"messageIds": [self.test_message_one.id, self.test_message_two.id]},
+        )
+        response_body = response.get_json()
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_body["SubCode"], "InvalidToken")
+
+    def test_delete_multiple_messages_returns_200(self):
+        """
+        Test that endpoint returns 200 for authenticated user deleting multiple messages
+        """
+        response = self.client.delete(
+            self.url,
+            headers={"Authorization": self.test_user_token},
+            json={"messageIds": [self.test_message_one.id, self.test_message_two.id]},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["Success"], "Messages deleted")

--- a/tests/backend/integration/api/notifications/test_resources.py
+++ b/tests/backend/integration/api/notifications/test_resources.py
@@ -1,0 +1,237 @@
+from datetime import datetime
+
+from tests.backend.base import BaseTestCase
+from tests.backend.helpers.test_helpers import (
+    create_canned_user,
+    generate_encoded_token,
+    return_canned_user,
+    create_canned_message,
+    create_canned_notification,
+)
+
+TEST_SUBJECT = "Test subject"
+TEST_MESSAGE = "This is a test message"
+MESSAGES_NOT_FOUND = "No messages found"
+NOT_FOUND = "NotFound"
+
+
+class TestNotificationsRestAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_message = create_canned_message(
+            subject=TEST_SUBJECT, message=TEST_MESSAGE
+        )
+        self.test_sender = create_canned_user()
+        self.test_receiver = return_canned_user("Test user", 11111)
+        self.test_receiver.create()
+        self.test_message.from_user_id = self.test_sender.id
+        self.test_message.to_user_id = self.test_receiver.id
+
+        self.test_sender_token = generate_encoded_token(self.test_sender.id)
+        self.test_receiver_token = generate_encoded_token(self.test_receiver.id)
+        self.url = f"/api/v2/notifications/{self.test_message.id}/"
+        self.non_existent_url = "/api/v2/notifications/9999999/"
+
+    def test_get_message_returns_401(self):
+        """
+        Test that endpoint returns 401 when an unauthenticated user accesses a particular message
+        """
+        response = self.client.get(self.url)
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_body["SubCode"], "InvalidToken")
+
+    def test_get_message_returns_403(self):
+        """
+        Test that endpoint returns 403 when one user accesses another user's messages
+        """
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.test_sender_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response_body["SubCode"], "AccessOtherUserMessage")
+
+    def test_get_message_returns_404(self):
+        """
+        Test that endpoint returns 404 when a user accesses a non-existent message
+        """
+        response = self.client.get(
+            self.non_existent_url,
+            headers={"Authorization": self.test_sender_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], MESSAGES_NOT_FOUND)
+        self.assertEqual(response_body["SubCode"], NOT_FOUND)
+
+    def test_get_message_returns_200(self):
+        """
+        Test that endpoint returns 200 when a user successfully accesses their existent message
+        """
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.test_receiver_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["subject"], TEST_SUBJECT)
+        self.assertEqual(response_body["message"], TEST_MESSAGE)
+        self.assertEqual(response_body["fromUsername"], self.test_sender.username)
+
+    def test_delete_message_returns_401(self):
+        """
+        Test that endpoint returns 401 when an unauthenticated user deletes a message
+        """
+        response = self.client.delete(self.url)
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_body["SubCode"], "InvalidToken")
+
+    def test_delete_message_returns_403(self):
+        """
+        Test that endpoint returns 403 when a user deletes another user's message
+        """
+        response = self.client.delete(
+            self.url,
+            headers={"Authorization": self.test_sender_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response_body["SubCode"], "AccessOtherUserMessage")
+
+    def test_delete_message_returns_404(self):
+        """
+        Test that endpoint returns 404 when a user deletes a non-existent message
+        """
+        response = self.client.delete(
+            self.non_existent_url,
+            headers={"Authorization": self.test_sender_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_body["Error"], MESSAGES_NOT_FOUND)
+        self.assertEqual(response_body["SubCode"], NOT_FOUND)
+
+    def test_delete_message_returns_200(self):
+        """
+        Test that endpoint returns 200 when a user successfully deletes their existent message
+        """
+        response = self.client.delete(
+            self.url,
+            headers={"Authorization": self.test_receiver_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body["Success"], "Message deleted")
+
+
+class TestNotificationsAllAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_user = create_canned_user()
+        self.test_user_token = generate_encoded_token(self.test_user.id)
+        self.url = "/api/v2/notifications/"
+
+    def test_get_message_notifications_returns_401(self):
+        """
+        Test that endpoint returns 401 when an unauthenticated user accesses messsage notifications
+        """
+        response = self.client.get(self.url)
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_body["SubCode"], "InvalidToken")
+
+    def test_get_messages_returns_200(self):
+        """
+        Test that endpoint returns 200 when authenticated user accesses their messsage notifications
+        """
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.test_user_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response_body["userMessages"]), 0)
+        self.assertEqual(response_body["userMessages"], [])
+
+        # setup - add a message
+        self.test_message = create_canned_message(
+            subject=TEST_SUBJECT, message=TEST_MESSAGE
+        )
+        self.test_message.to_user_id = self.test_user.id
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.test_user_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response_body["userMessages"]), 1)
+        user_messages = response_body["userMessages"][0]
+        self.assertEqual(user_messages["subject"], TEST_SUBJECT)
+        self.assertEqual(user_messages["message"], TEST_MESSAGE)
+
+
+class TestNotificationsQueriesCountUnreadAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_user = create_canned_user()
+        self.test_user_token = generate_encoded_token(self.test_user.id)
+        self.url = "/api/v2/notifications/queries/own/count-unread/"
+        self.test_message = create_canned_message(
+            subject=TEST_SUBJECT, message=TEST_MESSAGE
+        )
+        self.test_message.to_user_id = self.test_user.id
+
+    def test_get_unread_count_returns_401(self):
+        """
+        Test that endpoint returns 401 when an unauthenticated user wants to get the unread count
+        """
+        response = self.client.get(self.url)
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_body["SubCode"], "InvalidToken")
+
+    def test_get_unread_count_returns_200(self):
+        """
+        Test that endpoint returns 200 when an authenticated user successfully gets their unread count
+        """
+        response = self.client.get(
+            self.url,
+            headers={"Authorization": self.test_user_token},
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body, {"newMessages": True, "unread": 1})
+
+
+class TestNotificationsQueriesPostUnreadAPI(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.test_user = create_canned_user()
+        self.test_user_token = generate_encoded_token(self.test_user.id)
+        self.test_notification = create_canned_notification(
+            user_id=self.test_user.id, unread_count=1, date=datetime.today()
+        )
+        self.url = "/api/v2/notifications/queries/own/post-unread/"
+
+    def test_post_unread_count_returns_401(self):
+        """
+        Test that endpoint returns 401 when there is no user whose unread count should be updated
+        """
+        response = self.client.post(self.url)
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_body["SubCode"], "InvalidToken")
+
+    def test_post_unread_count_returns_200(self):
+        """
+        Test that endpoint returns 200 after updating an authenticated user's unread count
+        """
+        response = self.client.post(
+            self.url, headers={"Authorization": self.test_user_token}
+        )
+        response_body = response.get_json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_body, 1)


### PR DESCRIPTION
This PR adds tests related to the Notifications API endpoints. 

**Related issue:**
- #5442

**How to test:**
- create a test database following the instructions [here](https://github.com/hotosm/tasking-manager/blob/develop/docs-old/setup-development.md#create-the-database-user-and-database). The database name is preceded by `test_`
- pull and checkout test branch using `git fetch origin && git checkout chore/add-notifications-tests`
- run tests using `python3 -m unittest discover tests/backend`
