### PR TITLE
Display project categories in the project detail page

### DIFF
--- a/frontend/src/components/projectDetail/header.js
+++ b/frontend/src/components/projectDetail/header.js
@@ -66,6 +66,7 @@ export const ProjectHeader = ({ project, showEditLink }: Object) => {
       </div>
       <TagLine
         campaigns={project.campaigns}
+        interests={project.interests}
         countries={
           locale.includes('en') ? project.countryTag : translateCountry(project.countryTag, locale)
         }
@@ -74,14 +75,19 @@ export const ProjectHeader = ({ project, showEditLink }: Object) => {
   );
 };
 
-function TagLine({ campaigns = [], countries = [] }: Object) {
-  let tags = [];
-  tags = campaigns.map((i) => i.name).concat(countries);
+export function TagLine({ campaigns = [], countries = [], interests = [] }: Object) {
+  const locale = useSelector((state) => state.preferences.locale);
+  const formattedCampaigns = campaigns.map((campaign) => campaign.name).join(', ');
+  const formattedCountries = locale.includes('en') ? countries.join(', ') : countries;
+  const formattedInterests = interests.map((interest) => interest.name).join(', ');
+  // Remove empty formatted strings
+  const tags = [formattedCampaigns, formattedCountries, formattedInterests].filter((n) => n);
+
   return (
     <span className="blue-light">
-      {tags.map((tag, n) => (
-        <span key={n}>
-          <span className={n === 0 ? 'dn' : 'ph2'}>&#183;</span>
+      {tags.map((tag, index) => (
+        <span key={tag}>
+          {index !== 0 && <span className="ph2">&#183;</span>}
           {tag}
         </span>
       ))}

--- a/frontend/src/components/projectDetail/tests/header.test.js
+++ b/frontend/src/components/projectDetail/tests/header.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { screen, act } from '@testing-library/react';
+import { screen, act, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import { HeaderLine, ProjectHeader } from '../header';
+import { HeaderLine, ProjectHeader, TagLine } from '../header';
 import { ReduxIntlProviders, IntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
 import { getProjectSummary } from '../../../network/tests/mockData/projects';
 import { store } from '../../../store';
@@ -61,8 +61,8 @@ describe('test if ProjectHeader component', () => {
     expect(screen.getByText('Urgent')).toBeInTheDocument();
     expect(screen.getByText('La Paz Buildings')).toBeInTheDocument();
     expect(screen.getByText('La Paz Buildings').closest('h3').lang).toBe('en');
-    expect(screen.getByText('Environment Conservation')).toBeInTheDocument();
-    expect(screen.getByText('Women security')).toBeInTheDocument();
+    expect(screen.getByText(/Environment Conservation/i)).toBeInTheDocument();
+    expect(screen.getByText(/Women security/i)).toBeInTheDocument();
     expect(screen.getByText('Bolivia')).toBeInTheDocument();
     expect(screen.queryByText(/private/i)).not.toBeInTheDocument();
   });
@@ -83,8 +83,8 @@ describe('test if ProjectHeader component', () => {
     expect(screen.getByText('Urgent')).toBeInTheDocument();
     expect(screen.getByText('La Paz Buildings')).toBeInTheDocument();
     expect(screen.getByText('La Paz Buildings').closest('h3').lang).toBe('en');
-    expect(screen.getByText('Environment Conservation')).toBeInTheDocument();
-    expect(screen.getByText('Women security')).toBeInTheDocument();
+    expect(screen.getByText(/Environment Conservation/i)).toBeInTheDocument();
+    expect(screen.getByText(/Women security/i)).toBeInTheDocument();
     expect(screen.getByText('Bolivia')).toBeInTheDocument();
     expect(screen.queryByText(/private/i)).not.toBeInTheDocument();
   });
@@ -113,8 +113,62 @@ describe('test if ProjectHeader component', () => {
     expect(screen.queryByText('Draft')).toBeInTheDocument();
     expect(screen.getByText('La Paz Buildings')).toBeInTheDocument();
     expect(screen.getByText('La Paz Buildings').closest('h3').lang).toBe('en');
-    expect(screen.getByText('Environment Conservation')).toBeInTheDocument();
+    expect(screen.getByText(/Environment Conservation/i)).toBeInTheDocument();
     expect(screen.getByText('Bolivia')).toBeInTheDocument();
     expect(screen.queryByText(/private/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('TagLine', () => {
+  it('renders tags with proper formatting', () => {
+    const campaigns = [{ name: 'Campaign 1' }, { name: 'Campaign 2' }];
+    const countries = ['Country 1'];
+    const interests = [{ name: 'Interest 1' }, { name: 'Interest 2' }];
+
+    const { container } = render(
+      <ReduxIntlProviders>
+        <TagLine campaigns={campaigns} countries={countries} interests={interests} />
+      </ReduxIntlProviders>,
+    );
+
+    const tagLineElement = container.querySelector('.blue-light');
+    const tagElements = tagLineElement.querySelectorAll('span');
+    expect(tagElements.length).toBe(5);
+    expect(tagElements[0].textContent).toBe('Campaign 1, Campaign 2');
+    expect(tagElements[1].textContent).toBe('·Country 1');
+    expect(tagElements[2].textContent).toBe('·');
+    expect(tagElements[3].textContent).toBe('·Interest 1, Interest 2');
+    expect(tagElements[4].textContent).toBe('·');
+  });
+
+  it('renders tags without bullet separators if there is only one tag', () => {
+    const campaigns = [{ name: 'Campaign 1' }];
+    const countries = [];
+    const interests = [];
+
+    const { container } = render(
+      <ReduxIntlProviders>
+        <TagLine campaigns={campaigns} countries={countries} interests={interests} />
+      </ReduxIntlProviders>,
+    );
+    const tagLineElement = container.querySelector('.blue-light');
+    const tagElements = tagLineElement.querySelectorAll('span');
+    expect(tagElements.length).toBe(1);
+    expect(tagElements[0].textContent).toBe('Campaign 1');
+  });
+
+  it('renders an empty tag line if no tags are provided', () => {
+    const campaigns = [];
+    const countries = [];
+    const interests = [];
+
+    const { container } = render(
+      <ReduxIntlProviders>
+        <TagLine campaigns={campaigns} countries={countries} interests={interests} />
+      </ReduxIntlProviders>,
+    );
+    const tagLineElement = container.querySelector('.blue-light');
+    const tagElements = tagLineElement.querySelectorAll('span');
+    expect(tagElements.length).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #5734 

Changes made:
- The function signature of the TagLine component is updated to include the interests parameter. The rendering logic is also modified to display the interests. Campaigns and interests are now joined with a comma separator, while campaigns, countries, and interests are displayed with an interpunct as the separator.
![interests](https://user-images.githubusercontent.com/51614993/236994316-8d4c938b-e979-4bec-9791-86b67993c386.png)
- Updates tests for the same.