### PR TITLE
 Refactor country search for more precise matching

### DIFF
--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -331,9 +331,9 @@ class ProjectSearchService:
             sq = Project.query.with_entities(
                 Project.id, func.unnest(Project.country).label("country")
             ).subquery()
-            query = query.filter(sq.c.country == search_dto.country).filter(
-                Project.id == sq.c.id
-            )
+            query = query.filter(
+                func.lower(sq.c.country) == search_dto.country.lower()
+            ).filter(Project.id == sq.c.id)
 
         if search_dto.last_updated_gte:
             last_updated_gte = validate_date_input(search_dto.last_updated_gte)

--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -331,9 +331,9 @@ class ProjectSearchService:
             sq = Project.query.with_entities(
                 Project.id, func.unnest(Project.country).label("country")
             ).subquery()
-            query = query.filter(
-                sq.c.country.ilike("%{}%".format(search_dto.country))
-            ).filter(Project.id == sq.c.id)
+            query = query.filter(sq.c.country == search_dto.country).filter(
+                Project.id == sq.c.id
+            )
 
         if search_dto.last_updated_gte:
             last_updated_gte = validate_date_input(search_dto.last_updated_gte)


### PR DESCRIPTION
Closes #5751 
This PR refactors the country search functionality in response to an issue where South Sudan projects were showing up under Sudan when filtering by location. The previous implementation used an ilike search to match country names in a nested array, which resulted in false positives.

The new implementation uses exact matching to make the search more precise and reliable. It replaces the ilike function with the equality operator, ensuring that only the projects with the exact country name are returned.

This change improves the accuracy of the search results and eliminates the issue like South Sudan projects appearing under Sudan.