### PR TITLE
Use idempotent remote control commands for JOSM

### DIFF
--- a/frontend/src/utils/openEditor.js
+++ b/frontend/src/utils/openEditor.js
@@ -135,19 +135,16 @@ function loadTasksBoundaries(project, selectedTasks) {
   const layerName = `Boundary for task${selectedTasks.length > 1 ? 's:' : ':'} ${selectedTasks.join(
     ',',
   )} of TM Project #${project.projectId} - Do not edit or upload`;
-  const emptyTaskLayerParams = {
+  const tmTaskLayerParams = {
     new_layer: true,
     layer_name: layerName,
-    data: '<?xml version="1.0" encoding="utf8"?><osm generator="JOSM" upload="never" version="0.6"></osm>',
-  };
-  const tmTaskLayerParams = {
-    new_layer: false,
+    layer_locked: true,
+    download_policy: "never",
+    upload_policy: "never",
     url: getTaskXmlUrl(project.projectId, selectedTasks).href,
   };
 
-  return callJosmRemoteControl(formatJosmUrl('load_data', emptyTaskLayerParams)).then((result) =>
-    callJosmRemoteControl(formatJosmUrl('import', tmTaskLayerParams)),
-  );
+  return callJosmRemoteControl(formatJosmUrl('import', tmTaskLayerParams));
 }
 
 export function getImageryInfo(url) {
@@ -185,11 +182,6 @@ function loadImageryonJosm(project) {
 }
 
 function loadOsmDataToTasks(project, bbox, newLayer) {
-  const emptyOSMLayerParams = {
-    new_layer: newLayer,
-    layer_name: 'OSM Data',
-    data: '<?xml version="1.0" encoding="utf8"?><osm generator="JOSM" version="0.6"></osm>',
-  };
   const loadAndZoomParams = {
     left: bbox[0],
     bottom: bbox[1],
@@ -197,12 +189,11 @@ function loadOsmDataToTasks(project, bbox, newLayer) {
     top: bbox[3],
     changeset_comment: project.changesetComment,
     changeset_source: project.imagery ? project.imagery : '',
-    new_layer: false,
+    new_layer: newLayer,
+    layer_name: 'OSM Data',
   };
 
-  return callJosmRemoteControl(formatJosmUrl('load_data', emptyOSMLayerParams)).then((result) => {
-    return callJosmRemoteControl(formatJosmUrl('load_and_zoom', loadAndZoomParams));
-  });
+  return callJosmRemoteControl(formatJosmUrl('load_and_zoom', loadAndZoomParams));
 }
 
 export function formatJosmUrl(endpoint, params) {


### PR DESCRIPTION
Right now, there is a race condition when using JOSM remote control.

The TM currently makes the following calls, in order:
1. Import task boundary
 a. Create a new, empty layer with a hardcoded XML (I believe this is for the `upload="never"` option)
 b. Load the boundary into the new layer
2. Load data from OSM
 a. Create a new, empty layer with a hardcoded XML
 b. Load the data from a specified bounding box into JOSM

With the current implementation, the return information from JOSM is not checked. This means that if 2a fails, the OSM data will be loaded into the layer created in 1a. Additionally, if the user changes layers prior to the data load, the data may load into the wrong layer.

Having two sub-steps for either step is unnecessary. For the first, there is an `upload_policy=never` query parameter that can be used, instead of creating a new layer via an XML option. For the second step, there is a `layer_name` query parameter that can be used.

With this patch, I do the following:
1. Import task boundary with the `upload` and `download` policies set to `never`, and with the layer `locked` (this prevents users from moving the boundaries).
2. Load data from OSM (I just collapsed multiple remote control calls to a single call)