### PR TITLE
Display TM stats on the landing page simultaneously

### DIFF
--- a/frontend/src/components/homepage/tests/stats.test.js
+++ b/frontend/src/components/homepage/tests/stats.test.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
 import { FormattedNumber } from 'react-intl';
 
-import { StatsNumber } from '../stats';
-import { createComponentWithIntl } from '../../../utils/testWithIntl';
+import { StatsNumber, StatsSection } from '../stats';
+import { IntlProviders, createComponentWithIntl } from '../../../utils/testWithIntl';
 
 it('test number formatting in English', () => {
   const testNumber = createComponentWithIntl(<StatsNumber value={744531} />);
@@ -16,4 +17,18 @@ it('test number formatting smaller than 1000', () => {
   const testInstance = testNumber.root;
   expect(testInstance.findByType(FormattedNumber).props.value).toBe(744);
   expect(testInstance.children).not.toContain('K');
+});
+
+describe('Stats Section', () => {
+  it('should display OSM and TM stats', async () => {
+    render(
+      <IntlProviders>
+        <StatsSection />
+      </IntlProviders>,
+    );
+    // A stat from OSM's TM Stat
+    await waitFor(() => expect(screen.getByText('101.4M')).toBeInTheDocument());
+    // A stat from TM Stat
+    await waitFor(() => expect(screen.getByText(3)).toBeInTheDocument());
+  });
 });

--- a/frontend/src/network/tests/mockData/miscellaneous.js
+++ b/frontend/src/network/tests/mockData/miscellaneous.js
@@ -27,3 +27,10 @@ export const josmRemote = {
   application: 'JOSM RemoteControl',
   version: 18646,
 };
+
+export const systemStats = {
+  mappersOnline: 0,
+  tasksMapped: 14,
+  totalMappers: 3,
+  totalProjects: 10,
+};

--- a/frontend/src/network/tests/server-handlers.js
+++ b/frontend/src/network/tests/server-handlers.js
@@ -60,7 +60,7 @@ import {
 } from './mockData/teams';
 import { userTasks } from './mockData/tasksStats';
 import { homepageStats } from './mockData/homepageStats';
-import { banner, countries, josmRemote } from './mockData/miscellaneous';
+import { banner, countries, josmRemote, systemStats } from './mockData/miscellaneous';
 import tasksGeojson from '../../utils/tests/snippets/tasksGeometry';
 import { API_URL } from '../../config';
 import { notifications, ownCountUnread } from './mockData/notifications';
@@ -313,6 +313,9 @@ const handlers = [
   }),
   rest.post(API_URL + 'projects/:projectId/tasks/actions/extend/', (req, res, ctx) => {
     return res(ctx.json(extendTask));
+  }),
+  rest.get(API_URL + 'system/statistics/', (req, res, ctx) => {
+    return res(ctx.json(systemStats));
   }),
   // EXTERNAL API
   rest.get('https://osmstats-api.hotosm.org/wildcard', (req, res, ctx) => {


### PR DESCRIPTION
Closes #5738 

![stats](https://user-images.githubusercontent.com/51614993/235613577-68afc984-f443-4e37-a980-a9e691bce317.gif)

- Updates the component to load and display stats from two different APIs simultaneously. It does this by using the Promise.all() method, which allows concurrently fetching data from multiple sources. 
- Updated to show a dash ("-") instead of undefined values while the stats are still loading.