### PR TITLE
Add better defaults to backend config.py file

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -16,26 +16,24 @@ class EnvironmentConfig:
     )
 
     # The base url the application is reachable
-    APP_BASE_URL = os.getenv("TM_APP_BASE_URL", "http://127.0.0.1:5000/")
-    if APP_BASE_URL.endswith("/"):
-        APP_BASE_URL = APP_BASE_URL[:-1]
+    APP_BASE_URL = os.getenv("TM_APP_BASE_URL", "http://127.0.0.1:5000/").rstrip("/")
 
     API_VERSION = os.getenv("TM_APP_API_VERSION", "v2")
-    ORG_CODE = os.getenv("TM_ORG_CODE", "")
-    ORG_NAME = os.getenv("TM_ORG_NAME", "")
+    ORG_CODE = os.getenv("TM_ORG_CODE", "HOT")
+    ORG_NAME = os.getenv("TM_ORG_NAME", "Humanitarian OpenStreetMap Team")
     ORG_LOGO = os.getenv(
         "TM_ORG_LOGO",
         "https://cdn.hotosm.org/tasking-manager/uploads/1588741335578_hot-logo.png",
     )
     ENVIRONMENT = os.getenv("TM_ENVIRONMENT", "")
     # The default tag used in the OSM changeset comment
-    DEFAULT_CHANGESET_COMMENT = os.getenv("TM_DEFAULT_CHANGESET_COMMENT", None)
+    DEFAULT_CHANGESET_COMMENT = os.getenv("TM_DEFAULT_CHANGESET_COMMENT", "#hot-tm-stage-project")
 
     # The address to use as the sender on auto generated emails
-    EMAIL_FROM_ADDRESS = os.getenv("TM_EMAIL_FROM_ADDRESS", None)
+    EMAIL_FROM_ADDRESS = os.getenv("TM_EMAIL_FROM_ADDRESS", "noreply@hotosmmail.org")
 
     # The address to use as the receiver in contact form.
-    EMAIL_CONTACT_ADDRESS = os.getenv("TM_EMAIL_CONTACT_ADDRESS", None)
+    EMAIL_CONTACT_ADDRESS = os.getenv("TM_EMAIL_CONTACT_ADDRESS", "sysadmin@hotosm.org")
 
     # A freely definable secret key for connecting the front end with the back end
     SECRET_KEY = os.getenv("TM_SECRET", None)
@@ -47,24 +45,24 @@ class EnvironmentConfig:
     )
 
     # Database connection
-    POSTGRES_USER = os.getenv("POSTGRES_USER", None)
+    POSTGRES_USER = os.getenv("POSTGRES_USER", "postgres")
     POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD", None)
-    POSTGRES_ENDPOINT = os.getenv("POSTGRES_ENDPOINT", "postgresql")
-    POSTGRES_DB = os.getenv("POSTGRES_DB", None)
+    POSTGRES_ENDPOINT = os.getenv("POSTGRES_ENDPOINT", "localhost")
+    POSTGRES_DB = os.getenv("POSTGRES_DB", "postgres")
     POSTGRES_PORT = os.getenv("POSTGRES_PORT", "5432")
 
     # Assamble the database uri
     if os.getenv("TM_DB", False):
         SQLALCHEMY_DATABASE_URI = os.getenv("TM_DB", None)
-    elif os.getenv("TM_DB_CONNECT_PARAM_JSON", False):
+    elif os.getenv("DB_CONNECT_PARAM_JSON", False):
         """
         This section reads JSON formatted Database connection parameters passed
-        from AWS Secrets Manager with the ENVVAR key `TM_DB_CONNECT_PARAM_JSON`
+        from AWS Secrets Manager with the ENVVAR key `DB_CONNECT_PARAM_JSON`
         and forms a valid SQLALCHEMY DATABASE URI
         """
         import json
 
-        _params = json.loads(os.getenv("TM_DB_CONNECT_PARAM_JSON", None))
+        _params = json.loads(os.getenv("DB_CONNECT_PARAM_JSON", None))
         SQLALCHEMY_DATABASE_URI = (
             f"postgresql://{_params.get('username')}"
             + f":{_params.get('password')}"
@@ -94,27 +92,100 @@ class EnvironmentConfig:
 
     # Configuration for sending emails
     MAIL_SERVER = os.getenv("TM_SMTP_HOST", None)
-    MAIL_PORT = os.getenv("TM_SMTP_PORT", None)
-    MAIL_USE_TLS = int(os.getenv("TM_SMTP_USE_TLS", False))
-    MAIL_USE_SSL = int(os.getenv("TM_SMTP_USE_SSL", False))
+    MAIL_PORT = os.getenv("TM_SMTP_PORT", "587")
+    MAIL_USE_TLS = bool(os.getenv("TM_SMTP_USE_TLS", True))
+    MAIL_USE_SSL = bool(os.getenv("TM_SMTP_USE_SSL", False))
     MAIL_USERNAME = os.getenv("TM_SMTP_USER", None)
     MAIL_PASSWORD = os.getenv("TM_SMTP_PASSWORD", None)
-    MAIL_DEFAULT_SENDER = os.getenv("TM_EMAIL_FROM_ADDRESS", None)
+    MAIL_DEFAULT_SENDER = os.getenv("TM_EMAIL_FROM_ADDRESS", "noreply@hotosmmail.org")
     MAIL_DEBUG = True if LOG_LEVEL == "DEBUG" else False
 
+    if os.getenv("SMTP_CREDENTIALS", False):
+        """
+        This section reads JSON formatted SMTP connection parameters passed
+        from AWS Secrets Manager with the ENVVAR key `SMTP_CREDENTIALS`.
+        """
+        import json
+
+        _params = json.loads(os.getenv("SMTP_CREDENTIALS", None))
+        MAIL_SERVER = _params.get("SMTP_HOST", None)
+        MAIL_PORT = _params.get("SMTP_PORT", "587")
+        MAIL_USE_TLS = bool(_params.get("SMTP_USE_TLS", True))
+        MAIL_USE_SSL = bool(_params.get("SMTP_USE_SSL", False))
+        MAIL_USERNAME = _params.get("SMTP_USER", None)
+        MAIL_PASSWORD = _params.get("SMTP_PASSWORD", None)
+
     # If disabled project update emails will not be sent.
-    SEND_PROJECT_EMAIL_UPDATES = int(os.getenv("TM_SEND_PROJECT_EMAIL_UPDATES", True))
+    SEND_PROJECT_EMAIL_UPDATES = bool(os.getenv("TM_SEND_PROJECT_EMAIL_UPDATES", True))
 
     # Languages offered by the Tasking Manager
     # Please note that there must be exactly the same number of Codes as languages.
     SUPPORTED_LANGUAGES = {
         "codes": os.getenv(
             "TM_SUPPORTED_LANGUAGES_CODES",
-            "ar, cs, de, el, en, es, fa_IR, fr, he, hu, id, it, ja, ko, mg, ml, nl_NL, pt, pt_BR, ru, sv, sw, tl, tr, uk, zh_TW",  # noqa
+            ", ".join(
+                [
+                    "ar",
+                    "cs",
+                    "de",
+                    "el",
+                    "en",
+                    "es",
+                    "fa_IR",
+                    "fr",
+                    "he",
+                    "hu",
+                    "id",
+                    "it",
+                    "ja",
+                    "ko",
+                    "mg",
+                    "ml",
+                    "nl_NL",
+                    "pt",
+                    "pt_BR",
+                    "ru",
+                    "sv",
+                    "sw",
+                    "tl",
+                    "tr",
+                    "uk",
+                    "zh_TW",
+                ]
+            ),
         ),
         "languages": os.getenv(
             "TM_SUPPORTED_LANGUAGES",
-            "عربى, Čeština, Deutsch, Ελληνικά, English, Español, فارسی, Français, עברית, Magyar, Indonesia, Italiano, 日本語, 한국어, Malagasy, Malayalam, Nederlands, Português, Português (Brasil), Русский язык, Svenska, Kiswahili, Filipino (Tagalog), Türkçe, Українська, 繁體中文",  # noqa
+            ", ".join(
+                [
+                    "عربى",
+                    "Čeština",
+                    "Deutsch",
+                    "Ελληνικά",
+                    "English",
+                    "Español",
+                    "فارسی",
+                    "Français",
+                    "עברית",
+                    "Magyar",
+                    "Indonesia",
+                    "Italiano",
+                    "日本語",
+                    "한국어",
+                    "Malagasy",
+                    "Malayalam",
+                    "Nederlands",
+                    "Português",
+                    "Português (Brasil)",
+                    "Русский язык",
+                    "Svenska",
+                    "Kiswahili",
+                    "Filipino (Tagalog)",
+                    "Türkçe",
+                    "Українська",
+                    "繁體中文",
+                ]
+            ),
         ),
     }
 
@@ -122,8 +193,21 @@ class EnvironmentConfig:
     OAUTH_API_URL = "{}/api/0.6/".format(OSM_SERVER_URL)
     OAUTH_CLIENT_ID = os.getenv("TM_CLIENT_ID", None)
     OAUTH_CLIENT_SECRET = os.getenv("TM_CLIENT_SECRET", None)
-    OAUTH_SCOPE = os.getenv("TM_SCOPE", None)
+    OAUTH_SCOPE = os.getenv("TM_SCOPE", "read_prefs write_api")
     OAUTH_REDIRECT_URI = os.getenv("TM_REDIRECT_URI", None)
+
+    if os.getenv("OAUTH2_APP_CREDENTIALS", False):
+        """
+        This section reads JSON formatted OAuth2 app credentials passed
+        from AWS Secrets Manager with the ENVVAR key `OAUTH2_APP_CREDENTIALS`.
+        """
+        import json
+
+        _params = json.loads(os.getenv("OAUTH2_APP_CREDENTIALS"), None)
+        OAUTH_CLIENT_ID = _params.get("CLIENT_ID", None)
+        OAUTH_CLIENT_SECRET = _params.get("CLIENT_SECRET", None)
+        OAUTH_REDIRECT_URI = _params.get("REDIRECT_URI", None)
+        OAUTH_SCOPE = _params.get("ACCESS_SCOPE", "read_prefs write_api")
 
     # Some more definitions (not overridable)
     SQLALCHEMY_ENGINE_OPTIONS = {
@@ -136,6 +220,17 @@ class EnvironmentConfig:
     # Image upload Api
     IMAGE_UPLOAD_API_KEY = os.getenv("TM_IMAGE_UPLOAD_API_KEY", None)
     IMAGE_UPLOAD_API_URL = os.getenv("TM_IMAGE_UPLOAD_API_URL", None)
+
+    if os.getenv("IMAGE_UPLOAD_CREDENTIALS", False):
+        """
+        This section reads JSON formatted Image Upload credentials passed
+        from AWS Secrets Manager with the ENVVAR key `IMAGE_UPLOAD_CREDENTIALS`.
+        """
+        import json
+
+        _params = json.loads(os.getenv("IMAGE_UPLOAD_CREDENTIALS"), None)
+        IMAGE_UPLOAD_API_KEY = _params.get("IMAGE_UPLOAD_API_KEY", None)
+        IMAGE_UPLOAD_API_URL = _params.get("IMAGE_UPLOAD_API_URL", None)
 
     # Sentry backend DSN
     SENTRY_BACKEND_DSN = os.getenv("TM_SENTRY_BACKEND_DSN", None)

--- a/example.env
+++ b/example.env
@@ -7,6 +7,7 @@
 # to configure links on emails and some authentication callbacks.
 # On development instances it should be 127.0.0.1:3000 or localhost:3000
 # On production instances, use the public URL of your frontend
+# TM_APP_BASE_URL=https://tasks.hotosm.org
 TM_APP_BASE_URL=http://127.0.0.1:3000
 
 # The TM_APP_API_URL defines the URL of your backend server. It will be used by
@@ -19,17 +20,17 @@ TM_APP_API_URL=http://127.0.0.1:5000
 TM_APP_API_VERSION=v2
 
 # Information about the hosting organization
-TM_ORG_NAME="My organisation"
-TM_ORG_CODE=MYO
+TM_ORG_NAME="Humanitarian OpenStreetMap Team"
+TM_ORG_CODE=HOT
 TM_ORG_LOGO=https://cdn.img.url/logo.png
 # Don't use http or https on the following two variables
 TM_ORG_URL=example.com
-TM_ORG_PRIVACY_POLICY_URL=example.com/privacy
-TM_ORG_TWITTER=http://twitter.com/example/
-TM_ORG_FB=https://www.facebook.com/example
-TM_ORG_INSTAGRAM=https://www.instagram.com/example/
-TM_ORG_YOUTUBE=https://www.youtube.com/user/example
-TM_ORG_GITHUB=https://github.com/example/
+TM_ORG_PRIVACY_POLICY_URL=https://www.hotosm.org/privacy
+TM_ORG_TWITTER=http://twitter.com/hotosm
+TM_ORG_FB=https://www.facebook.com/hotosm
+TM_ORG_INSTAGRAM=https://www.instagram.com/open.mapping.hubs/
+TM_ORG_YOUTUBE=https://www.youtube.com/user/hotosm
+TM_ORG_GITHUB=https://github.com/hotosm
 
 # Information about the OSM server - Customize your server here
 # By default, it's the public OpenStreetMap.org server
@@ -121,14 +122,14 @@ TM_SCOPE=read_prefs write_api
 ####################################################
 # The connection to the postgres database (required)
 #
-# The parameter TM_DB_CONNECT_PARAM_JSON needs to be a JSON string readable by
+# The parameter DB_CONNECT_PARAM_JSON needs to be a JSON string readable by
 # json.loads() with the following keys: "username", "password", "host", "port"
 # and "dbname"
 #
 # If this parameter is set, then individual DB connection parameters are ignored
-# TM_DB_CONNECT_PARAM_JSON='{ "username": "tm", "password": "myprivatesecret", "host": "tm4-database.example.org", "port": "5432", "dbname": "taskingmanager }'
+# DB_CONNECT_PARAM_JSON='{ "username": "tm", "password": "myprivatesecret", "host": "tm4-database.example.org", "port": "5432", "dbname": "taskingmanager }'
 #
-# NOTE: These are ignored if TM_DB_CONNECT_PARAM_JSON is set
+# NOTE: These are ignored if DB_CONNECT_PARAM_JSON is set
 POSTGRES_DB=tasking-manager
 POSTGRES_USER=tm
 POSTGRES_PASSWORD=tm
@@ -201,5 +202,5 @@ TM_DEFAULT_LOCALE=en
 # TM_MAX_AOI_AREA=5000
 
 # Sentry.io DSN Config (optional)
-# TM_SENTRY_BACKEND_DSN=foo
-# TM_SENTRY_FRONTEND_DSN=foo
+# TM_SENTRY_BACKEND_DSN=https://foo.ingest.sentry.io/1234567
+# TM_SENTRY_FRONTEND_DSN=https://bar.ingest.sentry.io/8901234


### PR DESCRIPTION
Add better defaults to make it easy for HOT to deploy Tasking Manager using containers thereby reducing the need to manipulate every environment variable.

Cast flags as bool instead of int wherever appropriate