### PR TITLE
Remove tachyons outline in link focus

### DIFF
--- a/frontend/src/assets/styles/_extra.scss
+++ b/frontend/src/assets/styles/_extra.scss
@@ -611,3 +611,8 @@ a[href="https://www.mapbox.com/map-feedback/"]
 .blue-dark-abbey {
   color: #4c4f56;
 }
+
+// Remove tachyons outline
+.link:focus {
+  outline: revert;
+}


### PR DESCRIPTION
Closes #5874 

![outline-revert](https://github.com/hotosm/tasking-manager/assets/51614993/59a0a941-98d6-40d6-aeb8-d23e2bf73394)
