### PR TITLE
Update coverage configs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,7 @@ omit =
 omit =
         tests/*
         backend/*/__init__.py
+        __pypackages__/*
 
 # Regexes for lines to exclude from consideration
 exclude_lines =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ downgrade = "flask db downgrade"
 test = "python -m unittest discover"
 lint = "black manage.py backend tests migrations"
 flake8 = "flake8 manage.py backend tests migrations"
-coverage = "coverage run -m unittest discover"
+coverage-discover = "coverage run -m unittest discover"
 
 [build-system]
 requires = ["pdm-pep517>=1.0.0"]


### PR DESCRIPTION
This PR performs following modifications:
- Adds `__pypackages__` in list of directories that needs be excluded while generating coverage report.
- Modifies alias of pdm script to run command `coverage -m unittest discover` to `coverage-discover`, so that other coverage commands are executable using `pdm run coverage <option>`