### PR TITLE
Add env variable POSTGRES_TEST_DB for test database name.

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -142,16 +142,13 @@ class EnvironmentConfig:
 
 
 class TestEnvironmentConfig(EnvironmentConfig):
-    POSTGRES_USER = os.getenv("POSTGRES_USER", None)
-    POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD", None)
-    POSTGRES_ENDPOINT = os.getenv("POSTGRES_ENDPOINT", "localhost")
-    POSTGRES_DB = os.getenv("POSTGRES_DB", None)
-    POSTGRES_PORT = os.getenv("POSTGRES_PORT", "5432")
+    POSTGRES_TEST_DB = os.getenv("POSTGRES_TEST_DB", None)
+
     SQLALCHEMY_DATABASE_URI = (
-        f"postgresql://{POSTGRES_USER}"
-        + f":{POSTGRES_PASSWORD}"
-        + f"@{POSTGRES_ENDPOINT}:"
-        + f"{POSTGRES_PORT}"
-        + f"/test_{POSTGRES_DB}"
+        f"postgresql://{EnvironmentConfig.POSTGRES_USER}"
+        + f":{EnvironmentConfig.POSTGRES_PASSWORD}"
+        + f"@{EnvironmentConfig.POSTGRES_ENDPOINT}:"
+        + f"{EnvironmentConfig.POSTGRES_PORT}"
+        + f"/{POSTGRES_TEST_DB}"
     )
     LOG_LEVEL = "DEBUG"

--- a/example.env
+++ b/example.env
@@ -135,6 +135,9 @@ POSTGRES_PASSWORD=tm
 # POSTGRES_ENDPOINT=localhost
 # POSTGRES_PORT=5432
 
+# The postgres database name used for testing (required).
+# All other configurations except the database name are inherited from the main database defined above.
+POSTGRES_TEST_DB=tasking-manager-test
 
 # The address to use as the sender on auto generated emails
 # (optional, but required to send email)


### PR DESCRIPTION
 Use test database name from environment variable instead of adding `test_` ahead of `POSTGRES_DB` variable to improve the maintainability of the code base by reducing redundancy and improving readability.