### PR TITLE
Add feature to delete project chat messages.

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -202,6 +202,7 @@ def add_api_endpoints(app):
     # Comments API impor
     from backend.api.comments.resources import (
         CommentsProjectsRestAPI,
+        CommentsProjectsAllAPI,
         CommentsTasksRestAPI,
     )
 
@@ -566,9 +567,14 @@ def add_api_endpoints(app):
 
     # Comments REST endoints
     api.add_resource(
-        CommentsProjectsRestAPI,
+        CommentsProjectsAllAPI,
         format_url("projects/<int:project_id>/comments/"),
         methods=["GET", "POST"],
+    )
+    api.add_resource(
+        CommentsProjectsRestAPI,
+        format_url("projects/<int:project_id>/comments/<int:comment_id>/"),
+        methods=["DELETE"],
     )
     api.add_resource(
         CommentsTasksRestAPI,

--- a/backend/models/dtos/message_dto.py
+++ b/backend/models/dtos/message_dto.py
@@ -46,6 +46,7 @@ class MessagesDTO(Model):
 class ChatMessageDTO(Model):
     """ DTO describing an individual project chat message """
 
+    id = IntType(required=False, serialize_when_none=False)
     message = StringType(required=True)
     user_id = IntType(required=True, serialize_when_none=False)
     project_id = IntType(required=True, serialize_when_none=False)

--- a/backend/models/postgis/project_chat.py
+++ b/backend/models/postgis/project_chat.py
@@ -83,6 +83,7 @@ class ProjectChat(db.Model):
             chat_dto.username = message.posted_by.username
             chat_dto.picture_url = message.posted_by.picture_url
             chat_dto.timestamp = message.time_stamp
+            chat_dto.id = message.id
 
             dto.chat.append(chat_dto)
 

--- a/backend/services/messaging/chat_service.py
+++ b/backend/services/messaging/chat_service.py
@@ -85,6 +85,26 @@ class ChatService:
         return ProjectChat.get_messages(project_id, page, per_page)
 
     @staticmethod
+    def get_project_chat_by_id(project_id: int, comment_id: int) -> ProjectChat:
+        """Get a message from a project chat
+        ----------------------------------------
+        :param project_id: The id of the project the message belongs to
+        :param message_id: The message id to fetch
+        ----------------------------------------
+        :raises NotFound: When the message is not found
+        ----------------------------------------
+        returns: The message
+        """
+        chat_message = ProjectChat.query.filter(
+            ProjectChat.project_id == project_id,
+            ProjectChat.id == comment_id,
+        ).one_or_none()
+        if chat_message is None:
+            raise NotFound("Message not found")
+
+        return chat_message
+
+    @staticmethod
     def delete_project_chat_by_id(project_id: int, comment_id: int, user_id: int):
         """Deletes a message from a project chat
         ----------------------------------------

--- a/frontend/src/components/projectDetail/index.js
+++ b/frontend/src/components/projectDetail/index.js
@@ -128,12 +128,12 @@ export const ProjectDetail = (props) => {
   /* eslint-disable-next-line */
   const [visualError, visualLoading, visualData] = useFetch(
     `projects/${props.project.projectId}/contributions/queries/day/`,
-    props.project && props.project.projectId,
+    props.project?.projectId,
   );
   /* eslint-disable-next-line */
   const [contributorsError, contributorsLoading, contributors] = useFetch(
     `projects/${props.project.projectId}/contributions/`,
-    props.project && props.project.projectId,
+    props.project?.projectId,
   );
 
   const htmlDescription =
@@ -276,7 +276,7 @@ export const ProjectDetail = (props) => {
           type={'media'}
           rows={1}
           delay={200}
-          ready={contributors && contributors.userContributions}
+          ready={contributors?.userContributions}
         >
           {contributors && (
             <UserAvatarList

--- a/frontend/src/components/projectDetail/index.js
+++ b/frontend/src/components/projectDetail/index.js
@@ -260,7 +260,7 @@ export const ProjectDetail = (props) => {
         <FormattedMessage {...messages.questionsAndComments} />
       </a>
       <QuestionsAndComments
-        projectId={props.project.projectId}
+        project={props.project}
         contributors={contributors}
         titleClass={`${h2Classes} mv0 pt5`}
       />

--- a/frontend/src/components/projectDetail/questionsAndComments.js
+++ b/frontend/src/components/projectDetail/questionsAndComments.js
@@ -149,14 +149,12 @@ function CommentList({ userCanEditProject, projectId, comments, retryFn }: Objec
           <div className="flex justify-between">
             <div className="flex items-center">
               <div className="">
-                {comment.pictureUrl === null ? null : (
-                  <UserAvatar
-                    username={comment.username}
-                    picture={comment.pictureUrl}
-                    colorClasses="white bg-blue-grey"
-                    size="medium"
-                  />
-                )}
+                <UserAvatar
+                  username={comment.username}
+                  picture={comment.pictureUrl}
+                  colorClasses="white bg-blue-grey"
+                  size="medium"
+                />
               </div>
               <div className="ml2">
                 <a

--- a/frontend/src/components/projectDetail/questionsAndComments.js
+++ b/frontend/src/components/projectDetail/questionsAndComments.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
 
@@ -13,6 +13,9 @@ import { MessageStatus } from '../comments/status';
 import { UserAvatar } from '../user/avatar';
 import { htmlFromMarkdown, formatUserNamesToLink } from '../../utils/htmlFromMarkdown';
 import { pushToLocalJSONAPI, fetchLocalJSONAPI } from '../../network/genericJSONRequest';
+import { useFetchWithAbort } from '../../hooks/UseFetch';
+import { useEditProjectAllowed } from '../../hooks/UsePermissions';
+import { DeleteButton } from '../teamsAndOrgs/management';
 
 import './styles.scss';
 
@@ -25,8 +28,8 @@ export const PostProjectComment = ({ projectId, updateComments, contributors }) 
       `projects/${projectId}/comments/`,
       JSON.stringify({ message: comment }),
       token,
-    ).then((res) => {
-      updateComments(res);
+    ).then(() => {
+      updateComments();
       setComment('');
     });
   };
@@ -63,22 +66,19 @@ export const PostProjectComment = ({ projectId, updateComments, contributors }) 
   );
 };
 
-export const QuestionsAndComments = ({ projectId, contributors, titleClass }) => {
+export const QuestionsAndComments = ({ project, contributors, titleClass }) => {
   const token = useSelector((state) => state.auth.token);
-  const [comments, setComments] = useState(null);
   const [page, setPage] = useState(1);
+  const [userCanEditProject] = useEditProjectAllowed(project);
+  const projectId = project.projectId;
 
   const handlePagination = (val) => {
     setPage(val);
   };
 
-  useEffect(() => {
-    if (projectId && page) {
-      fetchLocalJSONAPI(`projects/${projectId}/comments/?perPage=5&page=${page}`, token).then(
-        (res) => setComments(res),
-      );
-    }
-  }, [page, projectId, token]);
+  const [, , comments, refetch] = useFetchWithAbort(
+    `projects/${projectId}/comments/?perPage=5&page=${page}`,
+  );
 
   return (
     <div className="bg-tan-dim">
@@ -86,8 +86,13 @@ export const QuestionsAndComments = ({ projectId, contributors, titleClass }) =>
         <FormattedMessage {...messages.questionsAndComments} />
       </h3>
       <div className="ph6-l ph4 pb5 w-100 w-70-l">
-        {comments && comments.chat.length ? (
-          <CommentList comments={comments.chat} />
+        {comments && comments.chat?.length ? (
+          <CommentList
+            userCanEditProject={userCanEditProject}
+            projectId={projectId}
+            comments={comments.chat}
+            retryFn={refetch}
+          />
         ) : (
           <div className="pv4 blue-grey tc">
             <FormattedMessage {...messages.noComments} />
@@ -105,7 +110,7 @@ export const QuestionsAndComments = ({ projectId, contributors, titleClass }) =>
         {token ? (
           <PostProjectComment
             projectId={projectId}
-            updateComments={setComments}
+            updateComments={refetch}
             contributors={contributors}
           />
         ) : (
@@ -120,32 +125,61 @@ export const QuestionsAndComments = ({ projectId, contributors, titleClass }) =>
   );
 };
 
-function CommentList({ comments }: Object) {
+function CommentList({ userCanEditProject, projectId, comments, retryFn }: Object) {
+  const token = useSelector((state) => state.auth.token);
+  const username = useSelector((state) => state.auth.userDetails.username);
+
+  const deleteComment = (project_id, comment_id) => {
+    fetchLocalJSONAPI(`projects/${project_id}/comments/${comment_id}/`, token, 'DELETE')
+      .then(() => {
+        retryFn();
+      })
+      .catch((e) => {
+        console.log(e.message);
+      });
+  };
+
   return (
     <div className="pt3">
       {comments.map((comment, n) => (
         <div
           className="w-100 center cf mb2 ba0 br1 b--grey-light bg-white shadow-7 comment-item"
-          key={n}
+          key={comment.id}
         >
-          <div className="flex items-center">
-            <div className="">
-              {comment.pictureUrl === null ? null : (
-                <UserAvatar
-                  username={comment.username}
-                  picture={comment.pictureUrl}
-                  colorClasses="white bg-blue-grey"
-                  size="medium"
-                />
-              )}
+          <div className="flex justify-between">
+            <div className="flex items-center">
+              <div className="">
+                {comment.pictureUrl === null ? null : (
+                  <UserAvatar
+                    username={comment.username}
+                    picture={comment.pictureUrl}
+                    colorClasses="white bg-blue-grey"
+                    size="medium"
+                  />
+                )}
+              </div>
+              <div className="ml2">
+                <a
+                  href={`/users/${comment.username}`}
+                  className="blue-dark fw5 link underline-hover"
+                >
+                  {comment.username}
+                </a>
+                <p className="blue-grey f6 ma0">
+                  <RelativeTimeWithUnit date={comment.timestamp} />
+                </p>
+              </div>
             </div>
-            <div className="ml2">
-              <a href={`/users/${comment.username}`} className="blue-dark fw5 link underline-hover">
-                {comment.username}
-              </a>
-              <p className="blue-grey f6 ma0">
-                <RelativeTimeWithUnit date={comment.timestamp} />
-              </p>
+            <div>
+              {userCanEditProject || comment.username === username ? (
+                <DeleteButton
+                  className={`bg-transparent bw0 w2 h2 lh-copy overflow-hidden blue-light p0 mb1 hover-red`}
+                  showText={false}
+                  onClick={() => {
+                    deleteComment(projectId, comment.id);
+                  }}
+                />
+              ) : null}
             </div>
           </div>
           <div

--- a/frontend/src/components/projectDetail/questionsAndComments.js
+++ b/frontend/src/components/projectDetail/questionsAndComments.js
@@ -86,7 +86,7 @@ export const QuestionsAndComments = ({ project, contributors, titleClass }) => {
         <FormattedMessage {...messages.questionsAndComments} />
       </h3>
       <div className="ph6-l ph4 pb5 w-100 w-70-l">
-        {comments && comments.chat?.length ? (
+        {comments?.chat?.length ? (
           <CommentList
             userCanEditProject={userCanEditProject}
             projectId={projectId}
@@ -99,7 +99,7 @@ export const QuestionsAndComments = ({ project, contributors, titleClass }) => {
           </div>
         )}
 
-        {comments && comments.pagination && comments.pagination.pages > 0 && (
+        {comments?.pagination?.pages > 0 && (
           <PaginatorLine
             activePage={page}
             setPageFn={handlePagination}
@@ -125,12 +125,12 @@ export const QuestionsAndComments = ({ project, contributors, titleClass }) => {
   );
 };
 
-function CommentList({ userCanEditProject, projectId, comments, retryFn }: Object) {
+export function CommentList({ userCanEditProject, projectId, comments, retryFn }: Object) {
   const token = useSelector((state) => state.auth.token);
   const username = useSelector((state) => state.auth.userDetails.username);
 
-  const deleteComment = (project_id, comment_id) => {
-    fetchLocalJSONAPI(`projects/${project_id}/comments/${comment_id}/`, token, 'DELETE')
+  const deleteComment = (commentId) => {
+    fetchLocalJSONAPI(`projects/${projectId}/comments/${commentId}/`, token, 'DELETE')
       .then(() => {
         retryFn();
       })
@@ -141,7 +141,7 @@ function CommentList({ userCanEditProject, projectId, comments, retryFn }: Objec
 
   return (
     <div className="pt3">
-      {comments.map((comment, n) => (
+      {comments.map((comment) => (
         <div
           className="w-100 center cf mb2 ba0 br1 b--grey-light bg-white shadow-7 comment-item"
           key={comment.id}
@@ -169,15 +169,15 @@ function CommentList({ userCanEditProject, projectId, comments, retryFn }: Objec
               </div>
             </div>
             <div>
-              {userCanEditProject || comment.username === username ? (
+              {(userCanEditProject || comment.username === username) && (
                 <DeleteButton
                   className={`bg-transparent bw0 w2 h2 lh-copy overflow-hidden blue-light p0 mb1 hover-red`}
                   showText={false}
                   onClick={() => {
-                    deleteComment(projectId, comment.id);
+                    deleteComment(comment.id);
                   }}
                 />
-              ) : null}
+              )}
             </div>
           </div>
           <div

--- a/frontend/src/components/projectDetail/tests/questionsAndComments.test.js
+++ b/frontend/src/components/projectDetail/tests/questionsAndComments.test.js
@@ -4,13 +4,15 @@ import '@testing-library/jest-dom';
 import { store } from '../../../store';
 
 import { ReduxIntlProviders } from '../../../utils/testWithIntl';
+import { getProjectSummary } from '../../../network/tests/mockData/projects';
 import { QuestionsAndComments, PostProjectComment } from '../questionsAndComments';
 
 describe('test if QuestionsAndComments component', () => {
+  const project = getProjectSummary(1);
   it('only renders text asking user to log in for non-logged in user', () => {
     render(
       <ReduxIntlProviders store={store}>
-        <QuestionsAndComments projectId={1} />
+        <QuestionsAndComments project={project} />
       </ReduxIntlProviders>,
     );
     expect(screen.getByText('Log in to be able to post comments.')).toBeInTheDocument();
@@ -39,7 +41,7 @@ describe('test if QuestionsAndComments component', () => {
     });
     render(
       <ReduxIntlProviders store={store}>
-        <QuestionsAndComments projectId={1} />
+        <QuestionsAndComments project={project} />
       </ReduxIntlProviders>,
     );
 

--- a/frontend/src/components/projectDetail/tests/questionsAndComments.test.js
+++ b/frontend/src/components/projectDetail/tests/questionsAndComments.test.js
@@ -1,11 +1,12 @@
-import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
 
 import { store } from '../../../store';
 
-import { ReduxIntlProviders } from '../../../utils/testWithIntl';
-import { getProjectSummary } from '../../../network/tests/mockData/projects';
-import { QuestionsAndComments, PostProjectComment } from '../questionsAndComments';
+import { ReduxIntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
+import { getProjectSummary, projectComments } from '../../../network/tests/mockData/projects';
+import { QuestionsAndComments, PostProjectComment, CommentList } from '../questionsAndComments';
 
 describe('test if QuestionsAndComments component', () => {
   const project = getProjectSummary(1);
@@ -35,76 +36,44 @@ describe('test if QuestionsAndComments component', () => {
   });
 
   it('enables logged in user to post and view comments', async () => {
-    jest.spyOn(window, 'fetch');
     act(() => {
-      store.dispatch({ type: 'SET_TOKEN', token: '123456' });
+      store.dispatch({ type: 'SET_TOKEN', token: '123456', role: 'ADMIN' });
     });
-    render(
+    renderWithRouter(
       <ReduxIntlProviders store={store}>
         <QuestionsAndComments project={project} />
       </ReduxIntlProviders>,
     );
-
-    window.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        chat: [
-          {
-            message: '<p>Test comment</p>',
-            pictureUrl: null,
-            timestamp: Date.now() - 1e3,
-            username: 'TestUser',
-            length: 1,
-          },
-        ],
-        pagination: {
-          hasNext: false,
-          hasPrev: false,
-          nextNum: null,
-          page: 1,
-          pages: 1,
-          perPage: 5,
-        },
-      }),
-    });
-    expect(
-      screen.queryByText(
-        'There are currently no questions or comments on this project. Be the first to post one!',
-      ),
-    ).toBeInTheDocument();
+    const user = userEvent.setup();
+    await waitFor(() => expect(screen.getByText('hello world')).toBeInTheDocument());
     const textarea = screen.getByRole('textbox');
-    expect(textarea.textContent).toBe('');
-    const button = screen.getByRole('button', { name: /post/i });
-    expect(button.textContent).toBe('Post');
+    const postBtn = screen.getByRole('button', { name: /post/i });
+    await user.type(textarea, 'Test comment');
+    await user.click(postBtn);
+    await waitFor(() => expect(screen.getByText(/Message sent./i)).toBeInTheDocument());
+    expect(textarea).toHaveTextContent('');
+  });
 
-    // type comment in textbox
-    fireEvent.change(textarea, { target: { value: 'Test comment' } });
-    expect(textarea.textContent).toBe('Test comment');
-    expect(
-      screen.queryByTitle('Add "#managers" to notify the project managers about your comment.')
-        .textContent,
-    ).toBe('#managers');
-    expect(
-      screen.queryByTitle('Add "#author" to notify the project author about your comment.')
-        .textContent,
-    ).toBe('#author');
-
-    // click button to post comment
-    fireEvent.click(button);
-    await waitFor(() => {
-      expect(fetch).toHaveBeenCalledTimes(2);
+  it('should delete the comment', async () => {
+    const retryFnMock = jest.fn();
+    store.dispatch({
+      type: 'SET_USER_DETAILS',
+      userDetails: { role: 'ADMIN' },
     });
-    expect(screen.getByRole('link').href).toContain('/users/TestUser');
-    expect(screen.getByRole('link').textContent).toBe('TestUser');
-    expect(screen.getByText('Test comment')).toBeInTheDocument(); //posted comment
-    expect(screen.getByText('1 second ago')).toBeInTheDocument(); //time posted
-    expect(screen.getByText('1')).toBeInTheDocument(); //page button
-    expect(screen.getByText('Message sent.')).toBeInTheDocument();
-    expect(textarea.textContent).toBe(''); //empty textarea
-    expect(
-      screen.queryByText(
-        'There are currently no questions or comments on this project. Be the first to post one!',
-      ),
-    ).not.toBeInTheDocument();
+    renderWithRouter(
+      <ReduxIntlProviders store={store}>
+        <CommentList
+          userCanEditProject
+          projectId={123}
+          comments={projectComments.chat}
+          retryFn={retryFnMock}
+        />
+      </ReduxIntlProviders>,
+    );
+
+    const user = userEvent.setup();
+    await waitFor(() => expect(screen.getByText('hello world')).toBeInTheDocument());
+    await user.click(screen.getAllByRole('button')[0]);
+    await waitFor(() => expect(retryFnMock).toHaveBeenCalledTimes(1));
   });
 });

--- a/frontend/src/components/taskSelection/tests/taskList.test.js
+++ b/frontend/src/components/taskSelection/tests/taskList.test.js
@@ -61,7 +61,7 @@ describe('Task Item', () => {
       {
         route: '/projects/6/tasks',
       },
-    );    
+    );
     await userEvent.click(screen.getAllByRole('button')[2]);
     expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(

--- a/frontend/src/components/teamsAndOrgs/management.js
+++ b/frontend/src/components/teamsAndOrgs/management.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
+import ReactTooltip from 'react-tooltip';
+import { useIntl } from 'react-intl';
 
 import messages from './messages';
 import { CustomButton } from '../button';
@@ -23,19 +25,22 @@ export const AddButton = () => (
   </CustomButton>
 );
 
-export const DeleteButton = ({ className, onClick, showText = true }: Object) => (
-  <CustomButton
-    className={`red bg-transparent ba b--red barlow-condensed pv1 ${className}`}
-    onClick={onClick}
-  >
-    <WasteIcon className="v-mid h1 w1" />
-    {showText && (
-      <span className="v-mid f4 fw6 ttu pl2">
-        <FormattedMessage {...messages.delete} />
-      </span>
-    )}
-  </CustomButton>
-);
+export const DeleteButton = ({ className, onClick, showText = true }: Object) => {
+  const intl = useIntl();
+  return (
+    <CustomButton className={`red bg-transparent ba b--red pv1 ${className}`} onClick={onClick}>
+      <div data-for="Delete" data-tip={!showText ? intl.formatMessage(messages.delete) : ''}>
+        <WasteIcon className="v-mid h1 w1" />
+        {showText && (
+          <span className="v-mid f4 fw6 ttu barlow-condensed pl2">
+            <FormattedMessage {...messages.delete} />
+          </span>
+        )}
+      </div>
+      <ReactTooltip effect="solid" id="Delete" />
+    </CustomButton>
+  );
+};
 
 export function VisibilityBox({ visibility, extraClasses }: Object) {
   let color = visibility === 'PUBLIC' ? 'blue-grey' : 'red';

--- a/frontend/src/components/teamsAndOrgs/management.js
+++ b/frontend/src/components/teamsAndOrgs/management.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { FormattedMessage } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
 import ReactTooltip from 'react-tooltip';
-import { useIntl } from 'react-intl';
 
 import messages from './messages';
 import { CustomButton } from '../button';

--- a/frontend/src/network/tests/server-handlers.js
+++ b/frontend/src/network/tests/server-handlers.js
@@ -100,6 +100,12 @@ const handlers = [
   rest.get(API_URL + 'projects/:id/comments/', async (req, res, ctx) => {
     return res(ctx.json(projectComments));
   }),
+  rest.post(API_URL + 'projects/:id/comments/', async (req, res, ctx) => {
+    return res(ctx.json({ message: 'Comment posted' }));
+  }),
+  rest.delete(API_URL + 'projects/:projectId/comments/:commentId/', async (req, res, ctx) => {
+    return res(ctx.json({ message: 'Message deleted' }));
+  }),
   rest.get(API_URL + 'projects/:id/favorite/', async (req, res, ctx) => {
     return res(ctx.json(userFavorite));
   }),

--- a/tests/backend/integration/services/messaging/test_chat_service.py
+++ b/tests/backend/integration/services/messaging/test_chat_service.py
@@ -25,6 +25,8 @@ class TestChatService(BaseTestCase):
         self.chat_dto.project_id = self.canned_project.id
         self.chat_dto.timestamp = "2022-06-30T05:45:06.198755Z"
         self.chat_dto.username = self.canned_author.username
+        self.test_user = return_canned_user(username="test_user", id=100000)
+        self.test_user.create()
 
     @patch.object(threading, "Thread")
     def test_post_message_sets_thread_if_user_allowed(self, mock_thread):
@@ -38,30 +40,22 @@ class TestChatService(BaseTestCase):
     def test_post_message_raises_error_if_user_not_manager_in_draft_project(self):
         # Arrange
         self.canned_project.status = ProjectStatus.DRAFT.value
-        sender = return_canned_user()
-        sender.id = 100000
-        sender.username = "test_user"
-        sender.create()
-        self.chat_dto.user_id = sender.id
-        self.chat_dto.username = sender.username
+        self.chat_dto.user_id = self.test_user.id
+        self.chat_dto.username = self.test_user.username
         # Act/Assert
         with self.assertRaises(ValueError):
-            ChatService.post_message(self.chat_dto, self.canned_project.id, sender.id)
+            ChatService.post_message(self.chat_dto, self.canned_project.id, self.test_user.id)
 
     @patch.object(threading, "Thread")
     def test_post_message_sets_thread_if_user_member_of_allowed_team_in_private_project(
         self, mock_thread
     ):
         # Arrange
-        sender = return_canned_user()
-        sender.id = 100000
-        sender.username = "test_user"
-        sender.create()
         canned_team = create_canned_team()
         assign_team_to_project(self.canned_project, canned_team, TeamRoles.MAPPER.value)
-        add_user_to_team(canned_team, sender, TeamMemberFunctions.MEMBER.value, True)
-        self.chat_dto.user_id = sender.id
-        self.chat_dto.username = sender.username
+        add_user_to_team(canned_team, self.test_user, TeamMemberFunctions.MEMBER.value, True)
+        self.chat_dto.user_id = self.test_user.id
+        self.chat_dto.username = self.test_user.username
         self.canned_project.status = ProjectStatus.PUBLISHED.value
         self.canned_project.private = True
         # Act
@@ -75,16 +69,12 @@ class TestChatService(BaseTestCase):
         self,
     ):
         # Arrange
-        sender = return_canned_user()
-        sender.id = 100000
-        sender.username = "test_user"
-        sender.create()
         canned_team = create_canned_team()
         assign_team_to_project(self.canned_project, canned_team, TeamRoles.MAPPER.value)
-        self.chat_dto.user_id = sender.id
-        self.chat_dto.username = sender.username
+        self.chat_dto.user_id = self.test_user.id
+        self.chat_dto.username = self.test_user.username
         self.canned_project.status = ProjectStatus.PUBLISHED.value
         self.canned_project.private = True
         # Act/Assert
         with self.assertRaises(ValueError):
-            ChatService.post_message(self.chat_dto, self.canned_project.id, sender.id)
+            ChatService.post_message(self.chat_dto, self.canned_project.id, self.test_user.id)

--- a/tests/backend/integration/services/messaging/test_chat_service.py
+++ b/tests/backend/integration/services/messaging/test_chat_service.py
@@ -1,6 +1,7 @@
 import threading
 from unittest.mock import patch
 
+from backend.models.postgis.utils import NotFound
 from backend.models.postgis.statuses import ProjectStatus
 from backend.models.postgis.team import TeamRoles, TeamMemberFunctions
 from tests.backend.base import BaseTestCase
@@ -44,7 +45,9 @@ class TestChatService(BaseTestCase):
         self.chat_dto.username = self.test_user.username
         # Act/Assert
         with self.assertRaises(ValueError):
-            ChatService.post_message(self.chat_dto, self.canned_project.id, self.test_user.id)
+            ChatService.post_message(
+                self.chat_dto, self.canned_project.id, self.test_user.id
+            )
 
     @patch.object(threading, "Thread")
     def test_post_message_sets_thread_if_user_member_of_allowed_team_in_private_project(
@@ -53,7 +56,9 @@ class TestChatService(BaseTestCase):
         # Arrange
         canned_team = create_canned_team()
         assign_team_to_project(self.canned_project, canned_team, TeamRoles.MAPPER.value)
-        add_user_to_team(canned_team, self.test_user, TeamMemberFunctions.MEMBER.value, True)
+        add_user_to_team(
+            canned_team, self.test_user, TeamMemberFunctions.MEMBER.value, True
+        )
         self.chat_dto.user_id = self.test_user.id
         self.chat_dto.username = self.test_user.username
         self.canned_project.status = ProjectStatus.PUBLISHED.value
@@ -77,4 +82,68 @@ class TestChatService(BaseTestCase):
         self.canned_project.private = True
         # Act/Assert
         with self.assertRaises(ValueError):
-            ChatService.post_message(self.chat_dto, self.canned_project.id, self.test_user.id)
+            ChatService.post_message(
+                self.chat_dto, self.canned_project.id, self.test_user.id
+            )
+
+    def test_delete_project_chat_by_id_raises_not_found_if_comment_is_not_found(self):
+        """Test raises not found if comment is not found"""
+        # Arrange
+        project_id = 999999
+        # Act/Assert
+        with self.assertRaises(NotFound):
+            ChatService.delete_project_chat_by_id(project_id, 11, 11)
+
+    def test_delete_project_chat_by_id_deletes_comment_if_user_is_comment_author(self):
+        """Test successfully deletes comment if user is comment author"""
+        # Arrange
+        self.chat_dto.user_id = self.test_user.id
+        self.canned_project.status = ProjectStatus.PUBLISHED.value
+        self.canned_project.save()
+        comments = ChatService.post_message(
+            self.chat_dto, self.canned_project.id, self.test_user.id
+        )
+        comment = comments.chat[0]
+        # Act
+        ChatService.delete_project_chat_by_id(
+            self.canned_project.id, comment.id, self.test_user.id
+        )
+        # Assert
+        with self.assertRaises(NotFound):
+            ChatService.get_project_chat_by_id(self.canned_project.id, comment.id)
+
+    def test_project_managers_can_delete_any_comment(self):
+        """Project managers can delete any comment"""
+        # Arrange
+        # Add a comment by a user who is not the project manager
+        self.canned_project.status = ProjectStatus.PUBLISHED.value
+        self.canned_project.save()
+        self.chat_dto.user_id = self.test_user.id
+        comments = ChatService.post_message(
+            self.chat_dto, self.canned_project.id, self.test_user.id
+        )
+        comment = comments.chat[0]
+        # Act
+        ChatService.delete_project_chat_by_id(
+            self.canned_project.id, comment.id, self.canned_author.id
+        )
+        # Assert
+        with self.assertRaises(NotFound):
+            ChatService.get_project_chat_by_id(self.canned_project.id, comment.id)
+
+    def test_delete_project_chat_by_id_raises_error_if_user_is_not_comment_author_and_project_manager(
+        self,
+    ):
+        """Test raises error if user is not comment author and project manager"""
+        # Arrange
+        self.canned_project.status = ProjectStatus.PUBLISHED.value
+        self.canned_project.save()
+        comments = ChatService.post_message(
+            self.chat_dto, self.canned_project.id, self.canned_author.id
+        )
+        comment = comments.chat[0]
+        # Act/Assert
+        with self.assertRaises(ValueError):
+            ChatService.delete_project_chat_by_id(
+                self.canned_project.id, comment.id, self.test_user.id
+            )


### PR DESCRIPTION
Partially addresses #4858 by adding feature to delete message on project's question and comment section.

Only the project manager and the message's author will be able to delete a message. On frontend delete button will be shown to all messages if user has project manage permission else the delete button will only be shown on the comment which is posted by the logged in user.

![image](https://user-images.githubusercontent.com/67958673/236114843-ac0158d1-b803-4faa-8d4d-46aa12f73596.png)


**TO DO: Add a toast message to indicate the success or failure of comment deleting.**