### PR TITLE
Tests: add missing await for async statements in tests

### DIFF
--- a/frontend/src/components/projectCard/tests/dueDateBox.test.js
+++ b/frontend/src/components/projectCard/tests/dueDateBox.test.js
@@ -28,7 +28,7 @@ describe('test DueDate', () => {
       </ReduxIntlProviders>,
     );
     expect(screen.queryByText('Tooltip works')).not.toBeInTheDocument();
-    userEvent.hover(screen.getByText('5 days left'));
+    await userEvent.hover(screen.getByText('5 days left'));
     await waitFor(() => expect(screen.getByText('Tooltip works')).toBeInTheDocument());
     expect(screen.getByText('Tooltip works')).toBeInTheDocument();
     expect(container.querySelectorAll('span')[0].className).toContain('bg-tan blue-grey');

--- a/frontend/src/components/projects/tests/moreFiltersForm.test.js
+++ b/frontend/src/components/projects/tests/moreFiltersForm.test.js
@@ -55,7 +55,7 @@ describe('MoreFiltersForm', () => {
           },
           parse(router.state.location.search),
         ),
-      ).toEqual({ basedOnMyInterests: 1 }),
+      ).toEqual({ basedOnMyInterests: true }),
     );
   });
 

--- a/frontend/src/components/projects/tests/moreFiltersForm.test.js
+++ b/frontend/src/components/projects/tests/moreFiltersForm.test.js
@@ -47,7 +47,7 @@ describe('MoreFiltersForm', () => {
 
     expect(switchControl).toBeInTheDocument();
     await userEvent.click(switchControl);
-    waitFor(() =>
+    await waitFor(() =>
       expect(
         decodeQueryParams(
           {

--- a/frontend/src/components/taskSelection/tests/footer.test.js
+++ b/frontend/src/components/taskSelection/tests/footer.test.js
@@ -149,7 +149,7 @@ describe('Footer Lock Tasks', () => {
     });
 
   it('should display task cannot be locked for mapping message', async () => {
-    clearReduxStore();
+    await clearReduxStore();
     setupFaultyHandlers();
     createComponentWithMemoryRouter(
       <ReduxIntlProviders>
@@ -172,7 +172,7 @@ describe('Footer Lock Tasks', () => {
   });
 
   it('should display no mapped tasks selected message', async () => {
-    clearReduxStore();
+    await clearReduxStore();
     setupFaultyHandlers();
     createComponentWithMemoryRouter(
       <ReduxIntlProviders>
@@ -198,7 +198,7 @@ describe('Footer Lock Tasks', () => {
   });
 
   it('should display task cannot be locked for validation message', async () => {
-    clearReduxStore();
+    await clearReduxStore();
     setupFaultyHandlers();
     createComponentWithMemoryRouter(
       <ReduxIntlProviders>
@@ -295,7 +295,7 @@ describe('Footer Lock Tasks', () => {
   });
 
   it('should navigate to task action page on validating a task', async () => {
-    clearReduxStore();
+    await clearReduxStore();
     const { router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter
@@ -319,7 +319,7 @@ describe('Footer Lock Tasks', () => {
   });
 
   it('should resume mapping', async () => {
-    clearReduxStore();
+    await clearReduxStore();
     const { router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter
@@ -343,7 +343,7 @@ describe('Footer Lock Tasks', () => {
   });
 
   it('should resume validation', async () => {
-    clearReduxStore();
+    await clearReduxStore();
     const { router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter
@@ -367,7 +367,7 @@ describe('Footer Lock Tasks', () => {
   });
 
   it('should fallback editor when user default is not in the list for validation', async () => {
-    clearReduxStore();
+    await clearReduxStore();
     const { router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter
@@ -391,7 +391,7 @@ describe('Footer Lock Tasks', () => {
   });
 
   it('should fallback editor when user default is not in the list for mapping', async () => {
-    clearReduxStore();
+    await clearReduxStore();
     const { router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter

--- a/frontend/src/views/tests/fallback.test.js
+++ b/frontend/src/views/tests/fallback.test.js
@@ -67,6 +67,6 @@ describe('Fallback component', () => {
       name: messages.return.defaultMessage,
     });
     await userEvent.click(returnBtn);
-    waitFor(() => expect(mockedUsedNavigate).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockedUsedNavigate).toHaveBeenCalledTimes(1));
   });
 });

--- a/frontend/src/views/tests/fallback.test.js
+++ b/frontend/src/views/tests/fallback.test.js
@@ -7,6 +7,18 @@ import { FallbackComponent } from '../fallback';
 import { SERVICE_DESK } from '../../config';
 import messages from '../messages';
 
+/*
+ * This was in "should trigger navigate on return button click". There are
+ * references to some things being hoisted to different locations in Jest
+ * documentation. For whatever reason, we have to mock it here, instead of later
+ * in the test where we actually need to mock it.
+ */
+const mockedUsedNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedUsedNavigate,
+}));
+
 describe('Fallback component', () => {
   it('should render component details', () => {
     renderWithRouter(
@@ -50,13 +62,6 @@ describe('Fallback component', () => {
   });
 
   it('should trigger navigate on return button click', async () => {
-    const mockedUsedNavigate = jest.fn();
-
-    jest.mock('react-router-dom', () => ({
-      ...jest.requireActual('react-router-dom'),
-      useNavigate: () => mockedUsedNavigate,
-    }));
-
     renderWithRouter(
       <IntlProviders>
         <FallbackComponent />

--- a/frontend/src/views/tests/organisationManagement.test.js
+++ b/frontend/src/views/tests/organisationManagement.test.js
@@ -109,8 +109,8 @@ describe('Create Organization', () => {
     await user.type(nameInput, 'New Organization Name');
     const subscriptionType = screen.getByRole('combobox');
     fireEvent.mouseDown(subscriptionType);
-    user.click(screen.getByText('Free'));
-    user.click(createButton);
+    await user.click(screen.getByText('Free'));
+    await user.click(createButton);
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledTimes(1);
       expect(router.state.location.pathname).toBe('/manage/organisations/123');
@@ -125,8 +125,8 @@ describe('Create Organization', () => {
     await user.type(nameInput, 'New Organization Name');
     const subscriptionType = screen.getByRole('combobox');
     fireEvent.mouseDown(subscriptionType);
-    user.click(screen.getByText('Free'));
-    user.click(createButton);
+    await user.click(screen.getByText('Free'));
+    await user.click(createButton);
     await waitFor(() =>
       expect(
         screen.getByText(/Failed to create organization. Please try again./i),


### PR DESCRIPTION
* `waitFor`
* `userEvent`
* `clearReduxStore`

Note: `act` not done since it is only async in newer versions of jest.