### PR TITLE
Enable AllowMajorVersionUpgrade flag in RDS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,10 @@ jobs:
         description: "Engine version of PostgreSQL database"
         type: string
         default: "11.19"
+      pg_param_group:
+        description: "Parameter group for RDS PostgreSQL server"
+        type: string
+        default: "tm3-logging-postgres11"
     working_directory: /home/circleci/tasking-manager
     resource_class: medium
     docker:
@@ -428,6 +432,7 @@ workflows:
           stack_name: "staging"
           host_ami: "ami-0fec2c2e2017f4e7b"
           pg_version: "13.7"
+          pg_param_group: "default.postgres13"
           requires:
             - backend-code-check-PEP8
             - backend-code-check-Black

--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -638,6 +638,7 @@ const Resources = {
     },
     Properties: {
         Engine: 'postgres',
+	AllowMajorVersionUpgrade: true,
         DBName: cf.if('UseASnapshot', cf.noValue, cf.ref('PostgresDB')),
         EngineVersion: cf.ref('DatabaseEngineVersion'),
         MasterUsername: cf.if('UseASnapshot', cf.noValue, cf.ref('PostgresUser')),


### PR DESCRIPTION
Enable AllowMajorVersionUpgrade flag in RDS instance to be able to upgrade PostgreSQL engine version from 11.x to 13.x

Additionally, ensure that the right flavour of parameter group is selected for RDS corresponding to the target version