### PR TITLE
Remove all of the transitive dependencies from requirements.txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "itsdangerous==2.1.2",
     "Markdown==3.4.3",
     "oauthlib==3.2.2",
+    "pandas>=2.0.2",
     "psycopg2==2.9.6",
     "python-dateutil==2.8.2",
     "python-dotenv==1.0.0",
@@ -29,6 +30,7 @@ dependencies = [
     "requests==2.31.0",
     "requests-oauthlib==1.3.1",
     "schematics==2.1.1",
+    "scikit-learn>=1.2.2",
     "sentry-sdk[flask]==1.24.0",
     "shapely==2.0.1",
     "SQLAlchemy==2.0.15",
@@ -41,8 +43,6 @@ dependencies = [
     "importlib-metadata==6.6.0",
     # Dependencies used by hotosm.org for production deployments
     "newrelic==8.8.0",
-    "pandas>=2.0.2",
-    "scikit-learn>=1.2.2",
 ]
 requires-python = ">=3.9,<=3.11"
 readme = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# IMPORTANT: It is recommended to generate requirements.txt using "pdm export --dev --without-hashes > requirements.txt"
+# Since we are using pdm for dependency management.
+
 # Update instructions:
 # 1. Delete the virtual environment
 # 2. Create a new clean virtual environment
@@ -50,36 +53,3 @@ gevent==22.10.2
 greenlet==2.0.2
 gunicorn==20.1.0
 importlib-metadata==6.6.0 # See https://github.com/hotosm/tasking-manager/issues/5395
-# Indirect dependencies (these can be blown away at any time)
-
-## The following requirements were added by pip freeze:
-aniso8601==9.0.1
-blinker==1.6.2
-certifi==2023.5.7
-charset-normalizer==3.1.0
-click==8.1.3
-idna==3.4
-iniconfig==2.0.0
-Jinja2==3.1.2
-Mako==1.2.4
-MarkupSafe==2.1.2
-mccabe==0.7.0
-mypy-extensions==1.0.0
-numpy==1.24.3
-packaging==23.1
-pathspec==0.11.1
-platformdirs==3.5.1
-pluggy==1.0.0
-pycodestyle==2.10.0
-pyflakes==3.0.1
-pytz==2023.3
-PyYAML==6.0
-six==1.16.0
-text-unidecode==1.3
-typing_extensions==4.5.0
-tzlocal==5.0.1
-urllib3==1.26.15
-webencodings==0.5.1
-zipp==3.15.0
-zope.event==4.6
-zope.interface==6.0


### PR DESCRIPTION
This PR does the following:
- Remove all of the transitive dependencies from requirements.txt as they are handled in pdm.lock and we only use requirements.txt to get dependency updates from dependabot.
- Reorder dependencies in pyproject.toml since pandas and scikit-learn were listed under section "dependencies used by HOT for production".