### PR TITLE
Remove OpsGenie Webhook and maintain orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,7 +432,4 @@ workflows:
       - backend-code-check-Black
       - backend-functional-tests
 
-notify:
-  webhooks:
-    - url: https://api.opsgenie.com/v1/json/circleci?apiKey=${OPSGENIE_API}
 


### PR DESCRIPTION
@eternaltyro 

Removing the OpsGenie webhook so that we maintain just the orb.