### PR TITLE
Fix issue with error component display during ongoing fetch

### DIFF
--- a/frontend/src/components/projects/filterSelectFields.js
+++ b/frontend/src/components/projects/filterSelectFields.js
@@ -139,26 +139,28 @@ export const DateFilterPicker = ({
       <legend className={titleStyle}>
         <FormattedMessage {...messages[fieldsetName]} />
       </legend>
-      <CalendarIcon className="blue-grey dib w1 pr2 v-mid" />
-      <DatePicker
-        selected={selectedValue ? parse(selectedValue, dateFormat, new Date()) : null}
-        onChange={(date) => {
-          setQueryForChild(
-            {
-              ...allQueryParamsForChild,
-              page: undefined,
-              [fieldsetName]: date ? format(date, dateFormat) : null,
-            },
-            'pushIn',
-          );
-          setIsCustomDateRange(true);
-        }}
-        dateFormat={dateFormat}
-        className="w-auto pv2 ph1 ba b--grey-light"
-        placeholderText={intl.formatMessage(messages[`${fieldsetName}Placeholder`])}
-        showYearDropdown
-        scrollableYearDropdown
-      />
+      <div className="flex">
+        <CalendarIcon className="blue-grey dib w1 pr2 v-mid" />
+        <DatePicker
+          selected={selectedValue ? parse(selectedValue, dateFormat, new Date()) : null}
+          onChange={(date) => {
+            setQueryForChild(
+              {
+                ...allQueryParamsForChild,
+                page: undefined,
+                [fieldsetName]: date ? format(date, dateFormat) : null,
+              },
+              'pushIn',
+            );
+            setIsCustomDateRange(true);
+          }}
+          dateFormat={dateFormat}
+          className="w-auto pv2 ph1 ba b--grey-light"
+          placeholderText={intl.formatMessage(messages[`${fieldsetName}Placeholder`])}
+          showYearDropdown
+          scrollableYearDropdown
+        />
+      </div>
     </fieldset>
   );
 };

--- a/frontend/src/hooks/UseTasksStatsQueryAPI.js
+++ b/frontend/src/hooks/UseTasksStatsQueryAPI.js
@@ -1,8 +1,15 @@
 import { useEffect, useReducer } from 'react';
 import { useSelector } from 'react-redux';
-import { useQueryParams, encodeQueryParams, StringParam, NumberParam } from 'use-query-params';
+import {
+  useQueryParams,
+  encodeQueryParams,
+  StringParam,
+  NumberParam,
+  withDefault,
+} from 'use-query-params';
 import { stringify as stringifyUQP } from 'query-string';
 import axios from 'axios';
+import { format, startOfYear } from 'date-fns';
 
 import { CommaArrayParam } from '../utils/CommaArrayParam';
 import { useThrottle } from '../hooks/UseThrottle';
@@ -13,7 +20,7 @@ import { API_URL } from '../config';
 /* This one is e.g. used for updating the URL when returning to /contribute
  *  and directly submitting the query to the API */
 const statsQueryAllSpecification = {
-  startDate: StringParam,
+  startDate: withDefault(StringParam, format(startOfYear(Date.now()), 'yyyy-MM-dd')),
   endDate: StringParam,
   campaign: StringParam,
   location: StringParam,

--- a/frontend/src/views/organisationStats.js
+++ b/frontend/src/views/organisationStats.js
@@ -1,13 +1,11 @@
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
-import { startOfYear, format } from 'date-fns';
 import ReactPlaceholder from 'react-placeholder';
 import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
 import { useTasksStatsQueryParams, useTasksStatsQueryAPI } from '../hooks/UseTasksStatsQueryAPI';
-import { useForceUpdate } from '../hooks/UseForceUpdate';
 import { useTotalTasksStats } from '../hooks/UseTotalTasksStats';
 import { useCurrentYearStats } from '../hooks/UseOrgYearStats';
 import { useFetch } from '../hooks/UseFetch';
@@ -23,20 +21,13 @@ export const OrganisationStats = () => {
   const token = useSelector((state) => state.auth.token);
   const isOrgManager = useSelector(
     (state) =>
-      state.auth.userDetails.role === 'ADMIN' ||
-      (state.auth.organisations && state.auth.organisations.includes(Number(id))),
+      state.auth.userDetails.role === 'ADMIN' || state.auth.organisations?.includes(Number(id)),
   );
   const [query, setQuery] = useTasksStatsQueryParams();
-  const [forceUpdated, forceUpdate] = useForceUpdate();
-  useEffect(() => {
-    if (!query.startDate) {
-      setQuery({ ...query, startDate: format(startOfYear(Date.now()), 'yyyy-MM-dd') }, 'replaceIn');
-    }
-  });
-  const [apiState] = useTasksStatsQueryAPI(
+
+  const [apiState, fetchTasksStatistics] = useTasksStatsQueryAPI(
     { taskStats: [] },
     query,
-    query.startDate ? forceUpdated : false,
     `organisationId=${id}`,
   );
   const [error, loading, organisation] = useFetch(`organisations/${id}/?omitManagerList=true`, id);
@@ -82,7 +73,7 @@ export const OrganisationStats = () => {
               stats={apiState.stats}
               error={apiState.isError}
               loading={apiState.isLoading}
-              retryFn={forceUpdate}
+              retryFn={fetchTasksStatistics}
             />
           </div>
           <div className="w-100 fl cf">

--- a/frontend/src/views/stats.js
+++ b/frontend/src/views/stats.js
@@ -1,10 +1,8 @@
-import React, { useEffect } from 'react';
-import { format, startOfYear } from 'date-fns';
+import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
 import { useTasksStatsQueryParams, useTasksStatsQueryAPI } from '../hooks/UseTasksStatsQueryAPI';
-import { useForceUpdate } from '../hooks/UseForceUpdate';
 import { useSetTitleTag } from '../hooks/UseMetaTags';
 import { TasksStats } from '../components/teamsAndOrgs/tasksStats';
 import { NewUsersStats } from '../components/teamsAndOrgs/newUsersStats';
@@ -13,17 +11,7 @@ import { FeatureStats } from '../components/teamsAndOrgs/featureStats';
 export const Stats = () => {
   useSetTitleTag('Stats');
   const [query, setQuery] = useTasksStatsQueryParams();
-  const [forceUpdated, forceUpdate] = useForceUpdate();
-  useEffect(() => {
-    if (!query.startDate) {
-      setQuery({ ...query, startDate: format(startOfYear(Date.now()), 'yyyy-MM-dd') }, 'replaceIn');
-    }
-  });
-  const [apiState] = useTasksStatsQueryAPI(
-    { taskStats: [] },
-    query,
-    query.startDate ? forceUpdated : false,
-  );
+  const [apiState, fetchTasksStatistics] = useTasksStatsQueryAPI({ taskStats: [] }, query);
 
   return (
     <div className="w-100 cf pv4">
@@ -41,7 +29,7 @@ export const Stats = () => {
             stats={apiState.stats}
             error={apiState.isError}
             loading={apiState.isLoading}
-            retryFn={forceUpdate}
+            retryFn={fetchTasksStatistics}
           />
         </div>
       </div>


### PR DESCRIPTION
This pull request closes #5863, where the error component would be displayed when a new request to the `/tasks/statistics/` endpoint was made while an ongoing fetch was in progress. The root cause of this issue has been identified and resolved.

#### Changes Made
- Accommodated using the use `TasksStatsQueryParams` in `OrganisationStats` and `Stats` components, utilizing the useTasksStatsQueryAPI hook.
- Removed the _now_ unused variables `forceUpdate` and `forceUpdated` from the `useForceUpdate`.
- Updated the usage of the `useTasksStatsQueryAPI` hook by _replacing_ the `forceUpdated` argument with the `fetchTasksStatistics` function. This change allows passing the `fetchTasksStatistics` function as the retry function in the `TasksStats` component.
- Wrapped the date picker and icon with flex so that they would appear on a single line. 
![flex](https://github.com/hotosm/tasking-manager/assets/51614993/8aa31bea-3f26-490f-9d73-a6c96e691481)
