### PR TITLE
Fix PostgreSQL upgrade target minor version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,7 +431,7 @@ workflows:
           gitsha: $CIRCLE_SHA1
           stack_name: "staging"
           host_ami: "ami-0fec2c2e2017f4e7b"
-          pg_version: "13.7"
+          pg_version: "13.10"
           pg_param_group: "default.postgres13"
           requires:
             - backend-code-check-PEP8


### PR DESCRIPTION
AWS RDS PostgreSQL major versions upgrades have to be performed to specific target versions specified in the following link:

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/ USER_UpgradeDBInstance.PostgreSQL.html#USER_UpgradeDBInstance.PostgreSQL.MajorVersion

In compliance with that, this change updates the target version from 13.7 to 13.10