### PR TITLE
Use window object to generate copy URLs for tasks and organizations

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,6 @@
     "@formatjs/macro": "^0.2.8",
     "@hotosm/id": "^2.21.1",
     "@hotosm/iso-countries-languages": "^1.1.2",
-    "@lokibai/react-use-copy-clipboard": "^1.0.4",
     "@mapbox/mapbox-gl-draw": "^1.3.0",
     "@mapbox/mapbox-gl-geocoder": "^5.0.1",
     "@mapbox/mapbox-gl-language": "^0.10.1",

--- a/frontend/src/components/taskSelection/imagery.js
+++ b/frontend/src/components/taskSelection/imagery.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { useCopyClipboard } from '@lokibai/react-use-copy-clipboard';
 
 import messages from './messages';
 import { ClipboardIcon } from '../svgIcons';
@@ -26,9 +25,10 @@ function getCustomMessageId(imagery) {
 export function Imagery({ value = '' }: Object) {
   const intl = useIntl();
   //eslint-disable-next-line
-  const [isCopied, setCopied] = useCopyClipboard();
   const imageryOption = useImageryOption(value);
   const customMessageId = getCustomMessageId(value);
+
+  const handleCopyToClipboard = () => navigator.clipboard.writeText(value);
 
   return (
     <p className={`f125 fw7 pt1 pr3 ma0 truncate blue-dark`}>
@@ -52,7 +52,7 @@ export function Imagery({ value = '' }: Object) {
           className="pointer pl2 blue-light hover-blue-dark"
           title={intl.formatMessage(messages.copyImageryURL)}
         >
-          <ClipboardIcon width="16px" height="16px" onClick={() => setCopied(value)} />
+          <ClipboardIcon width="16px" height="16px" onClick={handleCopyToClipboard} />
         </span>
       )}
     </p>

--- a/frontend/src/components/taskSelection/taskList.js
+++ b/frontend/src/components/taskSelection/taskList.js
@@ -148,7 +148,7 @@ export function TaskItem({
                 height="18px"
                 className={`pointer ${isCopied ? '' : 'hover-blue-grey'}`}
                 onClick={() =>
-                  setCopied(`${location.origin}${location.pathname}?search=${data.taskId}`)
+                  setCopied(`${window.location.origin}${location.pathname}?search=${data.taskId}`)
                 }
               />
             </div>

--- a/frontend/src/components/taskSelection/taskList.js
+++ b/frontend/src/components/taskSelection/taskList.js
@@ -4,7 +4,6 @@ import Popup from 'reactjs-popup';
 import { useQueryParam, NumberParam, StringParam } from 'use-query-params';
 import ReactPlaceholder from 'react-placeholder';
 import bbox from '@turf/bbox';
-import { useCopyClipboard } from '@lokibai/react-use-copy-clipboard';
 import { FormattedMessage, FormattedRelativeTime } from 'react-intl';
 
 import messages from './messages';
@@ -60,9 +59,14 @@ export function TaskItem({
   userCanValidate,
   selected = [],
 }: Object) {
-  const [isCopied, setCopied] = useCopyClipboard();
+  const [isCopied, setIsCopied] = useState(false);
   const location = useLocation();
   const { value, unit } = selectUnit(new Date(data.actionDate));
+
+  const handleCopyToClipboard = () =>
+    navigator.clipboard
+      .writeText(`${window.location.origin}${location.pathname}?search=${data.taskId}`)
+      .then(() => setIsCopied(true));
 
   return (
     <div
@@ -144,12 +148,11 @@ export function TaskItem({
           {(msg) => (
             <div className={`ph2 dib v-mid ${isCopied ? 'grey-light' : ''}`} title={msg}>
               <InternalLinkIcon
+                role="button"
                 width="18px"
                 height="18px"
                 className={`pointer ${isCopied ? '' : 'hover-blue-grey'}`}
-                onClick={() =>
-                  setCopied(`${window.location.origin}${location.pathname}?search=${data.taskId}`)
-                }
+                onClick={handleCopyToClipboard}
               />
             </div>
           )}

--- a/frontend/src/components/taskSelection/tests/imagery.test.js
+++ b/frontend/src/components/taskSelection/tests/imagery.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import { IntlProviders } from '../../../utils/testWithIntl';
@@ -175,5 +176,23 @@ describe('Imagery', () => {
     );
     expect(screen.getByText('Digital Globe')).toBeInTheDocument();
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('should copy value to the clipboard', async () => {
+    const originalClipboard = { ...global.navigator.clipboard };
+    const mockClipboard = {
+      writeText: jest.fn().mockImplementation(() => Promise.resolve()),
+    };
+    global.navigator.clipboard = mockClipboard;
+    render(
+      <IntlProviders>
+        <Imagery value={'wms'} />
+      </IntlProviders>,
+    );
+    await userEvent.click(screen.getByRole('img'));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('wms');
+    jest.resetAllMocks();
+    global.navigator.clipboard = originalClipboard;
   });
 });

--- a/frontend/src/components/taskSelection/tests/taskList.test.js
+++ b/frontend/src/components/taskSelection/tests/taskList.test.js
@@ -5,7 +5,12 @@ import userEvent from '@testing-library/user-event';
 import { getProjectSummary } from '../../../network/tests/mockData/projects';
 import { store } from '../../../store';
 import tasksGeojson from '../../../utils/tests/snippets/tasksGeometry';
-import { IntlProviders, ReduxIntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
+import {
+  createComponentWithMemoryRouter,
+  IntlProviders,
+  ReduxIntlProviders,
+  renderWithRouter,
+} from '../../../utils/testWithIntl';
 import { TaskFilter, TaskItem } from '../taskList';
 
 describe('Task Item', () => {
@@ -41,6 +46,29 @@ describe('Task Item', () => {
     );
     await userEvent.click(screen.getAllByRole('button')[1]);
     expect(setZoomedTaskIdMock).toHaveBeenCalledWith(8);
+  });
+
+  it('should copy task URL to the clipboard', async () => {
+    const originalClipboard = { ...global.navigator.clipboard };
+    const mockClipboard = {
+      writeText: jest.fn().mockImplementation(() => Promise.resolve()),
+    };
+    global.navigator.clipboard = mockClipboard;
+    createComponentWithMemoryRouter(
+      <IntlProviders>
+        <TaskItem data={task} selectTask={jest.fn()} />
+      </IntlProviders>,
+      {
+        route: '/projects/6/tasks',
+      },
+    );    
+    await userEvent.click(screen.getAllByRole('button')[2]);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      `${window.location.origin}/projects/6/tasks?search=8`,
+    );
+    jest.resetAllMocks();
+    global.navigator.clipboard = originalClipboard;
   });
 
   it('should display task detail modal', async () => {

--- a/frontend/src/components/teamsAndOrgs/organisations.js
+++ b/frontend/src/components/teamsAndOrgs/organisations.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Form, Field } from 'react-final-form';
 import { useCopyClipboard } from '@lokibai/react-use-copy-clipboard';
 import Select from 'react-select';
@@ -197,7 +197,6 @@ export function OrgInformation({ hasSlug, formState }) {
   const token = useSelector((state) => state.auth.token);
   const userDetails = useSelector((state) => state.auth.userDetails);
   const [uploadError, uploading, uploadImg] = useUploadImage();
-  const location = useLocation();
   const intl = useIntl();
   //eslint-disable-next-line
   const [isCopied, setCopied] = useCopyClipboard();
@@ -247,7 +246,7 @@ export function OrgInformation({ hasSlug, formState }) {
                   <ClipboardIcon
                     className="h1 w1 ph1 v-mid"
                     onClick={() =>
-                      setCopied(`${location.origin}/organisations/${props.input.value}/`)
+                      setCopied(`${window.location.origin}/organisations/${props.input.value}/`)
                     }
                   />
                 </span>

--- a/frontend/src/components/teamsAndOrgs/organisations.js
+++ b/frontend/src/components/teamsAndOrgs/organisations.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Form, Field } from 'react-final-form';
-import { useCopyClipboard } from '@lokibai/react-use-copy-clipboard';
 import Select from 'react-select';
 import ReactPlaceholder from 'react-placeholder';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -199,7 +198,6 @@ export function OrgInformation({ hasSlug, formState }) {
   const [uploadError, uploading, uploadImg] = useUploadImage();
   const intl = useIntl();
   //eslint-disable-next-line
-  const [isCopied, setCopied] = useCopyClipboard();
   const labelClasses = 'db pt3 pb2';
   const fieldClasses = 'blue-grey w-100 pv3 ph2 input-reset ba b--grey-light bg-transparent';
 
@@ -215,6 +213,8 @@ export function OrgInformation({ hasSlug, formState }) {
 
   const validateRequired = (value) =>
     value ? undefined : <FormattedMessage {...messages.requiredField} />;
+
+  const handleCopyToClipboard = (text) => navigator.clipboard.writeText(text);
 
   return (
     <>
@@ -244,9 +244,12 @@ export function OrgInformation({ hasSlug, formState }) {
                   title={intl.formatMessage(messages.copyPublicUrl)}
                 >
                   <ClipboardIcon
+                    role="button"
                     className="h1 w1 ph1 v-mid"
                     onClick={() =>
-                      setCopied(`${window.location.origin}/organisations/${props.input.value}/`)
+                      handleCopyToClipboard(
+                        `${window.location.origin}/organisations/${props.input.value}/`,
+                      )
                     }
                   />
                 </span>

--- a/frontend/src/components/user/content.js
+++ b/frontend/src/components/user/content.js
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { FormattedMessage, FormattedNumber, FormattedRelativeTime } from 'react-intl';
 import { selectUnit } from '../../utils/selectUnit';
-import { useCopyClipboard } from '@lokibai/react-use-copy-clipboard';
 import ReactPlaceholder from 'react-placeholder';
 import { OSM_SERVER_URL } from '../../config';
 
@@ -12,12 +11,8 @@ import { MappingIcon, ClipboardIcon } from '../svgIcons';
 import { UserInterestsForm } from './forms/interests';
 
 export function APIKeyCard({ token }) {
-  //eslint-disable-next-line
-  const [isCopied, setCopied] = useCopyClipboard();
+  const handleClick = () => navigator.clipboard.writeText(`Token ${token}`);
 
-  const handleClick = () => {
-    setCopied(`Token ${token}`);
-  };
   const link = (
     <a className="link red underline-hover" href="/api-docs/" target="_blank">
       <FormattedMessage {...messages.apiDocs} />

--- a/frontend/src/components/user/tests/content.test.js
+++ b/frontend/src/components/user/tests/content.test.js
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { APIKeyCard } from '../content';
+import userEvent from '@testing-library/user-event';
+import { IntlProviders } from '../../../utils/testWithIntl';
+
+test('should copy API key to the clipboard', async () => {
+  const originalClipboard = { ...global.navigator.clipboard };
+  const mockClipboard = {
+    writeText: jest.fn().mockImplementation(() => Promise.resolve()),
+  };
+  global.navigator.clipboard = mockClipboard;
+  render(
+    <IntlProviders>
+      <APIKeyCard token="validToken" />
+    </IntlProviders>,
+  );
+  await userEvent.click(screen.getByRole('img'));
+  expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+  expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Token validToken');
+  jest.resetAllMocks();
+  global.navigator.clipboard = originalClipboard;
+});

--- a/frontend/src/views/tests/organisationManagement.test.js
+++ b/frontend/src/views/tests/organisationManagement.test.js
@@ -175,6 +175,21 @@ describe('EditCampaign', () => {
     ).toBeInTheDocument();
   });
 
+  it('should copy the organization URL to clipboard', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: jest.fn().mockImplementation(() => Promise.resolve()),
+      },
+    });
+    setup();
+    await waitFor(() => expect(screen.getByText('Manage organization')).toBeInTheDocument());
+    await userEvent.click(screen.getAllByRole('button')[2]);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      `${window.location.origin}/organisations/organisation-name-123/`,
+    );
+  });
+
   it('should hide the save button after organisation edit is successful', async () => {
     setup();
     await waitFor(() => expect(screen.getByText('Manage organization')).toBeInTheDocument());

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2787,11 +2787,6 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@lokibai/react-use-copy-clipboard@^1.0.4":
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/@lokibai/react-use-copy-clipboard/-/react-use-copy-clipboard-1.0.5.tgz"
-  integrity sha512-S7vVvXmJSHpCorFG/zxMJh/1Mht6VbBMWw/sNvrJod/1nDsvpnXQAzqDejh6z0h8x5mth/TWcx4ej2rm8bRJNw==
-
 "@mapbox/extent@0.4.0":
   version "0.4.0"
   resolved "https://registry.npmjs.org/@mapbox/extent/-/extent-0.4.0.tgz"


### PR DESCRIPTION
This PR does the following: 
- Closes #5719 . Use the browser window object instead of the React Router location object to generate task and organization URLs. The values of the location object must have changed, making the origin variable undefined when we migrated to React Router from Reach Router.
- Removes the dependency on `@lokibai/react-use-copy-clipboard` previously used for copying text to the clipboard. This is due to deprecated usage of the [document.execCommand](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) function and lack of recent commits (last commit over 3 years ago). Instead, the `navigator.clipboard.writeText` function has been implemented to achieve the desired copy-to-clipboard functionality.