### PR TITLE
Add confirmation pop up window when leaving a team

### DIFF
--- a/frontend/src/components/teamsAndOrgs/leaveTeamConfirmationAlert.js
+++ b/frontend/src/components/teamsAndOrgs/leaveTeamConfirmationAlert.js
@@ -1,0 +1,33 @@
+import { FormattedMessage } from 'react-intl';
+
+import commonMessages from '../../views/messages';
+import messages from './messages';
+import { Button } from '../button';
+import { styleClasses } from '../../views/projectEdit';
+
+export const LeaveTeamConfirmationAlert = ({ teamName, close, leaveTeam }) => {
+  return (
+    <div className={styleClasses.modalClass}>
+      <h2 className={styleClasses.modalTitleClass}>
+        <FormattedMessage {...messages.leaveTheTeam} />
+      </h2>
+      <p className={`${styleClasses.pClass} pb2`}>
+        <FormattedMessage
+          {...messages.leaveTheTeamDescription}
+          values={{
+            name: teamName,
+            b: (chunks) => <strong>{chunks}</strong>,
+          }}
+        />
+      </p>
+      <p>
+        <Button className={styleClasses.whiteButtonClass} onClick={close}>
+          <FormattedMessage {...commonMessages.cancel} />
+        </Button>
+        <Button className={styleClasses.redButtonClass} onClick={() => leaveTeam()}>
+          <FormattedMessage {...messages.leave} />
+        </Button>
+      </p>
+    </div>
+  );
+};

--- a/frontend/src/components/teamsAndOrgs/messages.js
+++ b/frontend/src/components/teamsAndOrgs/messages.js
@@ -100,6 +100,18 @@ export default defineMessages({
     id: 'management.team',
     defaultMessage: 'Team',
   },
+  leaveTheTeam: {
+    id: 'user.team.leaveTeam',
+    defaultMessage: 'Leave the team',
+  },
+  leaveTheTeamDescription: {
+    id: 'user.team.leaveTeam.description',
+    defaultMessage: 'Are you sure you want to leave <b>{name}</b>?',
+  },
+  leave: {
+    id: 'user.team.leaveTeam.button.leave',
+    defaultMessage: 'Leave',
+  },
   projects: {
     id: 'management.projects',
     defaultMessage: 'Projects',

--- a/frontend/src/components/teamsAndOrgs/tests/leaveTeamConfirmationAlert.test.js
+++ b/frontend/src/components/teamsAndOrgs/tests/leaveTeamConfirmationAlert.test.js
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { IntlProviders } from '../../../utils/testWithIntl';
+import { LeaveTeamConfirmationAlert } from '../leaveTeamConfirmationAlert';
+
+describe('CampaignsManagement component', () => {
+  it('should call the close prop upon clicking the cancel button', async () => {
+    const user = userEvent.setup();
+    const closeMock = jest.fn();
+    render(
+      <IntlProviders>
+        <LeaveTeamConfirmationAlert teamName="KLL" close={closeMock} />
+      </IntlProviders>,
+    );
+    expect(screen.getByText(/Are you sure you want to leave /i)).toBeInTheDocument();
+    expect(screen.getByText('KLL')).toBeInTheDocument();
+    await user.click(
+      screen.getByRole('button', {
+        name: /cancel/i,
+      }),
+    );
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call the leaveTeam prop upon clicking the cancel button', async () => {
+    const user = userEvent.setup();
+    const leaveTeamMock = jest.fn();
+    render(
+      <IntlProviders>
+        <LeaveTeamConfirmationAlert teamName="KLL" leaveTeam={leaveTeamMock} />
+      </IntlProviders>,
+    );
+    expect(screen.getByText(/Are you sure you want to leave /i)).toBeInTheDocument();
+    expect(screen.getByText('KLL')).toBeInTheDocument();
+    await user.click(
+      screen.getByRole('button', {
+        name: /leave/i,
+      }),
+    );
+    expect(leaveTeamMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/views/teams.js
+++ b/frontend/src/views/teams.js
@@ -13,6 +13,7 @@ import {
 } from 'use-query-params';
 import { stringify } from 'query-string';
 import toast from 'react-hot-toast';
+import Popup from 'reactjs-popup';
 
 import messages from './messages';
 import { useFetch } from '../hooks/UseFetch';
@@ -37,6 +38,7 @@ import {
 } from '../components/teamsAndOrgs/teams';
 import { MessageMembers } from '../components/teamsAndOrgs/messageMembers';
 import { Projects } from '../components/teamsAndOrgs/projects';
+import { LeaveTeamConfirmationAlert } from '../components/teamsAndOrgs/leaveTeamConfirmationAlert';
 import { FormSubmitButton, CustomButton } from '../components/button';
 import { DeleteModal } from '../components/deleteModal';
 import { NotFound } from './notFound';
@@ -533,15 +535,28 @@ export function TeamDetail() {
           </div>
           <div className="w-20-l w-40-m w-50 h-100 fr">
             {isMember ? (
-              <CustomButton
-                className="w-100 h-100 bg-red white"
-                disabledClassName="bg-red o-50 white w-100 h-100"
-                onClick={() => leaveTeam()}
+              <Popup
+                trigger={
+                  <CustomButton
+                    className="w-100 h-100 bg-red white"
+                    disabledClassName="bg-red o-50 white w-100 h-100"
+                  >
+                    <FormattedMessage
+                      {...messages[isMember === 'requested' ? 'cancelRequest' : 'leaveTeam']}
+                    />
+                  </CustomButton>
+                }
+                modal
+                closeOnEscape
               >
-                <FormattedMessage
-                  {...messages[isMember === 'requested' ? 'cancelRequest' : 'leaveTeam']}
-                />
-              </CustomButton>
+                {(close) => (
+                  <LeaveTeamConfirmationAlert
+                    teamName={team.name}
+                    close={close}
+                    leaveTeam={leaveTeam}
+                  />
+                )}
+              </Popup>
             ) : (
               team.joinMethod !== 'BY_INVITE' && (
                 <CustomButton


### PR DESCRIPTION
Closes #5657 

- Triggers a modal popup upon clicking the Leave Team button
- Adds a new component LeaveTeamConfirmationAlert that has the modal content. Styles were forged from the project edit page's previously implemented dialogs.
- Adds test cases for the new component.