### PR TITLE
Remove unreachable condition to raise organisation NotFound

### DIFF
--- a/backend/services/project_admin_service.py
+++ b/backend/services/project_admin_service.py
@@ -71,8 +71,6 @@ class ProjectAdminService:
             org = OrganisationService.get_organisation_by_id(
                 draft_project_dto.organisation
             )
-            if org is None:
-                raise NotFound("Organisation does not exist")
             draft_project_dto.organisation = org
             draft_project.create_draft_project(draft_project_dto)
 

--- a/tests/backend/integration/services/test_project_admin_service.py
+++ b/tests/backend/integration/services/test_project_admin_service.py
@@ -111,18 +111,16 @@ class TestProjectAdminService(BaseTestCase):
             draft_project_dto.cloneFromProjectId, draft_project_dto.user_id
         )
 
-    @patch.object(OrganisationService, "get_organisation_by_id")
     @patch.object(UserService, "get_user_by_id")
     @patch.object(UserService, "is_user_an_admin")
     def test_create_draft_project_raises_error_if_org_not_found(
-        self, mock_admin_test, mock_user_get, mock_org_get
+        self, mock_admin_test, mock_user_get
     ):
         # Arrange
         mock_user_get.return_value = return_canned_user()
         draft_project_dto = DraftProjectDTO(return_canned_draft_project_json())
         draft_project_dto.user_id = 777777
         mock_admin_test.return_value = True
-        mock_org_get.return_value = None
         # Act/Assert
         with self.assertRaises(NotFound):
             ProjectAdminService.create_draft_project(draft_project_dto)


### PR DESCRIPTION
The condtion to raise NotFound was unreachable as the function to return org already would have raised the NotFound exception if org was returned None. This PR removes that condition and updates the test case reflecting the change.