### PR TITLE
Frontend Tests: Standardize `userEvent` usage to conform with upstream recomendations

### DIFF
--- a/frontend/src/components/comments/tests/hashtagPaste.test.js
+++ b/frontend/src/components/comments/tests/hashtagPaste.test.js
@@ -1,12 +1,14 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { ReduxIntlProviders } from '../../../utils/testWithIntl';
 import HashtagPaste from '../hashtagPaste';
+import userEvent from '@testing-library/user-event';
 
-test('HashtagPaste with an empty text string', () => {
+test('HashtagPaste with an empty text string', async () => {
   const setFn = jest.fn();
+  const user = userEvent.setup();
   render(
     <ReduxIntlProviders>
       <HashtagPaste text="" setFn={setFn} hashtag="#managers" className="pt2 f6" />
@@ -15,12 +17,13 @@ test('HashtagPaste with an empty text string', () => {
   expect(screen.getByText('#managers').className).toBe('bb pointer pt2 f6');
   expect(screen.getByText('#managers').style.borderBottomStyle).toBe('dashed');
   expect(screen.getByText('#managers').title).toBeTruthy();
-  fireEvent.click(screen.getByText('#managers'));
+  await user.click(screen.getByText('#managers'));
   expect(setFn).toHaveBeenCalledWith('#managers ');
 });
 
-test('HashtagPaste with a text string', () => {
+test('HashtagPaste with a text string', async () => {
   const setFn = jest.fn();
+  const user = userEvent.setup();
   render(
     <ReduxIntlProviders>
       <HashtagPaste text="My comment" setFn={setFn} hashtag="#managers" className="pt2 f6" />
@@ -28,6 +31,6 @@ test('HashtagPaste with a text string', () => {
   );
   expect(screen.getByText('#managers').className).toBe('bb pointer pt2 f6');
   expect(screen.getByText('#managers').style.borderBottomStyle).toBe('dashed');
-  fireEvent.click(screen.getByText('#managers'));
+  await user.click(screen.getByText('#managers'));
   expect(setFn).toHaveBeenCalledWith('My comment #managers');
 });

--- a/frontend/src/components/contributions/tests/myTasksOrderDropdown.test.js
+++ b/frontend/src/components/contributions/tests/myTasksOrderDropdown.test.js
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import MyTasksOrderDropdown from '../myTasksOrderDropdown';
 import { IntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
@@ -8,7 +7,7 @@ import { IntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
 describe('MyTasksOrderDropdown', () => {
   const setQueryMock = jest.fn();
   const setup = async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <IntlProviders>
         <MyTasksOrderDropdown
           allQueryParams={{
@@ -27,7 +26,8 @@ describe('MyTasksOrderDropdown', () => {
     const dropdownBtn = screen.getByRole('button', {
       name: /sort by/i,
     });
-    await userEvent.click(dropdownBtn);
+    await user.click(dropdownBtn);
+    return { user };
   };
 
   it('displays dropdown options after button is clicked', async () => {
@@ -37,8 +37,8 @@ describe('MyTasksOrderDropdown', () => {
   });
 
   it('should set query when an option is selected', async () => {
-    await setup();
-    await userEvent.click(screen.getByText(/recently edited/i));
+    const { user } = await setup();
+    await user.click(screen.getByText(/recently edited/i));
     expect(setQueryMock).toHaveBeenCalled();
   });
 

--- a/frontend/src/components/contributions/tests/taskCard.test.js
+++ b/frontend/src/components/contributions/tests/taskCard.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { ReduxIntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
@@ -8,7 +7,7 @@ import { TaskCard } from '../taskCard';
 
 describe('TaskCard', () => {
   it('on MAPPED state with comments', () => {
-    const { container } = renderWithRouter(
+    const { user, container } = renderWithRouter(
       <ReduxIntlProviders>
         <TaskCard
           taskId={987}
@@ -28,12 +27,12 @@ describe('TaskCard', () => {
     expect(container.querySelectorAll('svg').length).toBe(2);
     expect(screen.queryByText('Resume task')).not.toBeInTheDocument();
     // hovering on the card should not change anything
-    userEvent.hover(screen.getByText('Ready for validation'));
+    user.hover(screen.getByText('Ready for validation'));
     expect(screen.queryByText('Resume task')).not.toBeInTheDocument();
   });
 
   it('on VALIDATED state without comments', () => {
-    const { container } = renderWithRouter(
+    const { user, container } = renderWithRouter(
       <ReduxIntlProviders>
         <TaskCard
           taskId={987}
@@ -51,12 +50,12 @@ describe('TaskCard', () => {
     expect(screen.queryByText('0')).not.toBeInTheDocument();
     expect(container.querySelectorAll('svg').length).toBe(1);
     // hovering on the card should not change anything
-    userEvent.hover(screen.getByText('Finished'));
+    user.hover(screen.getByText('Finished'));
     expect(screen.queryByText('Resume task')).not.toBeInTheDocument();
   });
 
   it('on BADIMAGERY state', () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <TaskCard
           taskId={987}
@@ -71,12 +70,12 @@ describe('TaskCard', () => {
     expect(screen.getByText('Unavailable')).toBeInTheDocument();
     expect(screen.queryByText('Resume task')).not.toBeInTheDocument();
     // hovering on the card should not change anything
-    userEvent.hover(screen.getByText('Unavailable'));
+    user.hover(screen.getByText('Unavailable'));
     expect(screen.queryByText('Resume task')).not.toBeInTheDocument();
   });
 
-  it('on LOCKED_FOR_VALIDATION state', () => {
-    const { container } = renderWithRouter(
+  it('on LOCKED_FOR_VALIDATION state', async () => {
+    const { user, container } = renderWithRouter(
       <ReduxIntlProviders>
         <TaskCard
           taskId={987}
@@ -92,13 +91,13 @@ describe('TaskCard', () => {
     expect(screen.getByText('Locked for validation by user_1')).toBeInTheDocument();
     expect(screen.queryByText('Resume task')).not.toBeInTheDocument();
     // hovering on the card should show the resume task button
-    fireEvent.mouseOver(screen.getByText('Locked for validation by user_1'));
+    await user.hover(screen.getByText('Locked for validation by user_1'));
     expect(screen.getByText('Resume task')).toBeInTheDocument();
     expect(container.querySelectorAll('a')[1].href).toContain('/projects/4321/tasks?search=987');
   });
 
-  it('on INVALIDATED state', () => {
-    renderWithRouter(
+  it('on INVALIDATED state', async () => {
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <TaskCard
           taskId={987}
@@ -112,12 +111,12 @@ describe('TaskCard', () => {
     expect(screen.getByText('More mapping needed')).toBeInTheDocument();
     expect(screen.queryByText('Resume task')).not.toBeInTheDocument();
     // hovering on the card should show the resume task button
-    fireEvent.mouseOver(screen.getByText('More mapping needed'));
+    await user.hover(screen.getByText('More mapping needed'));
     expect(screen.getByText('Resume task')).toBeInTheDocument();
   });
 
-  it('on READY state', () => {
-    const { container } = renderWithRouter(
+  it('on READY state', async () => {
+    const { user, container } = renderWithRouter(
       <ReduxIntlProviders>
         <TaskCard
           taskId={543}
@@ -134,14 +133,14 @@ describe('TaskCard', () => {
     expect(screen.getByText('Available for mapping')).toBeInTheDocument();
     expect(screen.queryByText('Resume task')).not.toBeInTheDocument();
     // hover on the card
-    fireEvent.mouseOver(screen.getByText('Available for mapping'));
+    await user.hover(screen.getByText('Available for mapping'));
     expect(screen.getByText('Resume task')).toBeInTheDocument();
     expect(screen.getByText('Resume task').className).toBe(
       'dn dib-l link pv2 ph3 mh3 mv1 bg-red white f7 fr',
     );
     expect(container.querySelectorAll('a')[1].href).toContain('/projects/9983/tasks?search=543');
     // unhover
-    fireEvent.mouseOut(screen.getByText('Available for mapping'));
+    await user.unhover(screen.getByText('Available for mapping'));
     expect(screen.queryByText('Resume task')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/contributions/tests/taskCard.test.js
+++ b/frontend/src/components/contributions/tests/taskCard.test.js
@@ -6,7 +6,7 @@ import { ReduxIntlProviders, renderWithRouter } from '../../../utils/testWithInt
 import { TaskCard } from '../taskCard';
 
 describe('TaskCard', () => {
-  it('on MAPPED state with comments', () => {
+  it('on MAPPED state with comments', async () => {
     const { user, container } = renderWithRouter(
       <ReduxIntlProviders>
         <TaskCard
@@ -27,11 +27,11 @@ describe('TaskCard', () => {
     expect(container.querySelectorAll('svg').length).toBe(2);
     expect(screen.queryByText('Resume task')).not.toBeInTheDocument();
     // hovering on the card should not change anything
-    user.hover(screen.getByText('Ready for validation'));
+    await user.hover(screen.getByText('Ready for validation'));
     expect(screen.queryByText('Resume task')).not.toBeInTheDocument();
   });
 
-  it('on VALIDATED state without comments', () => {
+  it('on VALIDATED state without comments', async () => {
     const { user, container } = renderWithRouter(
       <ReduxIntlProviders>
         <TaskCard
@@ -50,11 +50,11 @@ describe('TaskCard', () => {
     expect(screen.queryByText('0')).not.toBeInTheDocument();
     expect(container.querySelectorAll('svg').length).toBe(1);
     // hovering on the card should not change anything
-    user.hover(screen.getByText('Finished'));
+    await user.hover(screen.getByText('Finished'));
     expect(screen.queryByText('Resume task')).not.toBeInTheDocument();
   });
 
-  it('on BADIMAGERY state', () => {
+  it('on BADIMAGERY state', async () => {
     const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <TaskCard
@@ -70,7 +70,7 @@ describe('TaskCard', () => {
     expect(screen.getByText('Unavailable')).toBeInTheDocument();
     expect(screen.queryByText('Resume task')).not.toBeInTheDocument();
     // hovering on the card should not change anything
-    user.hover(screen.getByText('Unavailable'));
+    await user.hover(screen.getByText('Unavailable'));
     expect(screen.queryByText('Resume task')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/contributions/tests/taskResults.test.js
+++ b/frontend/src/components/contributions/tests/taskResults.test.js
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import { IntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
 import { userTasks } from '../../../network/tests/mockData/tasksStats';
@@ -19,7 +18,7 @@ describe('Task Results Component', () => {
 
   it('should prompt user to retry on failure to fetch tasks', async () => {
     const retryFnMock = jest.fn();
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <IntlProviders>
         <TaskResults state={{ isError: true, isLoading: false, tasks: [] }} retryFn={retryFnMock} />
       </IntlProviders>,
@@ -29,7 +28,7 @@ describe('Task Results Component', () => {
       name: messages.retry.defaultMessage,
     });
     expect(retryBtn).toBeInTheDocument();
-    await userEvent.click(retryBtn);
+    await user.click(retryBtn);
     expect(retryFnMock).toHaveBeenCalled();
   });
 

--- a/frontend/src/components/deleteModal/tests/index.test.js
+++ b/frontend/src/components/deleteModal/tests/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import {
@@ -12,7 +12,7 @@ import { DeleteModal } from '../index';
 
 describe('Delete Interest', () => {
   const setup = () => {
-    const { history } = renderWithRouter(
+    const { user, history } = renderWithRouter(
       <ReduxIntlProviders>
         <DeleteModal id={interest.id} name={interest.name} type="interests" />
       </ReduxIntlProviders>,
@@ -22,24 +22,25 @@ describe('Delete Interest', () => {
     });
 
     return {
+      user,
       deleteButton,
       history,
     };
   };
 
-  it('should ask for confirmation when user tries to delete an interest', () => {
-    const { deleteButton } = setup();
-    fireEvent.click(deleteButton);
+  it('should ask for confirmation when user tries to delete an interest', async () => {
+    const { user, deleteButton } = setup();
+    await user.click(deleteButton);
     expect(screen.getByText('Are you sure you want to delete this category?')).toBeInTheDocument();
   });
 
-  it('should close the confirmation popup when cancel is clicked', () => {
-    const { deleteButton } = setup();
-    fireEvent.click(deleteButton);
+  it('should close the confirmation popup when cancel is clicked', async () => {
+    const { user, deleteButton } = setup();
+    await user.click(deleteButton);
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
-    fireEvent.click(cancelButton);
+    await user.click(cancelButton);
     expect(
       screen.queryByRole('heading', {
         name: 'Are you sure you want to delete this category?',
@@ -48,7 +49,7 @@ describe('Delete Interest', () => {
   });
 
   it('should direct to passed type list page on successful deletion of an interest', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <DeleteModal id={interest.id} name={interest.name} type="campaigns" />
       </ReduxIntlProviders>,
@@ -58,12 +59,12 @@ describe('Delete Interest', () => {
       name: 'Delete',
     });
 
-    fireEvent.click(deleteButton);
+    await user.click(deleteButton);
     const dialog = screen.getByRole('dialog');
     const deleteConfirmationButton = within(dialog).getByRole('button', {
       name: /delete/i,
     });
-    fireEvent.click(deleteConfirmationButton);
+    await user.click(deleteConfirmationButton);
     expect(
       await screen.findByRole('heading', { name: /campaign deleted successfully./i }),
     ).toBeInTheDocument();
@@ -71,7 +72,7 @@ describe('Delete Interest', () => {
   });
 
   it('should direct to categories list page on successful deletion of an interest', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <DeleteModal id={interest.id} name={interest.name} type="interests" />
       </ReduxIntlProviders>,
@@ -81,12 +82,12 @@ describe('Delete Interest', () => {
       name: 'Delete',
     });
 
-    fireEvent.click(deleteButton);
+    await user.click(deleteButton);
     const dialog = screen.getByRole('dialog');
     const deleteConfirmationButton = within(dialog).getByRole('button', {
       name: /delete/i,
     });
-    fireEvent.click(deleteConfirmationButton);
+    await user.click(deleteConfirmationButton);
     expect(
       await screen.findByRole('heading', { name: /interest deleted successfully./i }),
     ).toBeInTheDocument();

--- a/frontend/src/components/header/tests/authButtons.test.js
+++ b/frontend/src/components/header/tests/authButtons.test.js
@@ -1,12 +1,14 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { ReduxIntlProviders } from '../../../utils/testWithIntl';
 import { AuthButtons } from '../index';
+import userEvent from '@testing-library/user-event';
 
 describe('AuthButtons', () => {
-  it('without alternativeSignUpText', () => {
+  it('without alternativeSignUpText', async () => {
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <AuthButtons
@@ -20,12 +22,13 @@ describe('AuthButtons', () => {
     expect(screen.getByText('Sign up').className).toContain('bg-blue-dark white ml1 v-mid');
     expect(screen.queryByText('Create an account')).not.toBeInTheDocument();
     expect(screen.queryByText('Name')).not.toBeInTheDocument();
-    fireEvent.click(screen.getByText('Sign up'));
+    await user.click(screen.getByText('Sign up'));
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText('Email')).toBeInTheDocument();
     expect(screen.getByText('Next')).toBeInTheDocument();
   });
-  it('with alternativeSignUpText', () => {
+  it('with alternativeSignUpText', async () => {
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <AuthButtons
@@ -40,7 +43,7 @@ describe('AuthButtons', () => {
     expect(screen.getByText('Create an account').className).toContain('bg-orange black ml1 v-mid');
     expect(screen.queryByText('Sign up')).not.toBeInTheDocument();
     expect(screen.queryByText('Name')).not.toBeInTheDocument();
-    fireEvent.click(screen.getByText('Create an account'));
+    await user.click(screen.getByText('Create an account'));
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText('Email')).toBeInTheDocument();
     expect(screen.getByText('Next')).toBeInTheDocument();

--- a/frontend/src/components/header/tests/index.test.js
+++ b/frontend/src/components/header/tests/index.test.js
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom';
-import userEvent from '@testing-library/user-event';
 import { screen, fireEvent, act, within, waitFor, render } from '@testing-library/react';
 
 import '../../../utils/mockMatchMedia';
@@ -11,11 +10,13 @@ import { store } from '../../../store';
 
 describe('Header', () => {
   const setup = () => {
-    renderWithRouter(
-      <ReduxIntlProviders>
-        <Header />
-      </ReduxIntlProviders>,
-    );
+    return {
+      ...renderWithRouter(
+        <ReduxIntlProviders>
+          <Header />
+        </ReduxIntlProviders>,
+      ),
+    };
   };
 
   it('should render component details', () => {
@@ -78,8 +79,8 @@ describe('Header', () => {
   });
 
   it('should display menu when burger menu icon is clicked', async () => {
-    setup();
-    await userEvent.click(
+    const { user } = setup();
+    await user.click(
       screen.getByRole('button', {
         name: /menu/i,
       }),
@@ -169,8 +170,8 @@ describe('Dropdown menu of logged in user', () => {
         userDetails: { username: 'somebody' },
       });
     });
-    setup();
-    await userEvent.click(screen.getByText('somebody'));
+    const { user } = setup();
+    await user.click(screen.getByText('somebody'));
   });
 
   it('should log the user out', async () => {
@@ -180,10 +181,10 @@ describe('Dropdown menu of logged in user', () => {
         userDetails: { username: 'somebody' },
       });
     });
-    setup();
-    await userEvent.click(screen.getByText('somebody'));
+    const { user } = setup();
+    await user.click(screen.getByText('somebody'));
     // screen.getByRole('')
-    await userEvent.click(screen.getByText(/Logout/i));
+    await user.click(screen.getByText(/Logout/i));
     await waitFor(() =>
       expect(
         screen.getByRole('button', {
@@ -298,7 +299,7 @@ describe('PopupItems Component', () => {
   });
 
   it('should log the user out', async () => {
-    const { rerender } = renderWithRouter(
+    const { user, rerender } = renderWithRouter(
       <ReduxIntlProviders>
         <PopupItems
           menuItems={getMenuItemsForUser({ username: 'somebody', role: 'ADMIN' })}
@@ -309,7 +310,6 @@ describe('PopupItems Component', () => {
     const logoutBtn = screen.getByRole('button', {
       name: /logout/i,
     });
-    const user = userEvent.setup();
     await user.click(logoutBtn);
     rerender(
       <ReduxIntlProviders>

--- a/frontend/src/components/header/tests/notificationBell.test.js
+++ b/frontend/src/components/header/tests/notificationBell.test.js
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { act, screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import '../../../utils/mockMatchMedia';
 import { store } from '../../../store';
@@ -31,7 +30,7 @@ describe('Notification Bell', () => {
   });
 
   it('should clear unread notification count when bell icon is clicked', async () => {
-    const { container } = renderWithRouter(
+    const { user, container } = renderWithRouter(
       <ReduxIntlProviders>
         <NotificationBell />
       </ReduxIntlProviders>,
@@ -41,7 +40,7 @@ describe('Notification Bell', () => {
     await waitFor(() => {
       expect(container.getElementsByClassName('redicon')[0]).toBeInTheDocument();
     });
-    await userEvent.click(within(screen.getAllByRole('link')[0]).getByLabelText(/notifications/i));
+    await user.click(within(screen.getAllByRole('link')[0]).getByLabelText(/notifications/i));
     await waitFor(() => {
       expect(container.querySelector('redicon')).not.toBeInTheDocument();
     });

--- a/frontend/src/components/header/tests/signUp.test.js
+++ b/frontend/src/components/header/tests/signUp.test.js
@@ -10,12 +10,13 @@ import { ORG_PRIVACY_POLICY_URL } from '../../../config';
 describe('Sign Up Form', () => {
   it('should close the sign up popup when close icon is clicked', async () => {
     const closeModalMock = jest.fn();
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <SignUp closeModal={closeModalMock} />
       </IntlProviders>,
     );
-    await userEvent.click(screen.getByLabelText(/close popup/i));
+    await user.click(screen.getByLabelText(/close popup/i));
     expect(closeModalMock).toHaveBeenCalled();
   });
 
@@ -62,12 +63,12 @@ describe('Sign Up Form', () => {
   });
 
   it('should proceed to step two when expected inputs are fulfilled', async () => {
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <SignUp />
       </IntlProviders>,
     );
-    const user = userEvent.setup();
     await user.type(
       screen.getByPlaceholderText(messages.namePlaceHolder.defaultMessage),
       'My Name',
@@ -107,12 +108,12 @@ describe('Sign Up Form', () => {
 
 describe('Proceed OSM form', () => {
   const setup = async () => {
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <SignUp />
       </IntlProviders>,
     );
-    const user = userEvent.setup();
     await user.type(
       screen.getByPlaceholderText(messages.namePlaceHolder.defaultMessage),
       'My Name',
@@ -127,6 +128,7 @@ describe('Proceed OSM form', () => {
       }),
     );
     expect(await screen.findByText('Do you have an OpenStreetMap account?')).toBeInTheDocument();
+    return { user };
   };
 
   it('should render component details', async () => {
@@ -148,8 +150,8 @@ describe('Proceed OSM form', () => {
 
   it('should open OSM login window', async () => {
     global.open = jest.fn();
-    await setup();
-    await userEvent.click(
+    const { user } = await setup();
+    await user.click(
       screen.getByRole('button', {
         name: messages.submitProceedOSM.defaultMessage,
       }),
@@ -160,6 +162,7 @@ describe('Proceed OSM form', () => {
   it('should execute login prop when user already has an account', async () => {
     const setStepMock = jest.fn();
     const loginMock = jest.fn();
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <ProceedOSM
@@ -170,7 +173,7 @@ describe('Proceed OSM form', () => {
         />
       </IntlProviders>,
     );
-    await userEvent.click(screen.getByText(messages.proceedOSMLogin.defaultMessage));
+    await user.click(screen.getByText(messages.proceedOSMLogin.defaultMessage));
     expect(loginMock).toHaveBeenCalled();
   });
 });
@@ -202,12 +205,13 @@ describe('LoginModal component', () => {
   });
 
   it('should execute the login prop', async () => {
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <LoginModal step={{ number: 3 }} login={loginMock} />
       </IntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /log in/i,
       }),

--- a/frontend/src/components/header/tests/updateDialog.test.js
+++ b/frontend/src/components/header/tests/updateDialog.test.js
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { screen, fireEvent } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import messages from '../messages';
 import { UpdateDialog } from '../updateDialog';
@@ -57,7 +56,7 @@ describe('Update Dialog', () => {
   });
 
   it('should update the service worker', async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <IntlProviders>
         <UpdateDialog />
       </IntlProviders>,
@@ -75,7 +74,7 @@ describe('Update Dialog', () => {
         addEventListener: jest.fn(),
       },
     });
-    await userEvent.click(screen.getByRole('button', { name: /refresh/i }));
+    await user.click(screen.getByRole('button', { name: /refresh/i }));
     expect(postMessageMock).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/header/tests/updateEmail.test.js
+++ b/frontend/src/components/header/tests/updateEmail.test.js
@@ -10,11 +10,14 @@ import { ORG_PRIVACY_POLICY_URL } from '../../../config';
 describe('Update Email Dialog', () => {
   const closeModalMock = jest.fn();
   const setup = () => {
-    render(
-      <ReduxIntlProviders>
-        <UpdateEmail closeModal={closeModalMock} />
-      </ReduxIntlProviders>,
-    );
+    return {
+      user: userEvent.setup(),
+      ...render(
+        <ReduxIntlProviders>
+          <UpdateEmail closeModal={closeModalMock} />
+        </ReduxIntlProviders>,
+      ),
+    };
   };
   it('should render component details', () => {
     setup();
@@ -50,8 +53,8 @@ describe('Update Email Dialog', () => {
   });
 
   it('should update user email', async () => {
-    setup();
-    await userEvent.click(
+    const { user } = setup();
+    await user.click(
       screen.getByRole('button', {
         name: /update/i,
       }),
@@ -62,12 +65,9 @@ describe('Update Email Dialog', () => {
   });
 
   it('should update email text', async () => {
-    setup();
+    const { user } = setup();
 
-    await userEvent.type(
-      screen.getByPlaceholderText(messages.emailPlaceholder.defaultMessage),
-      'meow',
-    );
+    await user.type(screen.getByPlaceholderText(messages.emailPlaceholder.defaultMessage), 'meow');
     expect(screen.getByPlaceholderText(messages.emailPlaceholder.defaultMessage)).toHaveValue(
       'meow',
     );

--- a/frontend/src/components/interests/tests/index.test.js
+++ b/frontend/src/components/interests/tests/index.test.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { IntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
 import { InterestsManagement } from '../index';
 
@@ -62,7 +62,7 @@ describe('InterestsManagement component', () => {
   });
 
   it('filters interests list by the search query', async () => {
-    const { container } = renderWithRouter(
+    const { user, container } = renderWithRouter(
       <IntlProviders>
         <InterestsManagement interests={dummyInterests} isInterestsFetched={true} />
       </IntlProviders>,
@@ -73,11 +73,8 @@ describe('InterestsManagement component', () => {
       expect(screen.getByText(/Interest 1/i));
     });
     expect(container.querySelectorAll('svg').length).toBe(5);
-    fireEvent.change(textField, {
-      target: {
-        value: 2,
-      },
-    });
+    await user.clear(textField);
+    await user.type(textField, '2');
     expect(screen.getByText(/Interest 2/i)).toBeInTheDocument();
     expect(screen.queryByText(/Interest 1/i)).not.toBeInTheDocument();
   });

--- a/frontend/src/components/notifications/tests/actionButtons.test.js
+++ b/frontend/src/components/notifications/tests/actionButtons.test.js
@@ -31,6 +31,7 @@ describe('Action Buttons', () => {
   });
 
   it('should decrement unread count in redux store if all notifications are not selected upon marking notifications as read', async () => {
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <ActionButtons
@@ -44,7 +45,7 @@ describe('Action Buttons', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /mark as read/i,
       }),
@@ -55,6 +56,7 @@ describe('Action Buttons', () => {
   });
 
   it('should fetch unread count if all notifications are selected upon marking notifications as read', async () => {
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <ActionButtons
@@ -67,7 +69,7 @@ describe('Action Buttons', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /mark as read/i,
       }),
@@ -78,6 +80,7 @@ describe('Action Buttons', () => {
   });
 
   it('should decrement unread count in redux store if all notifications are not selected upon deleting notifications', async () => {
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <ActionButtons
@@ -92,7 +95,7 @@ describe('Action Buttons', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /delete/i,
       }),
@@ -103,6 +106,7 @@ describe('Action Buttons', () => {
   });
 
   it('should fetch unread count if all notifications are selected upon deleting notifications', async () => {
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <ActionButtons
@@ -115,7 +119,7 @@ describe('Action Buttons', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /delete/i,
       }),
@@ -128,6 +132,7 @@ describe('Action Buttons', () => {
   // Error are consoled in all cases of POST error
   it('should catch error when marking multiple selected notifications as read', async () => {
     setupFaultyHandlers();
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <ActionButtons
@@ -141,7 +146,7 @@ describe('Action Buttons', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /mark as read/i,
       }),
@@ -151,6 +156,7 @@ describe('Action Buttons', () => {
 
   it('should catch error when marking all notifications in a category as read', async () => {
     setupFaultyHandlers();
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <ActionButtons
@@ -163,7 +169,7 @@ describe('Action Buttons', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /mark as read/i,
       }),
@@ -174,6 +180,7 @@ describe('Action Buttons', () => {
   it('should catch error when deleting multiple selected notifications', async () => {
     act(() => {});
     setupFaultyHandlers();
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <ActionButtons
@@ -187,7 +194,7 @@ describe('Action Buttons', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /delete/i,
       }),
@@ -197,6 +204,7 @@ describe('Action Buttons', () => {
 
   it('should catch error when deleting all notifications in a category', async () => {
     setupFaultyHandlers();
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <ActionButtons
@@ -209,7 +217,7 @@ describe('Action Buttons', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /delete/i,
       }),

--- a/frontend/src/components/notifications/tests/notificationCard.test.js
+++ b/frontend/src/components/notifications/tests/notificationCard.test.js
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { screen, waitFor, render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import { MessageAvatar, NotificationCard, NotificationCardMini } from '../notificationCard';
 import { ReduxIntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
@@ -22,7 +21,7 @@ describe('Message Avatar', () => {
 describe('Notification Card', () => {
   const fetchNotificationsMock = jest.fn();
   it('should mark the notification as read', async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <NotificationCard
           {...notifications.userMessages[0]}
@@ -32,7 +31,7 @@ describe('Notification Card', () => {
       </ReduxIntlProviders>,
     );
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /Mark notification as read/i,
       }),
@@ -42,7 +41,7 @@ describe('Notification Card', () => {
 
   it('should delete the notification', async () => {
     const setSelectedMock = jest.fn();
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <NotificationCard
           {...notifications.userMessages[0]}
@@ -53,7 +52,7 @@ describe('Notification Card', () => {
       </ReduxIntlProviders>,
     );
 
-    await userEvent.click(screen.getAllByRole('button')[1]);
+    await user.click(screen.getAllByRole('button')[1]);
     await waitFor(() => {
       expect(fetchNotificationsMock).toHaveBeenCalledTimes(1);
     });
@@ -62,7 +61,7 @@ describe('Notification Card', () => {
   it('should catch error on deletion error', async () => {
     setupFaultyHandlers();
     const setSelectedMock = jest.fn();
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <NotificationCard
           {...notifications.userMessages[0]}
@@ -73,7 +72,7 @@ describe('Notification Card', () => {
       </ReduxIntlProviders>,
     );
 
-    await userEvent.click(screen.getAllByRole('button')[1]);
+    await user.click(screen.getAllByRole('button')[1]);
     // Error is then consoled
     expect(fetchNotificationsMock).not.toHaveBeenCalled();
   });
@@ -81,7 +80,7 @@ describe('Notification Card', () => {
   it('should open any links in the notification message', async () => {
     global.open = jest.fn();
     const setSelectedMock = jest.fn();
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <NotificationCard
           {...notifications.userMessages[0]}
@@ -91,7 +90,7 @@ describe('Notification Card', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('link', {
         name: 'Sample Team',
       }),
@@ -103,7 +102,7 @@ describe('Notification Card', () => {
     global.open = jest.fn();
 
     const setSelectedMock = jest.fn();
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <NotificationCard
           {...notifications.userMessages[0]}
@@ -113,7 +112,7 @@ describe('Notification Card', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(screen.getByText(/requested to join/i));
+    await user.click(screen.getByText(/requested to join/i));
     // Awaiting portion of the notification message inside the dialog
     await waitFor(() =>
       expect(
@@ -126,18 +125,18 @@ describe('Notification Card', () => {
 describe('Notification Card Mini', () => {
   it('should refetch notifications on closing the dialog', async () => {
     const fetchNotificationsMock = jest.fn();
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <NotificationCardMini {...notifications.userMessages[0]} retryFn={fetchNotificationsMock} />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(screen.getByRole('article'));
+    await user.click(screen.getByRole('article'));
     await waitFor(() =>
       expect(
         screen.getByText(/Access the team management page to accept or reject that request./i),
       ).toBeInTheDocument(),
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /close/i,
       }),

--- a/frontend/src/components/notifications/tests/notificationResults.test.js
+++ b/frontend/src/components/notifications/tests/notificationResults.test.js
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import { ReduxIntlProviders, createComponentWithMemoryRouter } from '../../../utils/testWithIntl';
 import { NotificationResults, NotificationResultsMini } from '../notificationResults';
@@ -10,7 +9,7 @@ import messages from '../messages';
 describe('Mini Notification Results', () => {
   it('should display the refresh button', async () => {
     const retryFnMock = jest.fn();
-    createComponentWithMemoryRouter(
+    const { user } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <NotificationResultsMini notifications={notifications} retryFn={retryFnMock} />
       </ReduxIntlProviders>,
@@ -18,7 +17,7 @@ describe('Mini Notification Results', () => {
     const refreshBtn = screen.getByRole('button', {
       name: /refresh/i,
     });
-    await userEvent.click(refreshBtn);
+    await user.click(refreshBtn);
     expect(retryFnMock).toHaveBeenCalledTimes(1);
   });
 
@@ -44,7 +43,7 @@ describe('Notifications Results', () => {
 
   it('should fetch for notifications on clicking the try again button', async () => {
     const retryFnMock = jest.fn();
-    createComponentWithMemoryRouter(
+    const { user } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <NotificationResults
           notifications={notifications}
@@ -57,7 +56,7 @@ describe('Notifications Results', () => {
     const retryBtn = screen.getByRole('button', {
       name: /try again/i,
     });
-    await userEvent.click(retryBtn);
+    await user.click(retryBtn);
     expect(retryFnMock).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/components/notifications/tests/selectAllNotifications.test.js
+++ b/frontend/src/components/notifications/tests/selectAllNotifications.test.js
@@ -8,12 +8,13 @@ import { IntlProviders } from '../../../utils/testWithIntl';
 describe('Action Buttons (Mark as read and Deletion)', () => {
   it('should select all notifications under a category', async () => {
     const setIsAllSelectedMock = jest.fn();
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <SelectAllNotifications setIsAllSelected={setIsAllSelectedMock} />
       </IntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /select all notifications/i,
       }),
@@ -23,12 +24,13 @@ describe('Action Buttons (Mark as read and Deletion)', () => {
 
   it('should empty selection upon clearing them', async () => {
     const setSelectedMock = jest.fn();
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <SelectAllNotifications isAllSelected setSelected={setSelectedMock} />
       </IntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /clear selection/i,
       }),

--- a/frontend/src/components/projectCard/tests/dueDateBox.test.js
+++ b/frontend/src/components/projectCard/tests/dueDateBox.test.js
@@ -22,13 +22,14 @@ describe('test DueDate', () => {
   it('with tooltip message', async () => {
     // five days of milliseconds plus a few seconds for the test
     const fiveDaysOut = 5 * 86400 * 1000 + 10000 + Date.now();
+    const user = userEvent.setup();
     const { container } = render(
       <ReduxIntlProviders>
         <DueDateBox dueDate={fiveDaysOut} tooltipMsg="Tooltip works" />
       </ReduxIntlProviders>,
     );
     expect(screen.queryByText('Tooltip works')).not.toBeInTheDocument();
-    await userEvent.hover(screen.getByText('5 days left'));
+    await user.hover(screen.getByText('5 days left'));
     await waitFor(() => expect(screen.getByText('Tooltip works')).toBeInTheDocument());
     expect(screen.getByText('Tooltip works')).toBeInTheDocument();
     expect(container.querySelectorAll('span')[0].className).toContain('bg-tan blue-grey');

--- a/frontend/src/components/projectCreate/tests/projectsAOILayerCheckBox.test.js
+++ b/frontend/src/components/projectCreate/tests/projectsAOILayerCheckBox.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 
@@ -7,7 +7,8 @@ import { IntlProviders } from '../../../utils/testWithIntl';
 
 describe('ProjectsAOILayerCheckBox', () => {
   const testFn = jest.fn();
-  it('with disabled property', () => {
+  it('with disabled property', async () => {
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <ProjectsAOILayerCheckBox isActive={false} setActive={testFn} disabled={true} />
@@ -16,16 +17,17 @@ describe('ProjectsAOILayerCheckBox', () => {
     expect(screen.getByText('Show existing projects AoIs')).toBeInTheDocument();
     expect(screen.getByRole('checkbox').className).toContain('b--grey-light');
     expect(screen.getByRole('checkbox').className).not.toContain('b--red');
-    userEvent.hover(screen.getByText('Show existing projects AoIs'));
+    await user.hover(screen.getByText('Show existing projects AoIs'));
     expect(
       screen.getByText(
         "Zoom in to be able to activate the visualization of other projects' areas of interest.",
       ),
     ).toBeInTheDocument();
-    userEvent.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('checkbox'));
     expect(testFn).not.toHaveBeenCalled();
   });
-  it('with disabled=false property', () => {
+  it('with disabled=false property', async () => {
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <ProjectsAOILayerCheckBox isActive={false} setActive={testFn} disabled={false} />
@@ -34,11 +36,11 @@ describe('ProjectsAOILayerCheckBox', () => {
     expect(screen.getByText('Show existing projects AoIs')).toBeInTheDocument();
     expect(screen.getByRole('checkbox').className).not.toContain('b--grey-light');
     expect(screen.getByRole('checkbox').className).toContain('b--red');
-    userEvent.hover(screen.getByText('Show existing projects AoIs'));
+    await user.hover(screen.getByText('Show existing projects AoIs'));
     expect(
       screen.getByText("Enable the visualization of the existing projects' areas of interest."),
     ).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('checkbox'));
     expect(testFn).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/projectDetail/tests/favorites.test.js
+++ b/frontend/src/components/projectDetail/tests/favorites.test.js
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { act, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import { store } from '../../../store';
 import {
@@ -34,12 +33,12 @@ describe('AddToFavorites button', () => {
     act(() => {
       store.dispatch({ type: 'SET_TOKEN', token: null });
     });
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <AddToFavorites projectId={1} />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
     expect(router.state.location.pathname).toBe('/login');
   });
 
@@ -47,13 +46,13 @@ describe('AddToFavorites button', () => {
     act(() => {
       store.dispatch({ type: 'SET_TOKEN', token: 'validToken' });
     });
-    createComponentWithMemoryRouter(
+    const { user } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <AddToFavorites projectId={123} />
       </ReduxIntlProviders>,
     );
     expect(screen.getByText(messages.addToFavorites.defaultMessage)).toBeInTheDocument();
-    await userEvent.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
     await waitFor(() =>
       expect(screen.queryByText(messages.addToFavorites.defaultMessage)).not.toBeInTheDocument(),
     );

--- a/frontend/src/components/projectDetail/tests/privateProjectError.test.js
+++ b/frontend/src/components/projectDetail/tests/privateProjectError.test.js
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import PrivateProjectError from '../privateProjectError';
 import {
@@ -31,13 +30,13 @@ describe('PrivateProjectError component', () => {
   });
 
   it('should navigate to explore projects page', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <IntlProviders>
         <PrivateProjectError />
       </IntlProviders>,
     );
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /explore other projects/i,
       }),

--- a/frontend/src/components/projectDetail/tests/questionsAndComments.test.js
+++ b/frontend/src/components/projectDetail/tests/questionsAndComments.test.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
-import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 
 import { store } from '../../../store';
 
@@ -19,7 +19,8 @@ describe('test if QuestionsAndComments component', () => {
     expect(screen.getByText('Log in to be able to post comments.')).toBeInTheDocument();
   });
 
-  it('renders tabs for writing and previewing comments', () => {
+  it('renders tabs for writing and previewing comments', async () => {
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders store={store}>
         <PostProjectComment projectId={1} />
@@ -30,7 +31,7 @@ describe('test if QuestionsAndComments component', () => {
     expect(screen.getByRole('button', { name: /write/i })).toBeInTheDocument();
     expect(previewBtn).toBeInTheDocument();
     expect(screen.getByRole('textbox')).toBeInTheDocument();
-    fireEvent.click(previewBtn);
+    await user.click(previewBtn);
     expect(screen.queryByRole('textbox', { hidden: true })).toBeInTheDocument();
     expect(screen.getByText(/nothing to preview/i)).toBeInTheDocument();
   });
@@ -39,12 +40,11 @@ describe('test if QuestionsAndComments component', () => {
     act(() => {
       store.dispatch({ type: 'SET_TOKEN', token: '123456', role: 'ADMIN' });
     });
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders store={store}>
         <QuestionsAndComments project={project} />
       </ReduxIntlProviders>,
     );
-    const user = userEvent.setup();
     await waitFor(() => expect(screen.getByText('hello world')).toBeInTheDocument());
     const textarea = screen.getByRole('textbox');
     const postBtn = screen.getByRole('button', { name: /post/i });
@@ -60,7 +60,7 @@ describe('test if QuestionsAndComments component', () => {
       type: 'SET_USER_DETAILS',
       userDetails: { role: 'ADMIN' },
     });
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders store={store}>
         <CommentList
           userCanEditProject
@@ -71,7 +71,6 @@ describe('test if QuestionsAndComments component', () => {
       </ReduxIntlProviders>,
     );
 
-    const user = userEvent.setup();
     await waitFor(() => expect(screen.getByText('hello world')).toBeInTheDocument());
     await user.click(screen.getAllByRole('button')[0]);
     await waitFor(() => expect(retryFnMock).toHaveBeenCalledTimes(1));

--- a/frontend/src/components/projectDetail/tests/shareButton.test.js
+++ b/frontend/src/components/projectDetail/tests/shareButton.test.js
@@ -31,6 +31,7 @@ describe('test if shareButton', () => {
 
   it('render open corresponding window popup', async () => {
     global.open = jest.fn();
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <ShareButton projectId={1} />

--- a/frontend/src/components/projectDetail/tests/shareButton.test.js
+++ b/frontend/src/components/projectDetail/tests/shareButton.test.js
@@ -37,10 +37,9 @@ describe('test if shareButton', () => {
         <ShareButton projectId={1} />
       </IntlProviders>,
     );
-    await userEvent.click(screen.getByText(/tweet/i));
-    await userEvent.click(screen.getByText(/post on facebook/i));
-    await userEvent.click(screen.getByText(/share on linkedin/i));
-
+    await user.click(screen.getByText(/tweet/i));
+    await user.click(screen.getByText(/post on facebook/i));
+    await user.click(screen.getByText(/share on linkedin/i));
     expect(global.open).toHaveBeenCalledTimes(3);
   });
 });

--- a/frontend/src/components/projectEdit/tests/localeOption.test.js
+++ b/frontend/src/components/projectEdit/tests/localeOption.test.js
@@ -1,12 +1,14 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { LocaleOption } from '../localeOption';
+import userEvent from '@testing-library/user-event';
 
 describe('LocaleOption', () => {
   const mockFn = jest.fn();
-  it('with isActive = true', () => {
+  it('with isActive = true', async () => {
+    const user = userEvent.setup();
     render(
       <LocaleOption
         localeCode={'es'}
@@ -21,7 +23,7 @@ describe('LocaleOption', () => {
     );
     expect(screen.getByText('es').className).toContain('bg-blue-grey fw6 white');
     expect(screen.getByText('es').title).toBe('Español');
-    fireEvent.click(screen.getByText('es'));
+    await user.click(screen.getByText('es'));
     expect(mockFn).toHaveBeenCalledWith('es');
   });
   it('with isActive = false and hasValue = true', () => {

--- a/frontend/src/components/projects/tests/filterSelectFields.test.js
+++ b/frontend/src/components/projects/tests/filterSelectFields.test.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { startOfWeek, startOfYear, format } from 'date-fns';
 
 import { createComponentWithReduxAndIntl, IntlProviders } from '../../../utils/testWithIntl';
@@ -36,6 +36,7 @@ describe('tests for selecting date range filters for not custom date ranges', ()
 
 describe('DateRangeFilterSelect', () => {
   it('should set query when an option is selected', async () => {
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <DateRangeFilterSelect
@@ -45,8 +46,8 @@ describe('DateRangeFilterSelect', () => {
         />
       </IntlProviders>,
     );
-    await userEvent.click(screen.getByRole('combobox'));
-    await userEvent.click(screen.getByText(/this week/i));
+    await user.click(screen.getByRole('combobox'));
+    await user.click(screen.getByText(/this week/i));
     expect(screen.getByText('This week')).toBeInTheDocument();
   });
 
@@ -82,6 +83,7 @@ describe('DateRangeFilterSelect', () => {
 
 test('DateFilterPicker', async () => {
   const setQueryForChildMock = jest.fn();
+  const user = userEvent.setup();
   render(
     <IntlProviders>
       <DateFilterPicker
@@ -91,10 +93,8 @@ test('DateFilterPicker', async () => {
       />
     </IntlProviders>,
   );
-  fireEvent.change(screen.getByRole('textbox'), {
-    target: {
-      value: '2022-02-22',
-    },
-  });
+  const textbox = screen.getByRole('textbox');
+  await user.clear(textbox);
+  await user.type(textbox, '2022-02-22');
   expect(setQueryForChildMock).toHaveBeenCalled();
 });

--- a/frontend/src/components/projects/tests/mappingTypeFilterPicker.test.js
+++ b/frontend/src/components/projects/tests/mappingTypeFilterPicker.test.js
@@ -4,7 +4,6 @@ import { screen } from '@testing-library/react';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
 import { QueryParamProvider } from 'use-query-params';
-import userEvent from '@testing-library/user-event';
 
 import {
   createComponentWithIntl,
@@ -29,14 +28,14 @@ it('mapping type options show the road icon', () => {
 
 it('should set query for the clicked icon', async () => {
   const setMappingTypesQueryMock = jest.fn();
-  renderWithRouter(
+  const { user } = renderWithRouter(
     <ReduxIntlProviders>
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <MappingTypeFilterPicker setMappingTypesQuery={setMappingTypesQueryMock} />
       </QueryParamProvider>
     </ReduxIntlProviders>,
   );
-  await userEvent.click(
+  await user.click(
     screen.getByRole('checkbox', {
       name: /roads/i,
     }),
@@ -62,7 +61,7 @@ it('should highlight active selected map icon', async () => {
 
 it('should concatinate values with the present query', async () => {
   const setMappingTypesQueryMock = jest.fn();
-  renderWithRouter(
+  const { user } = renderWithRouter(
     <ReduxIntlProviders>
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <MappingTypeFilterPicker
@@ -73,7 +72,7 @@ it('should concatinate values with the present query', async () => {
     </ReduxIntlProviders>,
   );
 
-  await userEvent.click(
+  await user.click(
     screen.getByRole('checkbox', {
       name: /waterways/i,
     }),
@@ -86,7 +85,7 @@ it('should concatinate values with the present query', async () => {
 
 it('should deselect from the query value', async () => {
   const setMappingTypesQueryMock = jest.fn();
-  renderWithRouter(
+  const { user } = renderWithRouter(
     <ReduxIntlProviders>
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <MappingTypeFilterPicker
@@ -97,7 +96,7 @@ it('should deselect from the query value', async () => {
     </ReduxIntlProviders>,
   );
 
-  await userEvent.click(
+  await user.click(
     screen.getByRole('checkbox', {
       name: /roads/i,
     }),

--- a/frontend/src/components/projects/tests/moreFiltersForm.test.js
+++ b/frontend/src/components/projects/tests/moreFiltersForm.test.js
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom';
-import userEvent from '@testing-library/user-event';
 import { parse } from 'query-string';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
@@ -20,14 +19,14 @@ describe('MoreFiltersForm', () => {
     act(() => {
       store.dispatch({ type: 'SET_TOKEN', token: null });
     });
-    const { container } = renderWithRouter(
+    const { user, container } = renderWithRouter(
       <ReduxIntlProviders>
         <QueryParamProvider adapter={ReactRouter6Adapter}>
           <MoreFiltersForm currentUrl="/current-url" />
         </QueryParamProvider>
       </ReduxIntlProviders>,
     );
-    await userEvent.click(container.querySelector('#organisation > div > div'));
+    await user.click(container.querySelector('#organisation > div > div'));
     await screen.findByText('American Red Cross');
     expect(screen.queryByLabelText('filter by user interests')).not.toBeInTheDocument();
   });
@@ -36,7 +35,7 @@ describe('MoreFiltersForm', () => {
     act(() => {
       store.dispatch({ type: 'SET_TOKEN', token: 'validToken' });
     });
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <QueryParamProvider adapter={ReactRouter6Adapter}>
           <MoreFiltersForm currentUrl="/current-url" />
@@ -46,7 +45,7 @@ describe('MoreFiltersForm', () => {
     const switchControl = screen.getAllByRole('checkbox').slice(-1)[0];
 
     expect(switchControl).toBeInTheDocument();
-    await userEvent.click(switchControl);
+    await user.click(switchControl);
     await waitFor(() =>
       expect(
         decodeQueryParams(

--- a/frontend/src/components/projects/tests/myProjectNav.test.js
+++ b/frontend/src/components/projects/tests/myProjectNav.test.js
@@ -86,7 +86,7 @@ describe('Manage Projects Top Navigation Bar', () => {
   });
 
   it('should navigate to new project creation page on button click', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <ReduxIntlProviders>
           <MyProjectNav management />
@@ -94,7 +94,6 @@ describe('Manage Projects Top Navigation Bar', () => {
       </QueryParamProvider>,
     );
 
-    const user = userEvent.setup();
     await user.click(
       screen.queryByRole('button', {
         name: /new/i,
@@ -122,13 +121,13 @@ describe('Filter Button Component', () => {
 
   it('should set query when clicked', async () => {
     const setQueryMock = jest.fn();
+    const user = userEvent.setup();
     render(
       <FilterButton isActive={false} setQuery={setQueryMock}>
         Click me!
       </FilterButton>,
     );
 
-    const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /click me!/i }));
     expect(setQueryMock).toHaveBeenCalled();
   });

--- a/frontend/src/components/projects/tests/orderBy.test.js
+++ b/frontend/src/components/projects/tests/orderBy.test.js
@@ -1,13 +1,12 @@
 import '@testing-library/jest-dom';
 import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import { IntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
 import { OrderBySelector } from '../orderBy';
 
 test('should select option on click', async () => {
   const setQueryMock = jest.fn();
-  renderWithRouter(
+  const { user } = renderWithRouter(
     <IntlProviders>
       <OrderBySelector
         allQueryParams={{
@@ -18,12 +17,12 @@ test('should select option on click', async () => {
       />
     </IntlProviders>,
   );
-  await userEvent.click(
+  await user.click(
     screen.getByRole('button', {
       name: /sort by/i,
     }),
   );
-  await userEvent.click(screen.getByText(/urgent projects/i));
+  await user.click(screen.getByText(/urgent projects/i));
   expect(setQueryMock).toHaveBeenCalledWith(
     expect.objectContaining({
       orderBy: 'priority',

--- a/frontend/src/components/projects/tests/projectCardPaginator.test.js
+++ b/frontend/src/components/projects/tests/projectCardPaginator.test.js
@@ -26,6 +26,7 @@ describe('ProjectCardPaginator Component', () => {
   });
 
   it('should set query on the button click', async () => {
+    const user = userEvent.setup();
     render(
       <ProjectCardPaginator
         setQueryParam={setQueryParamMock}
@@ -42,7 +43,7 @@ describe('ProjectCardPaginator Component', () => {
         }}
       />,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '2',
       }),

--- a/frontend/src/components/projects/tests/projectSearchBox.test.js
+++ b/frontend/src/components/projects/tests/projectSearchBox.test.js
@@ -8,24 +8,26 @@ import { ProjectSearchBox } from '../projectSearchBox';
 describe('ProjectSearchBox', () => {
   it('should set the query as the state', async () => {
     const setQueryMock = jest.fn();
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <ProjectSearchBox fullProjectsQuery={{}} setQuery={setQueryMock} />
       </IntlProviders>,
     );
     const textfield = screen.getByRole('textbox');
-    await userEvent.type(textfield, 'something');
+    await user.type(textfield, 'something');
     expect(setQueryMock).toHaveBeenCalled();
   });
 
   it('should clear the query when the close icon is clicked', async () => {
     const setQueryMock = jest.fn();
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <ProjectSearchBox fullProjectsQuery={{ text: 'something' }} setQuery={setQueryMock} />
       </IntlProviders>,
     );
-    await userEvent.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
     expect(setQueryMock).toHaveBeenCalledWith(
       expect.objectContaining({
         text: undefined,
@@ -37,6 +39,7 @@ describe('ProjectSearchBox', () => {
 
   it('should focus the textbox when search icon is clicked', async () => {
     const setQueryMock = jest.fn();
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <ProjectSearchBox fullProjectsQuery={{ text: 'something' }} setQuery={setQueryMock} />
@@ -44,7 +47,7 @@ describe('ProjectSearchBox', () => {
     );
     const textfield = screen.getByRole('textbox');
     expect(textfield).not.toHaveFocus();
-    await userEvent.click(screen.getByLabelText('Search'));
+    await user.click(screen.getByLabelText('Search'));
     expect(textfield).toHaveFocus();
   });
 });

--- a/frontend/src/components/projects/tests/projectSearchResults.test.js
+++ b/frontend/src/components/projects/tests/projectSearchResults.test.js
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom';
-import userEvent from '@testing-library/user-event';
 import { screen, act } from '@testing-library/react';
 
 import { ReduxIntlProviders, IntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
@@ -57,7 +56,7 @@ describe('Project Search Results', () => {
 
   it('should display error and provide actionable to retry', async () => {
     const retryFn = jest.fn();
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <ProjectSearchResults state={{ isError: true, projects: [] }} retryFn={retryFn} />
       </ReduxIntlProviders>,
@@ -66,7 +65,6 @@ describe('Project Search Results', () => {
     expect(screen.getByText('Error loading the Projects for Explore Projects')).toBeInTheDocument();
     const retryBtn = screen.getByRole('button', { name: /retry/i });
     expect(retryBtn).toBeInTheDocument();
-    const user = userEvent.setup();
     await user.click(retryBtn);
     expect(retryFn).toHaveBeenCalled();
   });

--- a/frontend/src/components/projects/tests/projectsActionFilter.test.js
+++ b/frontend/src/components/projects/tests/projectsActionFilter.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, fireEvent, act } from '@testing-library/react';
+import { screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { store } from '../../../store';
@@ -8,8 +8,8 @@ import { ProjectsActionFilter } from '../projectsActionFilter';
 
 describe('ProjectsActionFilter', () => {
   const myMock = jest.fn();
-  it('test initialization and state changes', () => {
-    renderWithRouter(
+  it('test initialization and state changes', async () => {
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <ProjectsActionFilter fullProjectsQuery={{ action: undefined }} setQuery={myMock} />
       </ReduxIntlProviders>,
@@ -19,36 +19,36 @@ describe('ProjectsActionFilter', () => {
     expect(screen.queryByText('Projects to validate')).not.toBeInTheDocument();
     expect(screen.queryByText('Archived')).not.toBeInTheDocument();
     // open dropdown
-    fireEvent.click(screen.queryByText('Any project'));
+    await user.click(screen.queryByText('Any project'));
     expect(screen.queryByText('Projects to map')).toBeInTheDocument();
     expect(screen.queryByText('Projects to validate')).toBeInTheDocument();
     expect(screen.queryByText('Archived')).toBeInTheDocument();
     // select Projects to validate
-    fireEvent.click(screen.queryByText('Projects to validate'));
+    await user.click(screen.queryByText('Projects to validate'));
     expect(store.getState()['preferences']['action']).toBe('validate');
     // select Any projects
-    fireEvent.click(screen.queryByText('Projects to validate'));
-    fireEvent.click(screen.queryByText('Any project'));
+    await user.click(screen.queryByText('Projects to validate'));
+    await user.click(screen.queryByText('Any project'));
     expect(store.getState()['preferences']['action']).toBe('any');
     // select Projects to map
-    fireEvent.click(screen.queryByText('Any project'));
-    fireEvent.click(screen.queryByText('Projects to map'));
+    await user.click(screen.queryByText('Any project'));
+    await user.click(screen.queryByText('Projects to map'));
     expect(store.getState()['preferences']['action']).toBe('map');
     // select Projects to archived, action set to any for this special case
-    fireEvent.click(screen.queryByText('Projects to map'));
-    fireEvent.click(screen.queryByText(/archived/i));
+    await user.click(screen.queryByText('Projects to map'));
+    await user.click(screen.queryByText(/archived/i));
     expect(store.getState()['preferences']['action']).toBe('any');
   });
 
-  it('initialize it with validate action set', () => {
-    renderWithRouter(
+  it('initialize it with validate action set', async () => {
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <ProjectsActionFilter fullProjectsQuery={{ action: 'validate' }} setQuery={myMock} />
       </ReduxIntlProviders>,
     );
     expect(screen.queryByText('Projects to validate')).toBeInTheDocument();
-    fireEvent.click(screen.queryByText('Projects to validate'));
-    fireEvent.click(screen.queryByText('Any project'));
+    await user.click(screen.queryByText('Projects to validate'));
+    await user.click(screen.queryByText('Any project'));
     expect(store.getState()['preferences']['action']).toBe('any');
     expect(myMock).toHaveBeenCalledTimes(2);
   });

--- a/frontend/src/components/taskSelection/tests/action.test.js
+++ b/frontend/src/components/taskSelection/tests/action.test.js
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import { getProjectSummary } from '../../../network/tests/mockData/projects';
 import { userMultipleLockedTasksDetails } from '../../../network/tests/mockData/userStats';
@@ -11,24 +10,25 @@ import { TaskMapAction } from '../action';
 import messages from '../messages';
 
 const setup = () => {
-  renderWithRouter(
-    <ReduxIntlProviders>
-      <TaskMapAction
-        project={getProjectSummary(123)}
-        projectIsReady
-        tasks={tasksGeojson}
-        activeTasks={userMultipleLockedTasksDetails.tasks}
-        action="VALIDATION"
-      />
-    </ReduxIntlProviders>,
-  );
+  return {
+    ...renderWithRouter(
+      <ReduxIntlProviders>
+        <TaskMapAction
+          project={getProjectSummary(123)}
+          projectIsReady
+          tasks={tasksGeojson}
+          activeTasks={userMultipleLockedTasksDetails.tasks}
+          action="VALIDATION"
+        />
+      </ReduxIntlProviders>,
+    ),
+  };
 };
 
 describe('Task Map Action', () => {
   it('should display JOSM error', async () => {
     setupFaultyHandlers();
-    setup();
-    const user = userEvent.setup();
+    const { user } = setup();
     await user.click(
       screen.getByRole('button', {
         name: /iD Editor/i,
@@ -42,7 +42,7 @@ describe('Task Map Action', () => {
         }),
       ).toBeInTheDocument(),
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /close/i,
       }),
@@ -55,8 +55,7 @@ describe('Task Map Action', () => {
   });
 
   it('should expand accordition to view task details', async () => {
-    setup();
-    const user = userEvent.setup();
+    const { user } = setup();
     await user.click(
       screen.getByRole('button', {
         name: /history/i,

--- a/frontend/src/components/taskSelection/tests/actionSidebars.test.js
+++ b/frontend/src/components/taskSelection/tests/actionSidebars.test.js
@@ -20,18 +20,18 @@ import { store } from '../../../store';
 
 describe('Appeareance of unsaved map changes to be dealt with while mapping', () => {
   test('when splitting a task', async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <CompletionTabForMapping disabled />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(screen.getByRole('button', { name: /split task/i }));
+    await user.click(screen.getByRole('button', { name: /split task/i }));
     expect(
       screen.getByRole('heading', {
         name: messages.unsavedChanges.defaultMessage,
       }),
     ).toBeInTheDocument();
-    await userEvent.click(
+    await user.click(
       within(screen.getByRole('dialog')).getByRole('button', {
         name: /close/i,
       }),
@@ -53,12 +53,12 @@ describe('Appeareance of unsaved map changes to be dealt with while mapping', ()
   });
 
   test('when selecting another task', async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <CompletionTabForMapping disabled />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /select another task/i,
       }),
@@ -74,13 +74,13 @@ describe('Appeareance of unsaved map changes to be dealt with while mapping', ()
 describe('Miscellaneous modals and prompts', () => {
   test('should display/hide split task error', async () => {
     setupFaultyHandlers();
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <CompletionTabForMapping project={{ projectId: 123 }} tasksIds={[1997]} />
       </ReduxIntlProviders>,
     );
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /split task/i,
       }),
@@ -88,7 +88,7 @@ describe('Miscellaneous modals and prompts', () => {
     await waitFor(() =>
       expect(screen.getByText('It was not possible to split the task')).toBeInTheDocument(),
     );
-    await userEvent.click(
+    await user.click(
       within(screen.getByRole('dialog')).getByRole('button', {
         name: /close/i,
       }),
@@ -98,14 +98,14 @@ describe('Miscellaneous modals and prompts', () => {
 
   test('should prompt the user to read comments', async () => {
     const historyTabSwitchMock = jest.fn();
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <CompletionTabForMapping showReadCommentsAlert historyTabSwitch={historyTabSwitchMock} />
       </ReduxIntlProviders>,
     );
 
     expect(screen.getByText(messages.readTaskComments.defaultMessage)).toBeInTheDocument();
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: messages.readTaskComments.defaultMessage,
       }),
@@ -114,27 +114,27 @@ describe('Miscellaneous modals and prompts', () => {
   });
 
   test('should display/hide help text', async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <CompletionTabForMapping showReadCommentsAlert />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(screen.getByLabelText('toggle help'));
+    await user.click(screen.getByLabelText('toggle help'));
     expect(screen.getByText(messages.instructionsSelect.defaultMessage)).toBeInTheDocument();
-    await userEvent.click(screen.getByLabelText('hide instructions'));
+    await user.click(screen.getByLabelText('hide instructions'));
     expect(screen.queryByText(messages.instructionsSelect.defaultMessage)).not.toBeInTheDocument();
   });
 
   test('should display/hide task specific instructions', async () => {
     const instruction = 'this is a sample instruction';
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <CompletionTabForMapping taskInstructions={instruction} />
       </ReduxIntlProviders>,
     );
 
     expect(screen.getByText(instruction)).toBeInTheDocument();
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: messages.taskExtraInfo.defaultMessage,
       }),
@@ -144,7 +144,7 @@ describe('Miscellaneous modals and prompts', () => {
 
   test('should display/hide task specific instructions', async () => {
     const instruction = 'this is a sample instruction';
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <CompletionTabForValidation
           taskInstructions={instruction}
@@ -155,7 +155,7 @@ describe('Miscellaneous modals and prompts', () => {
     );
 
     expect(screen.queryByText(instruction)).not.toBeInTheDocument();
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: messages.taskExtraInfo.defaultMessage,
       }),
@@ -166,18 +166,18 @@ describe('Miscellaneous modals and prompts', () => {
 
 describe('Appeareance of unsaved map changes to be dealt with while validating', () => {
   test('when stopping validation session', async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <CompletionTabForValidation disabled validationStatus={{}} tasksIds={[]} />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(screen.getByRole('button', { name: /stop validation/i }));
+    await user.click(screen.getByRole('button', { name: /stop validation/i }));
     expect(
       screen.getByRole('heading', {
         name: messages.unsavedChanges.defaultMessage,
       }),
     ).toBeInTheDocument();
-    await userEvent.click(
+    await user.click(
       within(screen.getByRole('dialog')).getByRole('button', {
         name: /close/i,
       }),
@@ -201,7 +201,7 @@ describe('Appeareance of unsaved map changes to be dealt with while validating',
 
 describe('Completion Tab for Validation', () => {
   it('should update status and comments for multiple tasks', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <CompletionTabForValidation
           project={{ projectId: 123 }}
@@ -214,7 +214,6 @@ describe('Completion Tab for Validation', () => {
         />
       </ReduxIntlProviders>,
     );
-    const user = userEvent.setup();
     await user.click(
       screen.getAllByRole('radio', {
         name: /yes/i,
@@ -246,7 +245,7 @@ describe('Completion Tab for Validation', () => {
   });
 
   it('should display radio to mark all tasks', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <CompletionTabForValidation
           project={{ projectId: 123 }}
@@ -265,7 +264,7 @@ describe('Completion Tab for Validation', () => {
       </ReduxIntlProviders>,
     );
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /submit task/i,
       }),
@@ -277,6 +276,7 @@ describe('Completion Tab for Validation', () => {
 describe('Toggling display of the sidebar', () => {
   it('should call the sidebar toggle function for ID editor', async () => {
     const restartMock = jest.fn();
+    const user = userEvent.setup();
     const context = {
       ui: jest.fn().mockReturnValue({
         restart: restartMock,
@@ -291,7 +291,7 @@ describe('Toggling display of the sidebar', () => {
         <SidebarToggle setShowSidebar={setShowSidebarMock} activeEditor="ID" />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /hide sidebar/i,
       }),
@@ -302,6 +302,7 @@ describe('Toggling display of the sidebar', () => {
 
   it('should call the sidebar toggle function for RAPID editor', async () => {
     const restartMock = jest.fn();
+    const user = userEvent.setup();
     const context = {
       ui: jest.fn().mockReturnValue({
         restart: restartMock,
@@ -316,7 +317,7 @@ describe('Toggling display of the sidebar', () => {
         <SidebarToggle setShowSidebar={setShowSidebarMock} activeEditor="RAPID" />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /hide sidebar/i,
       }),

--- a/frontend/src/components/taskSelection/tests/actionsTabsNav.test.js
+++ b/frontend/src/components/taskSelection/tests/actionsTabsNav.test.js
@@ -1,15 +1,17 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { ReduxIntlProviders } from '../../../utils/testWithIntl';
 import { ActionTabsNav } from '../actionTabsNav';
+import userEvent from '@testing-library/user-event';
 
 describe('ActionTabsNav', () => {
   const setActiveSection = jest.fn();
   const historyTabSwitch = jest.fn();
 
   it('for mapping does not show the Resouces tab', async () => {
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <ActionTabsNav
@@ -35,7 +37,7 @@ describe('ActionTabsNav', () => {
       'bg-red white br-100 f6 ml1 flex items-center justify-center',
     );
     expect(screen.queryByText('Resources')).not.toBeInTheDocument();
-    fireEvent.click(screen.getByText('Instructions'));
+    await user.click(screen.getByText('Instructions'));
     expect(setActiveSection).toHaveBeenLastCalledWith('instructions');
   });
 
@@ -72,6 +74,7 @@ describe('ActionTabsNav', () => {
   });
 
   it('for validation show the Resouces tab', async () => {
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <ActionTabsNav
@@ -91,11 +94,11 @@ describe('ActionTabsNav', () => {
     expect(screen.getByText('Resources').className).toContain(
       'dib mr4-l mr3 pb2 pointer bb b--red bw1',
     );
-    fireEvent.click(screen.getByText('History'));
+    await user.click(screen.getByText('History'));
     expect(historyTabSwitch).toHaveBeenCalled();
-    fireEvent.click(screen.getByText('Completion'));
+    await user.click(screen.getByText('Completion'));
     expect(setActiveSection).toHaveBeenLastCalledWith('completion');
-    fireEvent.click(screen.getByText('Resources'));
+    await user.click(screen.getByText('Resources'));
     expect(setActiveSection).toHaveBeenLastCalledWith('resources');
   });
 });

--- a/frontend/src/components/taskSelection/tests/contributions.test.js
+++ b/frontend/src/components/taskSelection/tests/contributions.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import selectEvent from 'react-select-event';
 
 import { ReduxIntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
@@ -12,7 +12,7 @@ describe('Contributions', () => {
   const selectTask = jest.fn();
 
   it('render users, links and ', async () => {
-    const { container } = renderWithRouter(
+    const { user, container } = renderWithRouter(
       <ReduxIntlProviders>
         <Contributions
           project={{ projectId: 1, osmchaFilterId: 'abc1234' }}
@@ -36,9 +36,9 @@ describe('Contributions', () => {
     expect(screen.getByText('Changesets')).toBeInTheDocument();
     expect(screen.getAllByRole('link')[1].href).toBe('https://osmcha.org/?aoi=abc1234');
     // clicking on the number of tasks trigger selectTask
-    fireEvent.click(screen.getAllByText('5')[0]);
+    await user.click(screen.getAllByText('5')[0]);
     expect(selectTask).toHaveBeenLastCalledWith([1, 3, 5, 7], 'ALL', 'test');
-    fireEvent.click(screen.getAllByText('5')[1]);
+    await user.click(screen.getAllByText('5')[1]);
     expect(selectTask).toHaveBeenLastCalledWith([5, 36, 99, 115, 142], 'MAPPED', 'test_1');
     // filter ADVANCED users
     await selectEvent.select(container.querySelectorAll('input')[0], 'Advanced');
@@ -66,8 +66,8 @@ describe('Contributions', () => {
     expect(screen.queryByText('user_5')).not.toBeInTheDocument();
     expect(screen.queryByText('test_1')).not.toBeInTheDocument();
   });
-  it('clean user selection if we click on the selected tasks of the user', () => {
-    const { container } = renderWithRouter(
+  it('clean user selection if we click on the selected tasks of the user', async () => {
+    const { user, container } = renderWithRouter(
       <ReduxIntlProviders>
         <Contributions
           project={{ projectId: 1, osmchaFilterId: 'abc1234' }}
@@ -80,7 +80,7 @@ describe('Contributions', () => {
       </ReduxIntlProviders>,
     );
     expect(container.querySelector('div.b--blue-dark')).toBeInTheDocument();
-    fireEvent.click(screen.getAllByText('5')[1]);
+    await user.click(screen.getAllByText('5')[1]);
     expect(selectTask).toHaveBeenLastCalledWith([]);
   });
 });

--- a/frontend/src/components/taskSelection/tests/extendSession.test.js
+++ b/frontend/src/components/taskSelection/tests/extendSession.test.js
@@ -10,12 +10,13 @@ import messages from '../messages';
 describe('Session About To Expire Dialog', () => {
   it('should display error when session could not be extended', async () => {
     setupFaultyHandlers();
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <SessionAboutToExpire showSessionExpiringDialog projectId={123} />
       </IntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /extend session/i,
       }),
@@ -27,6 +28,7 @@ describe('Session About To Expire Dialog', () => {
 
   it('should close the modal', async () => {
     const setShowSessionExpiryDialogMock = jest.fn();
+    const user = userEvent.setup();
     const { container } = render(
       <IntlProviders>
         <SessionAboutToExpire
@@ -36,7 +38,7 @@ describe('Session About To Expire Dialog', () => {
         />
       </IntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /close/i,
       }),
@@ -49,12 +51,13 @@ describe('Session About To Expire Dialog', () => {
 describe('Session Expired Dialog', () => {
   it('should display error when task cannot be relocked', async () => {
     setupFaultyHandlers();
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <SessionExpired showSessionExpiredDialog projectId={123} tasksIds={[12, 13]} />
       </IntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /relock tasks/i,
       }),
@@ -66,6 +69,7 @@ describe('Session Expired Dialog', () => {
 
   it('should close the modal', async () => {
     const setShowSessionExpiredDialogMock = jest.fn();
+    const user = userEvent.setup();
     const { container } = render(
       <IntlProviders>
         <SessionAboutToExpire
@@ -75,7 +79,7 @@ describe('Session Expired Dialog', () => {
         />
       </IntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /close/i,
       }),

--- a/frontend/src/components/taskSelection/tests/footer.test.js
+++ b/frontend/src/components/taskSelection/tests/footer.test.js
@@ -2,7 +2,6 @@ import '@testing-library/jest-dom';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { act, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 
 import { Imagery } from '../imagery';
@@ -151,7 +150,7 @@ describe('Footer Lock Tasks', () => {
   it('should display task cannot be locked for mapping message', async () => {
     await clearReduxStore();
     setupFaultyHandlers();
-    createComponentWithMemoryRouter(
+    const { user } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter
           defaultUserEditor="ID"
@@ -161,7 +160,7 @@ describe('Footer Lock Tasks', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /map a task/i,
       }),
@@ -174,7 +173,7 @@ describe('Footer Lock Tasks', () => {
   it('should display no mapped tasks selected message', async () => {
     await clearReduxStore();
     setupFaultyHandlers();
-    createComponentWithMemoryRouter(
+    const { user } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter
           defaultUserEditor="ID"
@@ -185,7 +184,7 @@ describe('Footer Lock Tasks', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /validate a task/i,
       }),
@@ -200,7 +199,7 @@ describe('Footer Lock Tasks', () => {
   it('should display task cannot be locked for validation message', async () => {
     await clearReduxStore();
     setupFaultyHandlers();
-    createComponentWithMemoryRouter(
+    const { user } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter
           defaultUserEditor="ID"
@@ -211,7 +210,7 @@ describe('Footer Lock Tasks', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /validate a task/i,
       }),
@@ -223,7 +222,7 @@ describe('Footer Lock Tasks', () => {
 
   it('should display JOSM error', async () => {
     setupFaultyHandlers();
-    createComponentWithMemoryRouter(
+    const { user } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter
           defaultUserEditor="JOSM"
@@ -233,7 +232,7 @@ describe('Footer Lock Tasks', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /map a task/i,
       }),
@@ -245,7 +244,7 @@ describe('Footer Lock Tasks', () => {
         }),
       ).toBeInTheDocument(),
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /close/i,
       }),
@@ -258,12 +257,12 @@ describe('Footer Lock Tasks', () => {
   });
 
   it('should navigate to explore page for a complete project', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter project={getProjectSummary(222)} taskAction="selectAnotherProject" />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /select another project/i,
       }),
@@ -272,7 +271,7 @@ describe('Footer Lock Tasks', () => {
   });
 
   it('should navigate to task action page on mapping a task', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter
           defaultUserEditor="ID"
@@ -283,7 +282,7 @@ describe('Footer Lock Tasks', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /map a task/i,
       }),
@@ -296,7 +295,7 @@ describe('Footer Lock Tasks', () => {
 
   it('should navigate to task action page on validating a task', async () => {
     await clearReduxStore();
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter
           defaultUserEditor="ID"
@@ -307,7 +306,7 @@ describe('Footer Lock Tasks', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /validate a task/i,
       }),
@@ -320,7 +319,7 @@ describe('Footer Lock Tasks', () => {
 
   it('should resume mapping', async () => {
     await clearReduxStore();
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter
           defaultUserEditor="ID"
@@ -331,7 +330,7 @@ describe('Footer Lock Tasks', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /resume mapping/i,
       }),
@@ -344,7 +343,7 @@ describe('Footer Lock Tasks', () => {
 
   it('should resume validation', async () => {
     await clearReduxStore();
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter
           defaultUserEditor="ID"
@@ -355,7 +354,7 @@ describe('Footer Lock Tasks', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /resume validation/i,
       }),
@@ -368,7 +367,7 @@ describe('Footer Lock Tasks', () => {
 
   it('should fallback editor when user default is not in the list for validation', async () => {
     await clearReduxStore();
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter
           defaultUserEditor="someRandomEditor"
@@ -379,7 +378,7 @@ describe('Footer Lock Tasks', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /resume validation/i,
       }),
@@ -392,7 +391,7 @@ describe('Footer Lock Tasks', () => {
 
   it('should fallback editor when user default is not in the list for mapping', async () => {
     await clearReduxStore();
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <TaskSelectionFooter
           defaultUserEditor="someRandomEditor"
@@ -403,7 +402,7 @@ describe('Footer Lock Tasks', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /resume mapping/i,
       }),

--- a/frontend/src/components/taskSelection/tests/imagery.test.js
+++ b/frontend/src/components/taskSelection/tests/imagery.test.js
@@ -184,12 +184,13 @@ describe('Imagery', () => {
       writeText: jest.fn().mockImplementation(() => Promise.resolve()),
     };
     global.navigator.clipboard = mockClipboard;
+    const user = userEvent.setup();
     render(
       <IntlProviders>
         <Imagery value={'wms'} />
       </IntlProviders>,
     );
-    await userEvent.click(screen.getByRole('img'));
+    await user.click(screen.getByRole('img'));
     expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('wms');
     jest.resetAllMocks();

--- a/frontend/src/components/taskSelection/tests/imagery.test.js
+++ b/frontend/src/components/taskSelection/tests/imagery.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -179,21 +179,13 @@ describe('Imagery', () => {
   });
 
   it('should copy value to the clipboard', async () => {
-    const originalClipboard = { ...global.navigator.clipboard };
-    const mockClipboard = {
-      writeText: jest.fn().mockImplementation(() => Promise.resolve()),
-    };
-    global.navigator.clipboard = mockClipboard;
-    const user = userEvent.setup();
+    const user = userEvent.setup({ writeToClipboard: true });
     render(
       <IntlProviders>
         <Imagery value={'wms'} />
       </IntlProviders>,
     );
     await user.click(screen.getByRole('img'));
-    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('wms');
-    jest.resetAllMocks();
-    global.navigator.clipboard = originalClipboard;
+    await waitFor(async () => expect(await navigator.clipboard.readText()).toBe('wms'));
   });
 });

--- a/frontend/src/components/taskSelection/tests/index.test.js
+++ b/frontend/src/components/taskSelection/tests/index.test.js
@@ -2,7 +2,6 @@ import '@testing-library/jest-dom';
 import { screen, act, waitFor } from '@testing-library/react';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import { QueryParamProvider } from 'use-query-params';
-import userEvent from '@testing-library/user-event';
 
 import { TaskSelection } from '..';
 import { getProjectSummary } from '../../../network/tests/mockData/projects';
@@ -20,7 +19,7 @@ describe('Contributions', () => {
       });
     });
 
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <ReduxIntlProviders>
           <TaskSelection project={getProjectSummary(123)} />
@@ -31,12 +30,12 @@ describe('Contributions', () => {
     await waitFor(() =>
       expect(screen.getByText(/Project Specific Mapping Notes/i)).toBeInTheDocument(),
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /contributions/i,
       }),
     );
-    await userEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Select tasks mapped by user_3',
       }),
@@ -49,7 +48,7 @@ describe('Contributions', () => {
   });
 
   it('should select tasks validated by the selected user', async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <ReduxIntlProviders>
           <TaskSelection project={getProjectSummary(123)} />
@@ -60,12 +59,12 @@ describe('Contributions', () => {
     await waitFor(() =>
       expect(screen.getByText(/Project Specific Mapping Notes/i)).toBeInTheDocument(),
     );
-    await userEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: /contributions/i,
       }),
     );
-    await userEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Select tasks validated by user_3',
       }),
@@ -78,7 +77,7 @@ describe('Contributions', () => {
   });
 
   it('should sort tasks by their task number', async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <ReduxIntlProviders>
           <TaskSelection project={getProjectSummary(123)} />
@@ -89,18 +88,18 @@ describe('Contributions', () => {
     await waitFor(() =>
       expect(screen.getByText(/Project Specific Mapping Notes/i)).toBeInTheDocument(),
     );
-    await userEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: /tasks/i,
       }),
     );
 
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /Most recently updated/i,
       }),
     );
-    await userEvent.click(await screen.findByText(/sort by task number/i));
+    await user.click(await screen.findByText(/sort by task number/i));
     const firstTask = screen.getByRole('button', {
       name: /Task #1 Patrik_B/i,
     });
@@ -111,7 +110,7 @@ describe('Contributions', () => {
   });
 
   it('should clear text when close icon is clicked', async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <ReduxIntlProviders>
           <TaskSelection project={getProjectSummary(123)} />
@@ -122,15 +121,15 @@ describe('Contributions', () => {
     await waitFor(() =>
       expect(screen.getByText(/Project Specific Mapping Notes/i)).toBeInTheDocument(),
     );
-    await userEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: /tasks/i,
       }),
     );
     const userQueryText = screen.getByRole('textbox');
-    await userEvent.type(userQueryText, 'hello');
+    await user.type(userQueryText, 'hello');
     expect(userQueryText).toHaveValue('hello');
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /clear/i,
       }),

--- a/frontend/src/components/taskSelection/tests/legend.test.js
+++ b/frontend/src/components/taskSelection/tests/legend.test.js
@@ -1,11 +1,13 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { ReduxIntlProviders } from '../../../utils/testWithIntl';
 import { TasksMapLegend } from '../legend';
+import userEvent from '@testing-library/user-event';
 
-test('Legend collapse / expand when clicking', () => {
+test('Legend collapse / expand when clicking', async () => {
+  const user = userEvent.setup();
   render(
     <ReduxIntlProviders>
       <TasksMapLegend />
@@ -20,8 +22,8 @@ test('Legend collapse / expand when clicking', () => {
   expect(screen.getByText('More mapping needed')).toBeInTheDocument();
   expect(screen.getByText('Finished')).toBeInTheDocument();
   expect(screen.getByText('Locked')).toBeInTheDocument();
-  fireEvent.click(screen.getByText('Legend'));
+  await user.click(screen.getByText('Legend'));
   expect(screen.queryByText('Available for mapping')).not.toBeInTheDocument();
-  fireEvent.click(screen.getByText('Legend'));
+  await user.click(screen.getByText('Legend'));
   expect(screen.getByText('Available for mapping')).toBeInTheDocument();
 });

--- a/frontend/src/components/taskSelection/tests/lockedTasks.test.js
+++ b/frontend/src/components/taskSelection/tests/lockedTasks.test.js
@@ -138,13 +138,14 @@ describe('test LockedTaskModalContent', () => {
 describe('License Modal', () => {
   it('should accept the license', async () => {
     const lockTasksMock = jest.fn();
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <LicenseError id="456" lockTasks={lockTasksMock} />
       </ReduxIntlProviders>,
     );
     await screen.findByText('Sample License');
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /accept/i,
       }),
@@ -154,13 +155,14 @@ describe('License Modal', () => {
 
   it('should decline request to accept the license', async () => {
     const closeMock = jest.fn();
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <LicenseError id="456" close={closeMock} />
       </ReduxIntlProviders>,
     );
     await screen.findByText('Sample License');
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /cancel/i,
       }),
@@ -175,7 +177,7 @@ test('SameProjectLock should display relevant message when user has multiple tas
     tasks: [1811, 1222],
     status: 'LOCKED_FOR_VALIDATION',
   };
-  const { router } = createComponentWithMemoryRouter(
+  const { user, router } = createComponentWithMemoryRouter(
     <IntlProviders>
       <SameProjectLock lockedTasks={lockedTasksSample} action="validate" />
     </IntlProviders>,
@@ -183,7 +185,7 @@ test('SameProjectLock should display relevant message when user has multiple tas
   expect(
     screen.getByText(messages.currentProjectLockTextPlural.defaultMessage),
   ).toBeInTheDocument();
-  await userEvent.click(
+  await user.click(
     screen.getByRole('button', {
       name: 'Validate those tasks',
     }),

--- a/frontend/src/components/taskSelection/tests/multipleTaskHistories.test.js
+++ b/frontend/src/components/taskSelection/tests/multipleTaskHistories.test.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { MultipleTaskHistoriesAccordion } from '../multipleTaskHistories';
 import { ReduxIntlProviders } from '../../../utils/testWithIntl';
+import userEvent from '@testing-library/user-event';
 
 describe('MultipleTaskHistories Accordion', () => {
   it('does not render accordion with task history items if there are no tasks', () => {
@@ -18,7 +19,7 @@ describe('MultipleTaskHistories Accordion', () => {
     expect(screen.queryByText(/Activities/i)).not.toBeInTheDocument();
   });
 
-  it('renders accordion correctly with task history items for 2 tasks', () => {
+  it('renders accordion correctly with task history items for 2 tasks', async () => {
     const tasks = [
       {
         taskId: 1,
@@ -51,6 +52,7 @@ describe('MultipleTaskHistories Accordion', () => {
         ],
       },
     ];
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <MultipleTaskHistoriesAccordion tasks={tasks} projectId={1} />
@@ -61,9 +63,9 @@ describe('MultipleTaskHistories Accordion', () => {
     expect(screen.getByText(/Task 2/i)).toBeInTheDocument();
 
     const taskAccordionItems = screen.getAllByRole('button');
-    taskAccordionItems.forEach((taskBtn) => {
-      fireEvent.click(taskBtn);
-    });
+    for (const taskBtn of taskAccordionItems) {
+      await user.click(taskBtn);
+    }
 
     expect(screen.getAllByText(/Comments/i)).toHaveLength(2);
     expect(screen.getAllByText(/Activities/i)).toHaveLength(2);

--- a/frontend/src/components/taskSelection/tests/permissionErrorModal.test.js
+++ b/frontend/src/components/taskSelection/tests/permissionErrorModal.test.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { MemoryRouter } from 'react-router-dom';
 import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import {
   createComponentWithIntl,
@@ -143,12 +142,12 @@ describe('UserPermissionErrorContent', () => {
         },
       ],
     };
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <IntlProviders>
         <UserPermissionErrorContent project={project} userLevel="BEGINNER" />
       </IntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /select another project/i,
       }),

--- a/frontend/src/components/taskSelection/tests/resourcesTab.test.js
+++ b/frontend/src/components/taskSelection/tests/resourcesTab.test.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 import { ReduxIntlProviders } from '../../../utils/testWithIntl';
 import { tasks } from '../../../network/tests/mockData/taskGrid';
 import { ResourcesTab } from '../resourcesTab';
+import userEvent from '@testing-library/user-event';
 
 describe('ResourcesTab', () => {
   const projectData = {
@@ -13,6 +14,7 @@ describe('ResourcesTab', () => {
     changesetComment: '#hot-osm-project-123 #buildings',
   };
   it('with multiple tasks locked', async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ReduxIntlProviders>
         <ResourcesTab tasksGeojson={tasks} project={projectData} tasksIds={[1, 2]} />
@@ -31,13 +33,13 @@ describe('ResourcesTab', () => {
     expect(container.querySelectorAll('a')[3].href).toContain('/projects/1/tasks/?as_file=true');
 
     const selectInput = container.querySelector('input');
-    fireEvent.focus(selectInput);
-    fireEvent.keyDown(selectInput, { key: 'ArrowDown' });
+    await selectInput.focus();
+    await user.type(selectInput, '{ArrowDown}');
     await waitFor(() => {
       expect(screen.getByText(1));
     });
     expect(screen.getByText(2));
-    fireEvent.click(screen.getByText(1));
+    await user.click(screen.getByText(1));
     await expect(screen.queryByText('Select task')).not.toBeInTheDocument();
     expect(screen.getByText("See task's changesets").disabled).toBeFalsy();
   });

--- a/frontend/src/components/taskSelection/tests/tabSelector.test.js
+++ b/frontend/src/components/taskSelection/tests/tabSelector.test.js
@@ -1,13 +1,15 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { ReduxIntlProviders } from '../../../utils/testWithIntl';
 import { TabSelector } from '../tabSelector';
+import userEvent from '@testing-library/user-event';
 
 describe('TabSelector component', () => {
   const setActiveSection = jest.fn();
-  it('with the tasks tab active', () => {
+  it('with the tasks tab active', async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <ReduxIntlProviders>
         <TabSelector activeSection={'tasks'} setActiveSection={setActiveSection} />
@@ -19,10 +21,11 @@ describe('TabSelector component', () => {
     expect(screen.getByText('Tasks').className).toBe('mr4 pb2 fw5 pointer dib bb bw1');
     expect(screen.getByText('Instructions').className).not.toContain('bb bw1 b--blue-dark');
     expect(screen.getByText('contributions').className).not.toContain('bb bw1 b--blue-dark');
-    fireEvent.click(screen.getByText('Instructions'));
+    await user.click(screen.getByText('Instructions'));
     expect(setActiveSection).toHaveBeenCalledWith('instructions');
   });
-  it('with the instructions tab active', () => {
+  it('with the instructions tab active', async () => {
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <TabSelector activeSection={'instructions'} setActiveSection={setActiveSection} />
@@ -31,10 +34,11 @@ describe('TabSelector component', () => {
     expect(screen.getByText('Tasks').className).not.toContain('bb bw1 b--blue-dark');
     expect(screen.getByText('Instructions').className).toContain('mr4 pb2 fw5 pointer dib bb bw1');
     expect(screen.getByText('contributions').className).not.toContain('bb bw1 b--blue-dark');
-    fireEvent.click(screen.getByText('contributions'));
+    await user.click(screen.getByText('contributions'));
     expect(setActiveSection).toHaveBeenLastCalledWith('contributions');
   });
-  it('with the contributions tab active', () => {
+  it('with the contributions tab active', async () => {
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <TabSelector activeSection={'contributions'} setActiveSection={setActiveSection} />
@@ -43,7 +47,7 @@ describe('TabSelector component', () => {
     expect(screen.getByText('Tasks').className).not.toContain('bb bw1 b--blue-dark');
     expect(screen.getByText('Instructions').className).not.toContain('bb bw1 b--blue-dark');
     expect(screen.getByText('contributions').className).toContain('mr4 pb2 fw5 pointer dib bb bw1');
-    fireEvent.click(screen.getByText('Tasks'));
+    await user.click(screen.getByText('Tasks'));
     expect(setActiveSection).toHaveBeenLastCalledWith('tasks');
   });
 });

--- a/frontend/src/components/taskSelection/tests/taskActivity.test.js
+++ b/frontend/src/components/taskSelection/tests/taskActivity.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { ReduxIntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
@@ -42,8 +42,8 @@ describe('TaskHistory', () => {
     lastUpdated: Date.now() - 1e3 * 60 * 60,
     numberOfComments: null,
   };
-  it('renders the task history comments and activities for a given project', () => {
-    renderWithRouter(
+  it('renders the task history comments and activities for a given project', async () => {
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <TaskHistory projectId={2} taskId={15} commentPayload={history} />
       </ReduxIntlProviders>,
@@ -65,7 +65,7 @@ describe('TaskHistory', () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText('locked for validation 2 hours ago')).not.toBeInTheDocument();
 
-    fireEvent.click(historyRadioButtons[1]); // check activities radio option
+    await user.click(historyRadioButtons[1]); // check activities radio option
     expect(historyRadioButtons[0]).not.toBeChecked();
     expect(historyRadioButtons[2]).not.toBeChecked();
     expect(screen.getByText('marked as more mapping needed 1 minute ago')).toBeInTheDocument();
@@ -73,7 +73,7 @@ describe('TaskHistory', () => {
     expect(screen.queryByText('commented 1 hour ago')).not.toBeInTheDocument();
     expect(screen.queryByText('missing buildings')).not.toBeInTheDocument();
 
-    fireEvent.click(historyRadioButtons[2]); // check All radio option
+    await user.click(historyRadioButtons[2]); // check All radio option
     expect(historyRadioButtons[0]).not.toBeChecked();
     expect(historyRadioButtons[1]).not.toBeChecked();
     expect(screen.getByText('marked as more mapping needed 1 minute ago')).toBeInTheDocument();
@@ -82,13 +82,13 @@ describe('TaskHistory', () => {
     expect(screen.getByText('missing buildings')).toBeInTheDocument();
   });
 
-  it('does not render any task history when not provided', () => {
+  it('does not render any task history when not provided', async () => {
     let history = {
       taskId: 15,
       projectId: 2,
       taskStatus: 'INVALIDATED',
     };
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <TaskHistory projectId={2} taskId={15} commentPayload={history} />
       </ReduxIntlProviders>,
@@ -104,11 +104,11 @@ describe('TaskHistory', () => {
     expect(historyRadioButtons[1]).not.toBeChecked();
     expect(historyRadioButtons[2]).not.toBeChecked();
 
-    fireEvent.click(historyRadioButtons[1]); // check activities radio option
+    await user.click(historyRadioButtons[1]); // check activities radio option
     expect(historyRadioButtons[0]).not.toBeChecked();
     expect(historyRadioButtons[2]).not.toBeChecked();
 
-    fireEvent.click(historyRadioButtons[2]); // check All radio option
+    await user.click(historyRadioButtons[2]); // check All radio option
     expect(historyRadioButtons[0]).not.toBeChecked();
     expect(historyRadioButtons[1]).not.toBeChecked();
   });

--- a/frontend/src/components/taskSelection/tests/taskList.test.js
+++ b/frontend/src/components/taskSelection/tests/taskList.test.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { act, screen, within } from '@testing-library/react';
+import { act, screen, waitFor, within } from '@testing-library/react';
 
 import { getProjectSummary } from '../../../network/tests/mockData/projects';
 import { store } from '../../../store';
@@ -48,11 +48,6 @@ describe('Task Item', () => {
   });
 
   it('should copy task URL to the clipboard', async () => {
-    const originalClipboard = { ...global.navigator.clipboard };
-    const mockClipboard = {
-      writeText: jest.fn().mockImplementation(() => Promise.resolve()),
-    };
-    global.navigator.clipboard = mockClipboard;
     const { user } = createComponentWithMemoryRouter(
       <IntlProviders>
         <TaskItem data={task} selectTask={jest.fn()} />
@@ -62,12 +57,11 @@ describe('Task Item', () => {
       },
     );
     await user.click(screen.getAllByRole('button')[2]);
-    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-      `${window.location.origin}/projects/6/tasks?search=8`,
+    await waitFor(async () =>
+      expect(await navigator.clipboard.readText()).toBe(
+        `${window.location.origin}/projects/6/tasks?search=8`,
+      ),
     );
-    jest.resetAllMocks();
-    global.navigator.clipboard = originalClipboard;
   });
 
   it('should display task detail modal', async () => {

--- a/frontend/src/components/taskSelection/tests/taskList.test.js
+++ b/frontend/src/components/taskSelection/tests/taskList.test.js
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { act, screen, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import { getProjectSummary } from '../../../network/tests/mockData/projects';
 import { store } from '../../../store';
@@ -24,12 +23,12 @@ describe('Task Item', () => {
 
   it('should set the clicked task', async () => {
     const selectTaskMock = jest.fn();
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <IntlProviders>
         <TaskItem data={task} selectTask={selectTaskMock} />
       </IntlProviders>,
     );
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /Task #8 helnershingthap/i,
       }),
@@ -39,12 +38,12 @@ describe('Task Item', () => {
 
   it('should set the zoom task ID of the task to be zoomed', async () => {
     const setZoomedTaskIdMock = jest.fn();
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <IntlProviders>
         <TaskItem data={task} selectTask={jest.fn()} setZoomedTaskId={setZoomedTaskIdMock} />
       </IntlProviders>,
     );
-    await userEvent.click(screen.getAllByRole('button')[1]);
+    await user.click(screen.getAllByRole('button')[1]);
     expect(setZoomedTaskIdMock).toHaveBeenCalledWith(8);
   });
 
@@ -54,7 +53,7 @@ describe('Task Item', () => {
       writeText: jest.fn().mockImplementation(() => Promise.resolve()),
     };
     global.navigator.clipboard = mockClipboard;
-    createComponentWithMemoryRouter(
+    const { user } = createComponentWithMemoryRouter(
       <IntlProviders>
         <TaskItem data={task} selectTask={jest.fn()} />
       </IntlProviders>,
@@ -62,7 +61,7 @@ describe('Task Item', () => {
         route: '/projects/6/tasks',
       },
     );
-    await userEvent.click(screen.getAllByRole('button')[2]);
+    await user.click(screen.getAllByRole('button')[2]);
     expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       `${window.location.origin}/projects/6/tasks?search=8`,
@@ -75,7 +74,7 @@ describe('Task Item', () => {
     act(() => {
       store.dispatch({ type: 'SET_TOKEN', token: 'validToken' });
     });
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <TaskItem
           taskId={1}
@@ -86,7 +85,7 @@ describe('Task Item', () => {
         />
       </ReduxIntlProviders>,
     );
-    await userEvent.click(screen.getByTitle(/See task history/i));
+    await user.click(screen.getByTitle(/See task history/i));
     expect(
       within(screen.getByRole('dialog')).getByRole('radio', { name: /activities/i }),
     ).toBeInTheDocument();
@@ -95,24 +94,24 @@ describe('Task Item', () => {
 
 describe('Task Filter', () => {
   it('should not show mapped option if user cannot validate', async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <IntlProviders>
         <TaskFilter userCanValidate={false} />
       </IntlProviders>,
     );
-    await userEvent.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
     expect(screen.queryByText(/mapped/i)).not.toBeInTheDocument();
   });
 
   it('should show mapped option if user can validate', async () => {
     const setStatusFn = jest.fn();
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <IntlProviders>
         <TaskFilter userCanValidate setStatusFn={setStatusFn} />
       </IntlProviders>,
     );
-    await userEvent.click(screen.getByRole('button'));
-    await userEvent.click(screen.getByText(/ready for validation/i));
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByText(/ready for validation/i));
     expect(setStatusFn).toHaveBeenCalledWith('MAPPED');
   });
 });

--- a/frontend/src/components/teamsAndOrgs/tests/campaigns.test.js
+++ b/frontend/src/components/teamsAndOrgs/tests/campaigns.test.js
@@ -1,4 +1,4 @@
-import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { IntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
 import { CampaignsManagement } from '../campaigns';
@@ -65,8 +65,8 @@ describe('CampaignsManagement component', () => {
     expect(container.querySelectorAll('svg').length).toBe(5);
   });
 
-  it('filters campaigns list by the search query', () => {
-    renderWithRouter(
+  it('filters campaigns list by the search query', async () => {
+    const { user } = renderWithRouter(
       <IntlProviders>
         <CampaignsManagement
           campaigns={dummyCampaigns}
@@ -76,17 +76,11 @@ describe('CampaignsManagement component', () => {
       </IntlProviders>,
     );
     const textField = screen.getByRole('textbox');
-    fireEvent.change(textField, {
-      target: {
-        value: '2',
-      },
-    });
+    await user.clear(textField);
+    await user.type(textField, '2');
     expect(screen.getByRole('heading', { name: 'Campaign 2' })).toHaveTextContent('Campaign 2');
-    fireEvent.change(textField, {
-      target: {
-        value: 'not 2',
-      },
-    });
+    await user.clear(textField);
+    await user.type(textField, 'not 2');
     expect(screen.queryByRole('heading', { name: 'Campaign 2' })).not.toBeInTheDocument();
     expect(screen.queryByText('There are no campaigns yet.')).toBeInTheDocument();
   });

--- a/frontend/src/components/teamsAndOrgs/tests/members.test.js
+++ b/frontend/src/components/teamsAndOrgs/tests/members.test.js
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { screen } from '@testing-library/react';
 
@@ -123,12 +122,11 @@ describe('Members Component', () => {
   });
 
   it('should display actionable buttons when edit button is clicked', async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <Members members={[]} />
       </ReduxIntlProviders>,
     );
-    const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: messages.edit.defaultMessage }));
     expect(screen.getByRole('combobox')).toBeInTheDocument();
     expect(
@@ -142,12 +140,11 @@ describe('Members Component', () => {
 
   it('should not display cross icon with only one member present', async () => {
     const mockRemoveMembers = jest.fn();
-    const { container } = renderWithRouter(
+    const { user, container } = renderWithRouter(
       <ReduxIntlProviders>
         <Members members={[usersList.users[0]]} removeMembers={mockRemoveMembers} />
       </ReduxIntlProviders>,
     );
-    const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: messages.edit.defaultMessage }));
     // Matching with that one SVG being displayed from the react-select
     expect(container.querySelectorAll('svg').length).toBe(1);

--- a/frontend/src/components/teamsAndOrgs/tests/organisations.test.js
+++ b/frontend/src/components/teamsAndOrgs/tests/organisations.test.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { FormattedMessage } from 'react-intl';
 import { Provider } from 'react-redux';
 
@@ -171,7 +171,7 @@ describe('OrgsManagement with', () => {
   });
 
   it('filters organisations list by the search query', async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <IntlProviders>
         <OrgsManagement
           organisations={orgData.organisations}
@@ -182,19 +182,13 @@ describe('OrgsManagement with', () => {
       </IntlProviders>,
     );
     const textField = screen.getByRole('textbox');
-    fireEvent.change(textField, {
-      target: {
-        value: 'Singapore',
-      },
-    });
+    await user.clear(textField);
+    await user.type(textField, 'Singapore');
     expect(screen.getByRole('heading', { name: 'Singapore Red Cross' })).toHaveTextContent(
       'Singapore Red Cross',
     );
-    fireEvent.change(textField, {
-      target: {
-        value: 'not Singapore',
-      },
-    });
+    await user.clear(textField);
+    await user.type(textField, 'not Singapore');
     expect(screen.queryByRole('heading', { name: 'Singapore Red Cross' })).not.toBeInTheDocument();
     expect(screen.queryByText('No organizations were found.')).toBeInTheDocument();
   });

--- a/frontend/src/components/teamsAndOrgs/tests/projects.test.js
+++ b/frontend/src/components/teamsAndOrgs/tests/projects.test.js
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom';
-import userEvent from '@testing-library/user-event';
 import { screen, waitFor } from '@testing-library/react';
 
 import { Projects } from '../projects';
@@ -34,12 +33,11 @@ describe('Projects component', () => {
   });
 
   it('should navigate to project creation page on new button click', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <IntlProviders>
         <Projects projects={projects} viewAllEndpoint="/view/all" showAddButton />
       </IntlProviders>,
     );
-    const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /new/i }));
     await waitFor(() => expect(router.state.location.pathname).toBe('/manage/projects/new/'));
   });
@@ -54,12 +52,11 @@ describe('Projects component', () => {
   });
 
   it('should navigate to manage projects page when view all is clicked ', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <IntlProviders>
         <Projects projects={projects} viewAllEndpoint="/path/to/view/all" />
       </IntlProviders>,
     );
-    const user = userEvent.setup();
     await user.click(
       screen.getByRole('link', {
         name: /view all/i,

--- a/frontend/src/components/teamsAndOrgs/tests/tasksStats.test.js
+++ b/frontend/src/components/teamsAndOrgs/tests/tasksStats.test.js
@@ -1,10 +1,11 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { ReduxIntlProviders } from '../../../utils/testWithIntl';
 import { tasksStats } from '../../../network/tests/mockData/tasksStats';
 import { TasksStats } from '../tasksStats';
+import userEvent from '@testing-library/user-event';
 
 jest.mock('react-chartjs-2', () => ({
   Bar: () => null,
@@ -112,6 +113,7 @@ describe('TasksStats', () => {
   });
 
   it('render "Try again" button case the error is not on the dates', async () => {
+    const user = userEvent.setup();
     render(
       <ReduxIntlProviders>
         <TasksStats
@@ -130,7 +132,7 @@ describe('TasksStats', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('An error occurred while loading stats.')).toBeInTheDocument();
     expect(screen.getByText('Try again')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Try again'));
+    await user.click(screen.getByText('Try again'));
     expect(retryFn).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/teamsAndOrgs/tests/teams.test.js
+++ b/frontend/src/components/teamsAndOrgs/tests/teams.test.js
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import TestRenderer from 'react-test-renderer';
-import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor, act } from '@testing-library/react';
 import { FormattedMessage } from 'react-intl';
 import { MemoryRouter } from 'react-router-dom';
@@ -295,12 +294,11 @@ describe('Teams component', () => {
   });
 
   it('should navigate to project creation page on new button click', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <IntlProviders>
         <Teams isReady teams={dummyTeams} viewAllQuery="/view/all" showAddButton />
       </IntlProviders>,
     );
-    const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /new/i }));
     await waitFor(() => expect(router.state.location.pathname).toBe('/manage/teams/new/'));
   });
@@ -315,12 +313,11 @@ describe('Teams component', () => {
   });
 
   it('should navigate to manage projects page when view all is clicked ', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <IntlProviders>
         <Teams isReady teams={[]} viewAllQuery="view/all" />
       </IntlProviders>,
     );
-    const user = userEvent.setup();
     await user.click(
       screen.getByRole('link', {
         name: /view all/i,
@@ -385,7 +382,7 @@ describe('Team Card', () => {
 
 describe('TeamSideBar component', () => {
   it('should search for users by search query', async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <TeamSideBar team={team} managers={[]} members={team.members} />
       </ReduxIntlProviders>,
@@ -397,7 +394,7 @@ describe('TeamSideBar component', () => {
         name: team.members[0].username,
       }),
     ).toBeInTheDocument();
-    await userEvent.type(inputField, 'not_sample_user');
+    await user.type(inputField, 'not_sample_user');
     expect(
       screen.queryByRole('link', {
         name: team.members[0].username,

--- a/frontend/src/components/tests/button.test.js
+++ b/frontend/src/components/tests/button.test.js
@@ -1,13 +1,15 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { Button, CustomButton, EditButton } from '../button';
 import { BanIcon } from '../svgIcons';
 import { renderWithRouter } from '../../utils/testWithIntl';
+import userEvent from '@testing-library/user-event';
 
 describe('Button', () => {
-  it('children and onClick props', () => {
+  it('children and onClick props', async () => {
     let testVar;
+    const user = userEvent.setup();
     const { container } = render(
       <Button className="black bg-white" onClick={() => (testVar = true)}>
         Test it
@@ -17,11 +19,12 @@ describe('Button', () => {
     expect(screen.getByRole('button').className).toBe('black bg-white br1 f5 bn pointer');
     expect(container.querySelector('svg')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
     expect(testVar).toEqual(true);
   });
-  it('loading prop', () => {
+  it('loading prop', async () => {
     let testVar = false;
+    const user = userEvent.setup();
     const { container } = render(
       <Button
         className="red bg-white"
@@ -38,11 +41,12 @@ describe('Button', () => {
     expect(container.querySelector('.mr2')).toBeInTheDocument(); // space after icon
     expect(container.querySelector('.blue')).not.toBeInTheDocument(); // ban icon is not present
 
-    fireEvent.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
     expect(testVar).toBeFalsy();
   });
-  it('disabled and icons props', () => {
+  it('disabled and icons props', async () => {
     let testVar = false;
+    const user = userEvent.setup();
     const { container } = render(
       <Button
         className="red bg-white"
@@ -59,14 +63,15 @@ describe('Button', () => {
     expect(container.querySelector('.blue')).toBeInTheDocument();
     expect(container.querySelector('.mr2')).toBeInTheDocument(); // space after icon
 
-    fireEvent.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
     expect(testVar).toBeFalsy();
   });
 });
 
 describe('CustomButton', () => {
-  it('children and onClick props, without icon', () => {
+  it('children and onClick props, without icon', async () => {
     let testVar;
+    const user = userEvent.setup();
     const { container } = render(
       <CustomButton className="black bg-white" onClick={() => (testVar = true)}>
         Test it
@@ -76,11 +81,12 @@ describe('CustomButton', () => {
     expect(screen.getByRole('button').className).toBe('black bg-white br1 f5 pointer');
     expect(container.querySelector('svg')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
     expect(testVar).toEqual(true);
   });
-  it('loading prop', () => {
+  it('loading prop', async () => {
     let testVar = false;
+    const user = userEvent.setup();
     const { container } = render(
       <CustomButton
         className="red bg-white"
@@ -97,11 +103,12 @@ describe('CustomButton', () => {
     expect(container.querySelector('.mr2')).toBeInTheDocument(); // space after icon
     expect(container.querySelector('.blue')).not.toBeInTheDocument(); // ban icon is not present
 
-    fireEvent.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
     expect(testVar).toBeFalsy();
   });
-  it('disabled and icons props', () => {
+  it('disabled and icons props', async () => {
     let testVar = false;
+    const user = userEvent.setup();
     const { container } = render(
       <CustomButton
         className="red bg-white"
@@ -118,7 +125,7 @@ describe('CustomButton', () => {
     expect(container.querySelector('.blue')).toBeInTheDocument();
     expect(container.querySelector('.mr2')).toBeInTheDocument(); // space after icon
 
-    fireEvent.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
     expect(testVar).toBeFalsy();
   });
 });

--- a/frontend/src/components/tests/checkBox.test.js
+++ b/frontend/src/components/tests/checkBox.test.js
@@ -1,13 +1,15 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { CheckBox } from '../formInputs';
+import userEvent from '@testing-library/user-event';
 
 describe('CheckBox', () => {
   let selected = [];
   const setSelected = (list) => (selected = list);
-  it('unactive when clicked select element', () => {
+  it('unactive when clicked select element', async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <CheckBox activeItems={selected} toggleFn={setSelected} itemId={1} />,
     );
@@ -15,11 +17,12 @@ describe('CheckBox', () => {
       'bg-white w1 h1 ma1 ba bw1 b--red br1 relative pointer ',
     );
     expect(container.querySelectorAll('div').length).toBe(1);
-    fireEvent.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('checkbox'));
     expect(selected).toEqual([1]);
   });
 
-  it('active when clicked unselect element', () => {
+  it('active when clicked unselect element', async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <CheckBox activeItems={selected} toggleFn={setSelected} itemId={1} />,
     );
@@ -27,7 +30,7 @@ describe('CheckBox', () => {
       'bg-white w1 h1 ma1 ba bw1 b--red br1 relative pointer ',
     );
     expect(container.querySelectorAll('div').length).toBe(2);
-    fireEvent.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('checkbox'));
     expect(selected).toEqual([]);
   });
 });

--- a/frontend/src/components/tests/selectAll.test.js
+++ b/frontend/src/components/tests/selectAll.test.js
@@ -1,14 +1,16 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { SelectAll } from '../formInputs';
+import userEvent from '@testing-library/user-event';
 
 describe('SelectAll', () => {
   const allItems = [1, 2, 3];
   let selected = [];
   const setSelected = (list) => (selected = list);
   it('unactive when clicked select all elements', async () => {
+    const user = userEvent.setup();
     const { container } = render(
       <SelectAll
         allItems={allItems}
@@ -21,12 +23,13 @@ describe('SelectAll', () => {
       'bg-white w1 h1 ma1 ba bw1 b--red br1 relative pointer dib v-mid mv3 ml3',
     );
     expect(container.querySelectorAll('div').length).toBe(1);
-    fireEvent.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('checkbox'));
     expect(selected).toEqual([1, 2, 3]);
   });
 
   it('active when clicked unselect elements', async () => {
     selected = [1, 2, 3];
+    const user = userEvent.setup();
     const { container } = render(
       <SelectAll
         allItems={allItems}
@@ -39,7 +42,7 @@ describe('SelectAll', () => {
       'bg-white w1 h1 ma1 ba bw1 b--red br1 relative pointer dib v-mid mv3 ml3',
     );
     expect(container.querySelectorAll('div').length).toBe(2);
-    fireEvent.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('checkbox'));
     expect(selected).toEqual([]);
   });
 });

--- a/frontend/src/components/user/tests/content.test.js
+++ b/frontend/src/components/user/tests/content.test.js
@@ -1,23 +1,15 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { APIKeyCard } from '../content';
 import userEvent from '@testing-library/user-event';
 import { IntlProviders } from '../../../utils/testWithIntl';
 
 test('should copy API key to the clipboard', async () => {
-  const originalClipboard = { ...global.navigator.clipboard };
-  const mockClipboard = {
-    writeText: jest.fn().mockImplementation(() => Promise.resolve()),
-  };
-  global.navigator.clipboard = mockClipboard;
-  const user = userEvent.setup();
+  const user = userEvent.setup({ writeToClipboard: true });
   render(
     <IntlProviders>
       <APIKeyCard token="validToken" />
     </IntlProviders>,
   );
   await user.click(screen.getByRole('img'));
-  expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
-  expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Token validToken');
-  jest.resetAllMocks();
-  global.navigator.clipboard = originalClipboard;
+  await waitFor(async () => expect(await navigator.clipboard.readText()).toBe('Token validToken'));
 });

--- a/frontend/src/components/user/tests/content.test.js
+++ b/frontend/src/components/user/tests/content.test.js
@@ -9,12 +9,13 @@ test('should copy API key to the clipboard', async () => {
     writeText: jest.fn().mockImplementation(() => Promise.resolve()),
   };
   global.navigator.clipboard = mockClipboard;
+  const user = userEvent.setup();
   render(
     <IntlProviders>
       <APIKeyCard token="validToken" />
     </IntlProviders>,
   );
-  await userEvent.click(screen.getByRole('img'));
+  await user.click(screen.getByRole('img'));
   expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
   expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Token validToken');
   jest.resetAllMocks();

--- a/frontend/src/utils/testWithIntl.js
+++ b/frontend/src/utils/testWithIntl.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { BrowserRouter, createMemoryRouter, RouterProvider } from 'react-router-dom';
 import TestRenderer from 'react-test-renderer';
 
 import { store } from '../store';
+import userEvent from '@testing-library/user-event';
 
 export const createComponentWithIntl = (children, props = { locale: 'en' }) => {
   return TestRenderer.create(<IntlProvider {...props}>{children}</IntlProvider>);
@@ -16,9 +17,10 @@ export const createComponentWithReduxAndIntl = (children, props = { locale: 'en'
 };
 
 export const renderWithRouter = (ui, { route = '/' } = {}) => {
-  window.history.pushState({}, 'Test page', route);
+  act(() => window.history.pushState({}, 'Test page', route));
 
   return {
+    user: userEvent.setup(),
     ...render(ui, { wrapper: BrowserRouter }),
   };
 };
@@ -41,6 +43,7 @@ export const createComponentWithMemoryRouter = (
   component,
   { route = '/starting/path', entryRoute = route } = {},
 ) => {
+  const user = userEvent.setup();
   const router = createMemoryRouter(
     [
       {
@@ -65,5 +68,5 @@ export const createComponentWithMemoryRouter = (
 
   const { container } = render(<RouterProvider router={router} />);
 
-  return { container, router };
+  return { user, container, router };
 };

--- a/frontend/src/utils/testWithIntl.js
+++ b/frontend/src/utils/testWithIntl.js
@@ -20,7 +20,7 @@ export const renderWithRouter = (ui, { route = '/' } = {}) => {
   act(() => window.history.pushState({}, 'Test page', route));
 
   return {
-    user: userEvent.setup(),
+    user: userEvent.setup({ copyToClipboard: true }),
     ...render(ui, { wrapper: BrowserRouter }),
   };
 };

--- a/frontend/src/views/tests/campaigns.test.js
+++ b/frontend/src/views/tests/campaigns.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import toast from 'react-hot-toast';
 
@@ -55,7 +55,7 @@ describe('CampaignError', () => {
 
 describe('CreateCampaign', () => {
   const setup = () => {
-    const { history } = renderWithRouter(
+    const { user, history } = renderWithRouter(
       <ReduxIntlProviders>
         <CreateCampaign />
       </ReduxIntlProviders>,
@@ -67,6 +67,7 @@ describe('CreateCampaign', () => {
       name: /cancel/i,
     });
     return {
+      user,
       createButton,
       cancelButton,
       history,
@@ -79,14 +80,15 @@ describe('CreateCampaign', () => {
   });
 
   it('should enable create campaign button when the value is changed', async () => {
-    const { createButton } = setup();
+    const { user, createButton } = setup();
     const inputText = screen.getByRole('textbox');
-    fireEvent.change(inputText, { target: { value: 'New Campaign Name' } });
+    await user.clear(inputText);
+    await user.type(inputText, 'New Campaign Name');
     expect(createButton).toBeEnabled();
   });
 
   it('should navigate to the newly created campaign detail page on creation success', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <CreateCampaign />
       </ReduxIntlProviders>,
@@ -95,10 +97,11 @@ describe('CreateCampaign', () => {
       name: /create campaign/i,
     });
     const inputText = screen.getByRole('textbox');
-    fireEvent.change(inputText, { target: { value: 'New Campaign Name' } });
+    await user.clear(inputText);
+    await user.type(inputText, 'New Campaign Name');
     expect(inputText.value).toBe('New Campaign Name');
     expect(createButton).toBeEnabled();
-    fireEvent.click(createButton);
+    await user.click(createButton);
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledTimes(1);
       expect(router.state.location.pathname).toBe('/manage/campaigns/123');
@@ -107,7 +110,7 @@ describe('CreateCampaign', () => {
 
   it('should display toast with error has occured message', async () => {
     setupFaultyHandlers();
-    createComponentWithMemoryRouter(
+    const { user } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <CreateCampaign />
       </ReduxIntlProviders>,
@@ -116,10 +119,11 @@ describe('CreateCampaign', () => {
       name: /create campaign/i,
     });
     const inputText = screen.getByRole('textbox');
-    fireEvent.change(inputText, { target: { value: 'New Campaign Name' } });
+    await user.clear(inputText);
+    await user.type(inputText, 'New Campaign Name');
     expect(inputText.value).toBe('New Campaign Name');
     expect(createButton).toBeEnabled();
-    fireEvent.click(createButton);
+    await user.click(createButton);
     await waitFor(() =>
       expect(screen.getByText(/Failed to create campaign. Please try again./i)).toBeInTheDocument(),
     );
@@ -130,7 +134,7 @@ describe('CreateCampaign', () => {
 
 describe('EditCampaign', () => {
   const setup = () => {
-    const { container, history } = renderWithRouter(
+    const { user, container, history } = renderWithRouter(
       <ReduxIntlProviders>
         <EditCampaign id={123} />
       </ReduxIntlProviders>,
@@ -138,6 +142,7 @@ describe('EditCampaign', () => {
     const inputText = screen.getByRole('textbox');
 
     return {
+      user,
       container,
       inputText,
       history,
@@ -151,9 +156,10 @@ describe('EditCampaign', () => {
   });
 
   it('should display save button when project name is changed', async () => {
-    const { inputText } = setup();
+    const { user, inputText } = setup();
     await waitFor(() => expect(inputText.value).toBe('Campaign Name 123'));
-    fireEvent.change(inputText, { target: { value: 'Changed Campaign Name' } });
+    await user.clear(inputText);
+    await user.type(inputText, 'Changed Campaign Name');
     const saveButton = screen.getByRole('button', {
       name: /save/i,
     });
@@ -161,9 +167,10 @@ describe('EditCampaign', () => {
   });
 
   it('should also display cancel button when project name is changed', async () => {
-    const { inputText } = setup();
+    const { user, inputText } = setup();
     await waitFor(() => expect(inputText.value).toBe('Campaign Name 123'));
-    fireEvent.change(inputText, { target: { value: 'Changed Campaign Name' } });
+    await user.clear(inputText);
+    await user.type(inputText, 'Changed Campaign Name');
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
@@ -171,13 +178,14 @@ describe('EditCampaign', () => {
   });
 
   it('should return input text value to default when cancel button is clicked', async () => {
-    const { inputText } = setup();
+    const { user, inputText } = setup();
     await waitFor(() => expect(inputText.value).toBe('Campaign Name 123'));
-    fireEvent.change(inputText, { target: { value: 'Changed Campaign Name' } });
+    await user.clear(inputText);
+    await user.type(inputText, 'Changed Campaign Name');
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
-    fireEvent.click(cancelButton);
+    await user.click(cancelButton);
     expect(inputText.value).toBe('Campaign Name 123');
   });
 
@@ -197,14 +205,15 @@ describe('EditCampaign', () => {
   });
 
   it('should hide the save button after campaign edit is successful', async () => {
-    const { inputText } = setup();
+    const { user, inputText } = setup();
     await waitFor(() => expect(inputText.value).toBe('Campaign Name 123'));
-    fireEvent.change(inputText, { target: { value: 'Changed Campaign Name' } });
+    await user.clear(inputText);
+    await user.type(inputText, 'Changed Campaign Name');
     const saveButton = screen.getByRole('button', { name: /save/i });
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
-    fireEvent.click(saveButton);
+    await user.click(saveButton);
     const savingLoder = within(saveButton).getByRole('img', {
       hidden: true,
     });
@@ -218,11 +227,12 @@ describe('EditCampaign', () => {
 
   it('should display toast with error has occured message', async () => {
     setupFaultyHandlers();
-    const { inputText } = setup();
+    const { user, inputText } = setup();
     await waitFor(() => expect(inputText.value).toBe('Campaign Name 123'));
-    fireEvent.change(inputText, { target: { value: 'Changed Campaign Name' } });
+    await user.clear(inputText);
+    await user.type(inputText, 'Changed Campaign Name');
     const saveButton = screen.getByRole('button', { name: /save/i });
-    fireEvent.click(saveButton);
+    await user.click(saveButton);
     await waitFor(() => {
       expect(screen.getByText(/There was an error saving this campaign./i)).toBeInTheDocument();
     });
@@ -231,7 +241,7 @@ describe('EditCampaign', () => {
 
 describe('Delete Campaign', () => {
   const setup = () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <ReduxIntlProviders>
         <EditCampaign id={123} />
       </ReduxIntlProviders>,
@@ -239,38 +249,39 @@ describe('Delete Campaign', () => {
     const inputText = screen.getByRole('textbox');
 
     return {
+      user,
       inputText,
     };
   };
 
   it('should ask for confirmation when user tries to delete a campaign', async () => {
-    setup();
+    const { user } = setup();
     expect(await screen.findByText('NRCS_Duduwa Mapping')).toBeInTheDocument();
     const deleteButton = screen.getByRole('button', {
       name: /delete/i,
     });
-    fireEvent.click(deleteButton);
+    await user.click(deleteButton);
     expect(screen.getByText('Are you sure you want to delete this campaign?')).toBeInTheDocument();
   });
 
   it('should close the confirmation popup when cancel is clicked', async () => {
-    setup();
+    const { user } = setup();
     expect(await screen.findByText('NRCS_Duduwa Mapping')).toBeInTheDocument();
     const deleteButton = screen.getByRole('button', {
       name: /delete/i,
     });
-    fireEvent.click(deleteButton);
+    await user.click(deleteButton);
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
-    fireEvent.click(cancelButton);
+    await user.click(cancelButton);
     expect(
       screen.queryByText('Are you sure you want to delete this campaign?'),
     ).not.toBeInTheDocument();
   });
 
   it('should direct to campaigns list page on successful deletion of a campaign', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <EditCampaign id={123} />
       </ReduxIntlProviders>,
@@ -279,12 +290,12 @@ describe('Delete Campaign', () => {
     const deleteButton = screen.getByRole('button', {
       name: /delete/i,
     });
-    fireEvent.click(deleteButton);
+    await user.click(deleteButton);
     const dialog = screen.getByRole('dialog');
     const deleteConfirmationButton = within(dialog).getByRole('button', {
       name: /delete/i,
     });
-    fireEvent.click(deleteConfirmationButton);
+    await user.click(deleteConfirmationButton);
     expect(await screen.findByText('Campaign deleted successfully.')).toBeInTheDocument();
     await waitFor(() => {
       expect(router.state.location.pathname).toBe('/manage/campaigns');
@@ -293,7 +304,7 @@ describe('Delete Campaign', () => {
 
   it('should direct to campaigns list page on successful deletion of a campaign', async () => {
     setupFaultyHandlers();
-    createComponentWithMemoryRouter(
+    const { user } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <EditCampaign id={123} />
       </ReduxIntlProviders>,
@@ -302,12 +313,12 @@ describe('Delete Campaign', () => {
     const deleteButton = screen.getByRole('button', {
       name: /delete/i,
     });
-    fireEvent.click(deleteButton);
+    await user.click(deleteButton);
     const dialog = screen.getByRole('dialog');
     const deleteConfirmationButton = within(dialog).getByRole('button', {
       name: /delete/i,
     });
-    fireEvent.click(deleteConfirmationButton);
+    await user.click(deleteConfirmationButton);
     await waitFor(() => {
       expect(
         screen.getByText(/An error occurred when trying to delete this campaign/i),

--- a/frontend/src/views/tests/contact.test.js
+++ b/frontend/src/views/tests/contact.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { ReduxIntlProviders, renderWithRouter } from '../../utils/testWithIntl';
 import { ContactPage } from '../contact';
 
-test('Contact page', () => {
-  const { container } = renderWithRouter(
+test('Contact page', async () => {
+  const { user, container } = renderWithRouter(
     <ReduxIntlProviders>
       <ContactPage />
     </ReduxIntlProviders>,
@@ -19,8 +19,12 @@ test('Contact page', () => {
   expect(screen.getByText('Send').className).toContain('bg-red o-50 white');
 
   const [name, email] = container.querySelectorAll('input');
-  fireEvent.change(name, { target: { value: 'User' } });
-  fireEvent.change(email, { target: { value: 'a@e.com' } });
-  fireEvent.change(container.querySelector('textarea'), { target: { value: 'Hola! Danke!' } });
+  const textArea = container.querySelector('textarea');
+  await user.clear(name);
+  await user.clear(email);
+  await user.clear(textArea);
+  await user.type(name, 'User');
+  await user.type(email, 'a@e.com');
+  await user.type(textArea, 'Hola! Danke!');
   expect(screen.getByText('Send').className).not.toContain('o-50');
 });

--- a/frontend/src/views/tests/contributions.test.js
+++ b/frontend/src/views/tests/contributions.test.js
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom';
-import userEvent from '@testing-library/user-event';
 import { act, screen, waitFor } from '@testing-library/react';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import { QueryParamProvider } from 'use-query-params';
@@ -38,7 +37,7 @@ describe('Contributions Page', () => {
       store.dispatch({ type: 'SET_TOKEN', token: 'validToken' });
     });
 
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <ReduxIntlProviders>
           <ContributionsPage />
@@ -46,7 +45,6 @@ describe('Contributions Page', () => {
       </QueryParamProvider>,
     );
     expect(screen.getByRole('heading', { name: /my tasks/i })).toBeInTheDocument();
-    const user = userEvent.setup();
     await user.click(screen.getByRole('combobox'));
     expect(await screen.findByText('#8629')).toBeInTheDocument();
     expect(await screen.findByText('Task #1822 · Project #5871')).toBeInTheDocument();

--- a/frontend/src/views/tests/fallback.test.js
+++ b/frontend/src/views/tests/fallback.test.js
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import { IntlProviders, renderWithRouter } from '../../utils/testWithIntl';
 import { FallbackComponent } from '../fallback';
@@ -62,7 +61,7 @@ describe('Fallback component', () => {
   });
 
   it('should trigger navigate on return button click', async () => {
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <IntlProviders>
         <FallbackComponent />
       </IntlProviders>,
@@ -71,7 +70,7 @@ describe('Fallback component', () => {
     const returnBtn = screen.getByRole('button', {
       name: messages.return.defaultMessage,
     });
-    await userEvent.click(returnBtn);
+    await user.click(returnBtn);
     await waitFor(() => expect(mockedUsedNavigate).toHaveBeenCalledTimes(1));
   });
 });

--- a/frontend/src/views/tests/interests.test.js
+++ b/frontend/src/views/tests/interests.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import toast from 'react-hot-toast';
 
@@ -46,7 +46,7 @@ describe('List Interests', () => {
   });
 
   it('should navigate to interest edit page when clicked on the interest card', async () => {
-    const { container, router } = createComponentWithMemoryRouter(
+    const { user, container, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <ListInterests />
       </ReduxIntlProviders>,
@@ -57,7 +57,7 @@ describe('List Interests', () => {
     await waitFor(() =>
       expect(container.getElementsByClassName('show-loading-animation').length).toBe(0),
     );
-    fireEvent.click(
+    await user.click(
       screen.getByRole('link', {
         name: /Interest Name 1/i,
       }),
@@ -68,7 +68,7 @@ describe('List Interests', () => {
 
 describe('Create Interest', () => {
   const setup = () => {
-    const { history } = renderWithRouter(
+    const { user, history } = renderWithRouter(
       <ReduxIntlProviders>
         <CreateInterest />
       </ReduxIntlProviders>,
@@ -78,6 +78,7 @@ describe('Create Interest', () => {
       name: /cancel/i,
     });
     return {
+      user,
       createButton,
       cancelButton,
       history,
@@ -90,22 +91,24 @@ describe('Create Interest', () => {
   });
 
   it('should enable create interest button when the value is changed', async () => {
-    const { createButton } = setup();
+    const { user, createButton } = setup();
     const nameInput = screen.getByRole('textbox');
-    fireEvent.change(nameInput, { target: { value: 'New interest Name' } });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'New interest Name');
     expect(createButton).toBeEnabled();
   });
 
   it('should navigate to the newly created interest detail page on creation success', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <CreateInterest />
       </ReduxIntlProviders>,
     );
     const createButton = screen.getByRole('button', { name: /create category/i });
     const nameInput = screen.getByRole('textbox');
-    fireEvent.change(nameInput, { target: { value: 'New interest Name' } });
-    fireEvent.click(createButton);
+    await user.clear(nameInput);
+    await user.type(nameInput, 'New interest Name');
+    await user.click(createButton);
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledTimes(1);
       expect(router.state.location.pathname).toBe('/manage/categories/123');
@@ -114,15 +117,16 @@ describe('Create Interest', () => {
 
   it('should display callout alert with error has occured message', async () => {
     setupFaultyHandlers();
-    createComponentWithMemoryRouter(
+    const { user } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <CreateInterest />
       </ReduxIntlProviders>,
     );
     const createButton = screen.getByRole('button', { name: /create category/i });
     const nameInput = screen.getByRole('textbox');
-    fireEvent.change(nameInput, { target: { value: 'New interest Name' } });
-    fireEvent.click(createButton);
+    await user.clear(nameInput);
+    await user.type(nameInput, 'New interest Name');
+    await user.click(createButton);
     await waitFor(() => {
       expect(screen.getByText(/Failed to create category. Please try again./i)).toBeInTheDocument();
     });
@@ -133,7 +137,7 @@ describe('Create Interest', () => {
 
 describe('Edit Interest', () => {
   const setup = () => {
-    createComponentWithMemoryRouter(
+    const { user } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <EditInterest />
       </ReduxIntlProviders>,
@@ -145,6 +149,7 @@ describe('Edit Interest', () => {
     const nameInput = screen.getByRole('textbox');
 
     return {
+      user,
       nameInput,
     };
   };
@@ -155,9 +160,10 @@ describe('Edit Interest', () => {
   });
 
   it('should display save button when interest name is changed', async () => {
-    const { nameInput } = setup();
+    const { user, nameInput } = setup();
     await waitFor(() => expect(nameInput.value).toBe('Interest Name 123'));
-    fireEvent.change(nameInput, { target: { value: 'Changed Interest Name' } });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Changed Interest Name');
     const saveButton = screen.getByRole('button', {
       name: /save/i,
     });
@@ -165,9 +171,10 @@ describe('Edit Interest', () => {
   });
 
   it('should also display cancel button when project name is changed', async () => {
-    const { nameInput } = setup();
+    const { user, nameInput } = setup();
     await waitFor(() => expect(nameInput.value).toBe('Interest Name 123'));
-    fireEvent.change(nameInput, { target: { value: 'Changed Interest Name' } });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Changed Interest Name');
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
@@ -175,25 +182,27 @@ describe('Edit Interest', () => {
   });
 
   it('should return input text value to default when cancel button is clicked', async () => {
-    const { nameInput } = setup();
+    const { user, nameInput } = setup();
     await waitFor(() => expect(nameInput.value).toBe('Interest Name 123'));
-    fireEvent.change(nameInput, { target: { value: 'Changed Interest Name' } });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Changed Interest Name');
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
-    fireEvent.click(cancelButton);
+    await user.click(cancelButton);
     expect(nameInput.value).toBe('Interest Name 123');
   });
 
   it('should hide the save button on click', async () => {
-    const { nameInput } = setup();
+    const { user, nameInput } = setup();
     await waitFor(() => expect(nameInput.value).toBe('Interest Name 123'));
-    fireEvent.change(nameInput, { target: { value: 'Changed Interest Name' } });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Changed Interest Name');
     const saveButton = screen.getByRole('button', { name: /save/i });
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
-    fireEvent.click(saveButton);
+    await user.click(saveButton);
     await waitFor(() => expect(saveButton).not.toBeInTheDocument());
     expect(cancelButton).not.toBeInTheDocument();
   });

--- a/frontend/src/views/tests/licenses.test.js
+++ b/frontend/src/views/tests/licenses.test.js
@@ -219,7 +219,7 @@ describe('Edit License', () => {
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
-    user.click(saveButton);
+    await user.click(saveButton);
     await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1));
     expect(saveButton).not.toBeInTheDocument();
     expect(cancelButton).not.toBeInTheDocument();
@@ -235,7 +235,7 @@ describe('Edit License', () => {
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
-    user.click(saveButton);
+    await user.click(saveButton);
     await waitFor(() =>
       expect(
         screen.getByText(/Failed to update license information. Please try again/i),

--- a/frontend/src/views/tests/licenses.test.js
+++ b/frontend/src/views/tests/licenses.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import toast from 'react-hot-toast';
 
@@ -46,7 +46,7 @@ describe('List Licenses', () => {
   });
 
   it('should navigate to license edit page when clicked on the license card', async () => {
-    const { container, router } = createComponentWithMemoryRouter(
+    const { user, container, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <ListLicenses />
       </ReduxIntlProviders>,
@@ -57,7 +57,7 @@ describe('List Licenses', () => {
     await waitFor(() =>
       expect(container.getElementsByClassName('show-loading-animation').length).toBe(0),
     );
-    fireEvent.click(
+    await user.click(
       screen.getByRole('link', {
         name: /license 1/i,
       }),
@@ -68,7 +68,7 @@ describe('List Licenses', () => {
 
 describe('Create License', () => {
   const setup = () => {
-    const { history } = renderWithRouter(
+    const { user, history } = renderWithRouter(
       <ReduxIntlProviders>
         <CreateLicense />
       </ReduxIntlProviders>,
@@ -78,6 +78,7 @@ describe('Create License', () => {
       name: /cancel/i,
     });
     return {
+      user,
       createButton,
       cancelButton,
       history,
@@ -90,26 +91,30 @@ describe('Create License', () => {
   });
 
   it('should enable create license button when the value is changed', async () => {
-    const { createButton } = setup();
+    const { user, createButton } = setup();
     const nameInput = screen.getAllByRole('textbox')[0];
-    fireEvent.change(nameInput, { target: { value: 'New license Name' } });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'New license Name');
     expect(createButton).toBeEnabled();
   });
 
   it('should navigate to the newly created license detail page on creation success', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <CreateLicense />
       </ReduxIntlProviders>,
     );
     const createButton = screen.getByRole('button', { name: /create license/i });
     const nameInput = screen.getAllByRole('textbox')[0];
-    fireEvent.change(nameInput, { target: { value: 'New license Name' } });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'New license Name');
     const descriptionInput = screen.getAllByRole('textbox')[1];
-    fireEvent.change(descriptionInput, { target: { value: 'New license description' } });
+    await user.clear(descriptionInput);
+    await user.type(descriptionInput, 'New license description');
     const plainTextInput = screen.getAllByRole('textbox')[2];
-    fireEvent.change(plainTextInput, { target: { value: 'New license plain text' } });
-    fireEvent.click(createButton);
+    await user.clear(plainTextInput);
+    await user.type(plainTextInput, 'New license plain text');
+    await user.click(createButton);
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledTimes(1);
       expect(router.state.location.pathname).toBe('/manage/licenses/123');
@@ -118,19 +123,22 @@ describe('Create License', () => {
 
   it('should display toast with error has occured message', async () => {
     setupFaultyHandlers();
-    createComponentWithMemoryRouter(
+    const { user } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <CreateLicense />
       </ReduxIntlProviders>,
     );
     const createButton = screen.getByRole('button', { name: /create license/i });
     const nameInput = screen.getAllByRole('textbox')[0];
-    fireEvent.change(nameInput, { target: { value: 'New license Name' } });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'New license Name');
     const descriptionInput = screen.getAllByRole('textbox')[1];
-    fireEvent.change(descriptionInput, { target: { value: 'New license description' } });
+    await user.clear(descriptionInput);
+    await user.type(descriptionInput, 'New license description');
     const plainTextInput = screen.getAllByRole('textbox')[2];
-    fireEvent.change(plainTextInput, { target: { value: 'New license plain text' } });
-    fireEvent.click(createButton);
+    await user.clear(plainTextInput);
+    await user.type(plainTextInput, 'New license plain text');
+    await user.click(createButton);
     await waitFor(() =>
       expect(screen.getByText(/Failed to create license. Please try again./i)).toBeInTheDocument(),
     );
@@ -141,7 +149,7 @@ describe('Create License', () => {
 
 describe('Edit License', () => {
   const setup = () => {
-    const { history } = renderWithRouter(
+    const { user, history } = renderWithRouter(
       <ReduxIntlProviders>
         <EditLicense id={1} />
       </ReduxIntlProviders>,
@@ -151,6 +159,7 @@ describe('Edit License', () => {
     const plainTextInput = screen.getAllByRole('textbox')[2];
 
     return {
+      user,
       nameInput,
       descriptionInput,
       plainTextInput,
@@ -168,9 +177,10 @@ describe('Edit License', () => {
   });
 
   it('should display save button when project name is changed', async () => {
-    const { nameInput } = setup();
+    const { user, nameInput } = setup();
     await waitFor(() => expect(nameInput.value).toBe('Sample License'));
-    fireEvent.change(nameInput, { target: { value: 'Changed License Name' } });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Changed License Name');
     const saveButton = screen.getByRole('button', {
       name: /save/i,
     });
@@ -178,9 +188,10 @@ describe('Edit License', () => {
   });
 
   it('should also display cancel button when project name is changed', async () => {
-    const { nameInput } = setup();
+    const { user, nameInput } = setup();
     await waitFor(() => expect(nameInput.value).toBe('Sample License'));
-    fireEvent.change(nameInput, { target: { value: 'Changed License Name' } });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Changed License Name');
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
@@ -188,25 +199,27 @@ describe('Edit License', () => {
   });
 
   it('should return input text value to default when cancel button is clicked', async () => {
-    const { nameInput } = setup();
+    const { user, nameInput } = setup();
     await waitFor(() => expect(nameInput.value).toBe('Sample License'));
-    fireEvent.change(nameInput, { target: { value: 'Changed License Name' } });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Changed License Name');
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
-    fireEvent.click(cancelButton);
+    await user.click(cancelButton);
     expect(nameInput.value).toBe('Sample License');
   });
 
   it('should hide the save button on click', async () => {
-    const { nameInput } = setup();
+    const { user, nameInput } = setup();
     await waitFor(() => expect(nameInput.value).toBe('Sample License'));
-    fireEvent.change(nameInput, { target: { value: 'Changed License Name' } });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Changed License Name');
     const saveButton = screen.getByRole('button', { name: /save/i });
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
-    fireEvent.click(saveButton);
+    user.click(saveButton);
     await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1));
     expect(saveButton).not.toBeInTheDocument();
     expect(cancelButton).not.toBeInTheDocument();
@@ -214,14 +227,15 @@ describe('Edit License', () => {
 
   it('should display toast with error has occured message', async () => {
     setupFaultyHandlers();
-    const { nameInput } = setup();
+    const { user, nameInput } = setup();
     await waitFor(() => expect(nameInput.value).toBe('Sample License'));
-    fireEvent.change(nameInput, { target: { value: 'Changed License Name' } });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Changed License Name');
     const saveButton = screen.getByRole('button', { name: /save/i });
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
-    fireEvent.click(saveButton);
+    user.click(saveButton);
     await waitFor(() =>
       expect(
         screen.getByText(/Failed to update license information. Please try again/i),
@@ -234,7 +248,7 @@ describe('Edit License', () => {
 
 describe('Delete License', () => {
   const setup = () => {
-    const { history } = renderWithRouter(
+    const { user, history } = renderWithRouter(
       <ReduxIntlProviders>
         <EditLicense id={1} />
       </ReduxIntlProviders>,
@@ -244,6 +258,7 @@ describe('Delete License', () => {
     const plainTextInput = screen.getAllByRole('textbox')[2];
 
     return {
+      user,
       nameInput,
       descriptionInput,
       plainTextInput,
@@ -252,33 +267,33 @@ describe('Delete License', () => {
   };
 
   it('should ask for confirmation when user tries to delete a license', async () => {
-    const { nameInput } = setup();
+    const { user, nameInput } = setup();
     await waitFor(() => expect(nameInput.value).toBe('Sample License'));
     const deleteButton = screen.getByRole('button', {
       name: /delete/i,
     });
-    fireEvent.click(deleteButton);
+    await user.click(deleteButton);
     expect(screen.getByText('Are you sure you want to delete this license?')).toBeInTheDocument();
   });
 
   it('should close the confirmation popup when cancel is clicked', async () => {
-    const { nameInput } = setup();
+    const { user, nameInput } = setup();
     await waitFor(() => expect(nameInput.value).toBe('Sample License'));
     const deleteButton = screen.getByRole('button', {
       name: /delete/i,
     });
-    fireEvent.click(deleteButton);
+    await user.click(deleteButton);
     const cancelButton = screen.getByRole('button', {
       name: /cancel/i,
     });
-    fireEvent.click(cancelButton);
+    await user.click(cancelButton);
     expect(
       screen.queryByText('Are you sure you want to delete this license?'),
     ).not.toBeInTheDocument();
   });
 
   it('should direct to licenses list page on successful deletion of a license', async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <EditLicense id={1} />
       </ReduxIntlProviders>,
@@ -288,12 +303,12 @@ describe('Delete License', () => {
     const deleteButton = screen.getByRole('button', {
       name: /delete/i,
     });
-    fireEvent.click(deleteButton);
+    await user.click(deleteButton);
     const dialog = screen.getByRole('dialog');
     const deleteConfirmationButton = within(dialog).getByRole('button', {
       name: /delete/i,
     });
-    fireEvent.click(deleteConfirmationButton);
+    await user.click(deleteConfirmationButton);
     expect(await screen.findByText('License deleted successfully.')).toBeInTheDocument();
     await waitFor(() => expect(router.state.location.pathname).toBe('/manage/licenses'));
   });

--- a/frontend/src/views/tests/login.test.js
+++ b/frontend/src/views/tests/login.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { ReduxIntlProviders, renderWithRouter } from '../../utils/testWithIntl';
 import { Login } from '../login';
 
-test('Login component renders the elements correctly formatted', () => {
-  renderWithRouter(
+test('Login component renders the elements correctly formatted', async () => {
+  const { user } = renderWithRouter(
     <ReduxIntlProviders>
       <Login redirectTo={'/welcome'} />
     </ReduxIntlProviders>,
@@ -16,7 +16,7 @@ test('Login component renders the elements correctly formatted', () => {
   expect(screen.getByText('Create an account').className).toContain('bg-blue-dark white ml1 v-mid');
   expect(screen.queryByText('Sign up')).not.toBeInTheDocument();
   expect(screen.queryByText('Name')).not.toBeInTheDocument();
-  fireEvent.click(screen.getByText('Create an account'));
+  await user.click(screen.getByText('Create an account'));
   expect(screen.getByText('Name')).toBeInTheDocument();
   expect(screen.getByText('Email')).toBeInTheDocument();
   expect(screen.getByText('Next')).toBeInTheDocument();

--- a/frontend/src/views/tests/organisationManagement.test.js
+++ b/frontend/src/views/tests/organisationManagement.test.js
@@ -216,9 +216,10 @@ describe('Edit Organisation', () => {
     const { user } = setup();
     await waitFor(() => expect(screen.getByText('Manage organization')).toBeInTheDocument());
     await user.click(screen.getAllByRole('button')[2]);
-    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-      `${window.location.origin}/organisations/organisation-name-123/`,
+    await waitFor(async () =>
+      expect(await navigator.clipboard.readText()).toBe(
+        `${window.location.origin}/organisations/organisation-name-123/`,
+      ),
     );
   });
 

--- a/frontend/src/views/tests/project.test.js
+++ b/frontend/src/views/tests/project.test.js
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom';
-import userEvent from '@testing-library/user-event';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import { QueryParamProvider } from 'use-query-params';
 import { act, render, screen, waitFor } from '@testing-library/react';
@@ -100,7 +99,7 @@ describe('UserProjectsPage Component', () => {
 });
 
 test('More Filters should close the more filters container when clicked outside the container', async () => {
-  const { router } = createComponentWithMemoryRouter(
+  const { user, router } = createComponentWithMemoryRouter(
     <QueryParamProvider adapter={ReactRouter6Adapter}>
       <ReduxIntlProviders>
         <MoreFilters />
@@ -113,7 +112,7 @@ test('More Filters should close the more filters container when clicked outside 
     }),
   ).toBeInTheDocument();
 
-  await userEvent.click(screen.getAllByRole('button')[2]);
+  await user.click(screen.getAllByRole('button')[2]);
   await waitFor(() => expect(router.state.location.pathname).toBe('/explore'));
 });
 
@@ -144,7 +143,7 @@ describe('ManageProjectsPage', () => {
     act(() => {
       store.dispatch({ type: 'TOGGLE_MAP' });
     });
-    renderWithRouter(
+    const { user } = renderWithRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <ReduxIntlProviders>
           <ManageProjectsPage />
@@ -152,7 +151,6 @@ describe('ManageProjectsPage', () => {
       </QueryParamProvider>,
     );
 
-    const user = userEvent.setup();
     await user.click(screen.getByRole('checkbox'));
     // Since WebGL is not supported by Node, we'll assume that the map context will be loaded
     expect(screen.getByRole('heading', { name: 'WebGL Context Not Found' })).toBeInTheDocument();

--- a/frontend/src/views/tests/taskAction.test.js
+++ b/frontend/src/views/tests/taskAction.test.js
@@ -2,7 +2,6 @@ import '@testing-library/jest-dom';
 import { screen, act, waitFor } from '@testing-library/react';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 import { QueryParamProvider } from 'use-query-params';
-import userEvent from '@testing-library/user-event';
 
 import { MapTask, TaskAction, ValidateTask } from '../taskAction';
 import {
@@ -14,7 +13,7 @@ import { store } from '../../store';
 
 describe('Submitting Mapping Status for a Task', () => {
   const setup = () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <ReduxIntlProviders>
           <MapTask />
@@ -26,7 +25,7 @@ describe('Submitting Mapping Status for a Task', () => {
       },
     );
 
-    return { router };
+    return { user, router };
   };
 
   it('should stop mapping and direct to tasks selection page', async () => {
@@ -39,7 +38,7 @@ describe('Submitting Mapping Status for a Task', () => {
       });
     });
 
-    const { router } = setup();
+    const { user, router } = setup();
     await waitFor(() => {
       expect(
         screen.getByRole('button', {
@@ -47,7 +46,7 @@ describe('Submitting Mapping Status for a Task', () => {
         }),
       ).toBeInTheDocument();
     });
-    await userEvent.click(screen.getByRole('button', { name: /select another task/i }));
+    await user.click(screen.getByRole('button', { name: /select another task/i }));
     await waitFor(() => expect(router.state.location.pathname).toBe('/projects/123/tasks/'));
   });
 
@@ -69,12 +68,11 @@ describe('Submitting Mapping Status for a Task', () => {
   });
 
   it('should submit task mapping status (YES option) and direct to tasks selection page', async () => {
-    const { router } = setup();
+    const { user, router } = setup();
     const submitBtn = await screen.findByRole('button', {
       name: /submit task/i,
     });
     expect(submitBtn).toBeDisabled();
-    const user = userEvent.setup();
     await user.click(
       screen.getByRole('radio', {
         name: /yes/i,
@@ -86,12 +84,11 @@ describe('Submitting Mapping Status for a Task', () => {
   });
 
   it('should submit task mapping status (NO option) and direct to tasks selection page', async () => {
-    const { router } = setup();
+    const { user, router } = setup();
     const submitBtn = await screen.findByRole('button', {
       name: /submit task/i,
     });
     expect(submitBtn).toBeDisabled();
-    const user = userEvent.setup();
     await user.click(
       screen.getByRole('radio', {
         name: /no/i,
@@ -111,12 +108,11 @@ describe('Submitting Mapping Status for a Task', () => {
       });
     });
 
-    const { router } = setup();
+    const { user, router } = setup();
     const submitBtn = await screen.findByRole('button', {
       name: /submit task/i,
     });
     expect(submitBtn).toBeDisabled();
-    const user = userEvent.setup();
     await user.click(
       screen.getByRole('radio', {
         name: /the imagery is bad/i,
@@ -136,12 +132,11 @@ describe('Submitting Mapping Status for a Task', () => {
       });
     });
 
-    const { router } = setup();
+    const { user, router } = setup();
     const submitBtn = await screen.findByRole('button', {
       name: /submit task/i,
     });
     expect(submitBtn).toBeDisabled();
-    const user = userEvent.setup();
     await user.click(
       screen.getByRole('radio', {
         name: /the imagery is bad/i,
@@ -153,11 +148,11 @@ describe('Submitting Mapping Status for a Task', () => {
   });
 
   it('should split the task and direct to tasks selection page', async () => {
-    const { router } = setup();
+    const { user, router } = setup();
     await screen.findByRole('button', {
       name: /submit task/i,
     });
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /split task/i,
       }),
@@ -182,7 +177,7 @@ describe('Submitting Mapping Status for a Task', () => {
 
 describe('Submitting Validation Status for Tasks', () => {
   const setup = () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <ReduxIntlProviders>
           <ValidateTask />
@@ -194,7 +189,7 @@ describe('Submitting Validation Status for Tasks', () => {
       },
     );
 
-    return { router };
+    return { user, router };
   };
 
   it('should stop validation and direct to tasks selection page', async () => {
@@ -207,7 +202,7 @@ describe('Submitting Validation Status for Tasks', () => {
       });
     });
 
-    const { router } = setup();
+    const { user, router } = setup();
     await waitFor(() => {
       expect(
         screen.getByRole('button', {
@@ -215,17 +210,16 @@ describe('Submitting Validation Status for Tasks', () => {
         }),
       ).toBeInTheDocument();
     });
-    await userEvent.click(screen.getByRole('button', { name: /stop validation/i }));
+    await user.click(screen.getByRole('button', { name: /stop validation/i }));
     await waitFor(() => expect(router.state.location.pathname).toBe('/projects/123/tasks/'));
   });
 
   it('should submit task validation status (YES option) and direct to tasks selection page', async () => {
-    const { router } = setup();
+    const { user, router } = setup();
     const submitBtn = await screen.findByRole('button', {
       name: /submit task/i,
     });
     expect(submitBtn).toBeDisabled();
-    const user = userEvent.setup();
     await user.click(screen.getAllByRole('radio')[0]);
     expect(submitBtn).toBeEnabled();
     await user.click(submitBtn);
@@ -233,12 +227,11 @@ describe('Submitting Validation Status for Tasks', () => {
   });
 
   it('should submit task validation status (NO option) and direct to tasks selection page', async () => {
-    const { router } = setup();
+    const { user, router } = setup();
     const submitBtn = await screen.findByRole('button', {
       name: /submit task/i,
     });
     expect(submitBtn).toBeDisabled();
-    const user = userEvent.setup();
     await user.click(screen.getAllByRole('radio')[1]);
     expect(submitBtn).toBeEnabled();
     await user.click(submitBtn);
@@ -249,7 +242,7 @@ describe('Submitting Validation Status for Tasks', () => {
 
 describe('Tabs in Task Action Page', () => {
   const setup = async () => {
-    const { router } = createComponentWithMemoryRouter(
+    const { user, router } = createComponentWithMemoryRouter(
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <ReduxIntlProviders>
           <ValidateTask />
@@ -261,24 +254,24 @@ describe('Tabs in Task Action Page', () => {
       },
     );
     await screen.findByRole('button', { name: /submit task/i });
-    return { router };
+    return { user, router };
   };
 
   it('should display project instructions on the instruction tab', async () => {
-    await setup();
-    await userEvent.click(screen.getByRole('button', { name: /instructions/i }));
+    const { user } = await setup();
+    await user.click(screen.getByRole('button', { name: /instructions/i }));
     expect(screen.getByText(/Project Specific Mapping Notes:/i)).toBeInTheDocument();
   });
 
   it('should display task history on the history tab', async () => {
-    await setup();
-    await userEvent.click(screen.getByRole('button', { name: /history/i }));
+    const { user } = await setup();
+    await user.click(screen.getByRole('button', { name: /history/i }));
     expect(screen.getByRole('radio', { name: /comments/i })).toBeChecked();
   });
 
   it('should display resources on the resources tab', async () => {
-    await setup();
-    await userEvent.click(screen.getByRole('button', { name: /resources/i }));
+    const { user } = await setup();
+    await user.click(screen.getByRole('button', { name: /resources/i }));
     expect(screen.getByRole('button', { name: 'Download Tasks Grid' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/views/tests/taskSelection.test.js
+++ b/frontend/src/views/tests/taskSelection.test.js
@@ -10,23 +10,27 @@ import { ReduxIntlProviders } from '../../utils/testWithIntl';
 import { SelectTask } from '../taskSelection';
 
 describe('Task Selection Page', () => {
-  const setup = () =>
-    render(
-      <MemoryRouter initialEntries={['/projects/123/tasks']}>
-        <Routes>
-          <Route
-            path="projects/:id/tasks"
-            element={
-              <QueryParamProvider adapter={ReactRouter6Adapter}>
-                <ReduxIntlProviders>
-                  <SelectTask />
-                </ReduxIntlProviders>
-              </QueryParamProvider>
-            }
-          />
-        </Routes>
-      </MemoryRouter>,
-    );
+  const setup = () => {
+    return {
+      user: userEvent.setup(),
+      ...render(
+        <MemoryRouter initialEntries={['/projects/123/tasks']}>
+          <Routes>
+            <Route
+              path="projects/:id/tasks"
+              element={
+                <QueryParamProvider adapter={ReactRouter6Adapter}>
+                  <ReduxIntlProviders>
+                    <SelectTask />
+                  </ReduxIntlProviders>
+                </QueryParamProvider>
+              }
+            />
+          </Routes>
+        </MemoryRouter>,
+      ),
+    };
+  };
 
   it('should redirect to login page if the user is not logged in', () => {
     act(() => {
@@ -86,7 +90,7 @@ describe('Task Selection Page', () => {
   });
 
   it('should change the button text to map selected task when user selects a task', async () => {
-    setup();
+    const { user } = setup();
     await screen.findAllByText(/last updated by/i);
     expect(
       screen.getByRole('button', {
@@ -94,7 +98,7 @@ describe('Task Selection Page', () => {
       }),
     ).toBeInTheDocument();
     // Selecting a task that is available for mapping
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /Task #1 Patrik_B/i,
       }),
@@ -110,7 +114,7 @@ describe('Task Selection Page', () => {
       }),
     ).toBeInTheDocument();
     // Unselecting selected tasks
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /Task #1 Patrik_B/i,
       }),
@@ -123,10 +127,10 @@ describe('Task Selection Page', () => {
   });
 
   it('should change the button text to map another task when user selects a task for validation but the user level is not met', async () => {
-    setup();
+    const { user } = setup();
     await screen.findAllByText(/last updated by/i);
     // Selecting a task that is available for validation
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /Task #5 Aadesh Baral/i,
       }),
@@ -145,8 +149,7 @@ describe('Task Selection Page', () => {
         userDetails: { id: 69, username: 'user_3', isExpert: true, role: 'ADMIN' },
       });
     });
-    setup();
-    const user = userEvent.setup();
+    const { user } = setup();
     await screen.findAllByText(/last updated by/i);
     // Selecting a single task that is available for validation
     await user.click(
@@ -194,14 +197,14 @@ describe('Task Selection Page', () => {
   });
 
   it('should filter the task list by search query', async () => {
-    setup();
+    const { user } = setup();
     await screen.findAllByText(/last updated by/i);
     expect(
       screen.getByRole('button', {
         name: /Task #5 Aadesh Baral/i,
       }),
     ).toBeInTheDocument();
-    await userEvent.type(
+    await user.type(
       screen.getByPlaceholderText(/filter tasks by id or username/i),
       'helnershingthapa',
     );
@@ -213,9 +216,9 @@ describe('Task Selection Page', () => {
   });
 
   it('should navigate to the contributions tab', async () => {
-    setup();
+    const { user } = setup();
     await screen.findAllByText(/last updated by/i);
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /contributions/i,
       }),
@@ -229,23 +232,27 @@ describe('Task Selection Page', () => {
 });
 
 describe('Random Task Selection', () => {
-  const setup = () =>
-    render(
-      <MemoryRouter initialEntries={['/projects/963/tasks']}>
-        <Routes>
-          <Route
-            path="projects/:id/tasks"
-            element={
-              <QueryParamProvider adapter={ReactRouter6Adapter}>
-                <ReduxIntlProviders>
-                  <SelectTask />
-                </ReduxIntlProviders>
-              </QueryParamProvider>
-            }
-          />
-        </Routes>
-      </MemoryRouter>,
-    );
+  const setup = () => {
+    return {
+      user: userEvent.setup(),
+      ...render(
+        <MemoryRouter initialEntries={['/projects/963/tasks']}>
+          <Routes>
+            <Route
+              path="projects/:id/tasks"
+              element={
+                <QueryParamProvider adapter={ReactRouter6Adapter}>
+                  <ReduxIntlProviders>
+                    <SelectTask />
+                  </ReduxIntlProviders>
+                </QueryParamProvider>
+              }
+            />
+          </Routes>
+        </MemoryRouter>,
+      ),
+    };
+  };
 
   it('should not change the button text to map selected task when user selects a task for mapping', async () => {
     act(() => {
@@ -254,7 +261,7 @@ describe('Random Task Selection', () => {
         userDetails: { id: 69, username: 'user_3', isExpert: true },
       });
     });
-    setup();
+    const { user } = setup();
     await screen.findAllByText(/last updated by/i);
     expect(
       screen.getByRole('button', {
@@ -262,7 +269,7 @@ describe('Random Task Selection', () => {
       }),
     ).toBeInTheDocument();
     // Selecting a task that is available for mapping
-    await userEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /Task #1 Patrik_B/i,
       }),

--- a/frontend/src/views/tests/users.test.js
+++ b/frontend/src/views/tests/users.test.js
@@ -1,7 +1,6 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import userEvent from '@testing-library/user-event';
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 
 import {
   createComponentWithMemoryRouter,
@@ -40,12 +39,11 @@ describe('List Users', () => {
   });
 
   it('should navigate to user detail page when clicked on the display picture', async () => {
-    const { container, router } = createComponentWithMemoryRouter(
+    const { user, container, router } = createComponentWithMemoryRouter(
       <ReduxIntlProviders>
         <UsersList />
       </ReduxIntlProviders>,
     );
-    const user = userEvent.setup();
     await waitFor(() =>
       expect(container.getElementsByClassName('show-loading-animation').length).toBe(0),
     );
@@ -56,19 +54,19 @@ describe('List Users', () => {
 
 describe('Change of role and mapper level', () => {
   const setup = () => {
-    const { container } = renderWithRouter(
+    const { user, container } = renderWithRouter(
       <ReduxIntlProviders>
         <UsersList />
       </ReduxIntlProviders>,
     );
     return {
+      user,
       container,
     };
   };
 
   it('should call endpoint to update role', async () => {
-    const { container } = setup();
-    const user = userEvent.setup();
+    const { user, container } = setup();
     await waitFor(() =>
       expect(container.getElementsByClassName('show-loading-animation').length).toBe(0),
     );
@@ -83,8 +81,7 @@ describe('Change of role and mapper level', () => {
   });
 
   it('should call endpoint to update level', async () => {
-    const { container } = setup();
-    const user = userEvent.setup();
+    const { user, container } = setup();
     await waitFor(() =>
       expect(container.getElementsByClassName('show-loading-animation').length).toBe(0),
     );
@@ -101,27 +98,25 @@ describe('Change of role and mapper level', () => {
 
 describe('Search and Filters', () => {
   const setup = () => {
-    const { container } = renderWithRouter(
+    const { user, container } = renderWithRouter(
       <ReduxIntlProviders>
         <UsersList />
       </ReduxIntlProviders>,
     );
     return {
+      user,
       container,
     };
   };
 
   it('should call endpoint to search users', async () => {
-    const { container } = setup();
+    const { user, container } = setup();
     await waitFor(() =>
       expect(container.getElementsByClassName('show-loading-animation').length).toBe(0),
     );
     const searchInput = screen.getByRole('textbox');
-    fireEvent.change(searchInput, {
-      target: {
-        value: 'search query',
-      },
-    });
+    await user.clear(searchInput);
+    await user.type(searchInput, 'search query');
     expect(searchInput.value).toBe('search query');
     await waitFor(
       async () =>
@@ -131,16 +126,16 @@ describe('Search and Filters', () => {
   });
 
   it('should call endpoint to update level', async () => {
-    const { container } = setup();
+    const { user, container } = setup();
     await waitFor(() =>
       expect(container.getElementsByClassName('show-loading-animation').length).toBe(0),
     );
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /all levels/i,
       }),
     );
-    fireEvent.click(screen.getAllByText(/beginner/i)[0]);
+    await user.click(screen.getAllByText(/beginner/i)[0]);
     await waitFor(
       async () =>
         expect(await screen.findByText(/clear filters/i)).toBeInTheDocument() &&


### PR DESCRIPTION
[userEvent](https://testing-library.com/docs/user-event/intro#writing-tests-with-userevent) recommends using `userEvent.setup` instead of `userEvent.click` (or other global methods).

This also replaces most usages of `fireEvent` with `userEvent` equivalents.