### PR TITLE
upgrade frontend image to node 16

### DIFF
--- a/scripts/docker/Dockerfile.frontend
+++ b/scripts/docker/Dockerfile.frontend
@@ -1,4 +1,4 @@
-FROM tiangolo/node-frontend:10 as build
+FROM node:16 as build
 
 WORKDIR /usr/src/app/frontend
 COPY frontend .
@@ -12,7 +12,7 @@ RUN npm run build
 
 FROM nginx:stable-alpine
 COPY --from=build /usr/src/app/frontend/build /usr/share/nginx/html
-COPY --from=build /nginx.conf /etc/nginx/conf.d/default.conf
+COPY scripts/docker/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/scripts/docker/nginx.conf
+++ b/scripts/docker/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 80;
+  
+  location / {
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+    try_files $uri $uri/ /index.html =404;
+  }
+  
+  include /etc/nginx/extra-conf.d/*.conf;
+}


### PR DESCRIPTION
Provides an updated image for the frontend using node js 16 official image.
To maintain compatibility with `tiangolo/node-frontend:10` a basic nginx configuration is provided to be copied inside the image.

Related to issue: https://github.com/hotosm/tasking-manager/issues/5659