### PR TITLE
Fix eslint warnings for valid-typeof

### DIFF
--- a/frontend/src/components/editor.js
+++ b/frontend/src/components/editor.js
@@ -11,7 +11,7 @@ export default function Editor({ setDisable, comment, presets, imagery, gpxUrl }
   const iDContext = useSelector((state) => state.editor.context);
   const locale = useSelector((state) => state.preferences.locale);
   const [customImageryIsSet, setCustomImageryIsSet] = useState(false);
-  const windowInit = typeof window !== undefined;
+  const windowInit = typeof window !== 'undefined';
   const customSource =
     iDContext && iDContext.background() && iDContext.background().findSource('custom');
 

--- a/frontend/src/components/rapidEditor.js
+++ b/frontend/src/components/rapidEditor.js
@@ -18,7 +18,7 @@ export default function RapidEditor({
   const RapiDContext = useSelector((state) => state.editor.rapidContext);
   const locale = useSelector((state) => state.preferences.locale);
   const [customImageryIsSet, setCustomImageryIsSet] = useState(false);
-  const windowInit = typeof window !== undefined;
+  const windowInit = typeof window !== 'undefined';
   const customSource =
     RapiDContext && RapiDContext.background() && RapiDContext.background().findSource('custom');
 

--- a/frontend/src/components/teamsAndOrgs/teams.js
+++ b/frontend/src/components/teamsAndOrgs/teams.js
@@ -310,19 +310,13 @@ export function TeamSideBar({ team, members, managers, requestedToJoin }: Object
           return member.username.toLowerCase().includes(searchQuery.toLowerCase());
         })
       : members;
-  const organisations = useSelector((state) => state.auth.organisations);
-  const pmTeams = useSelector((state) => state.auth.pmTeams);
 
   return (
     <ReactPlaceholder
       showLoadingAnimation={true}
       type="media"
       rows={20}
-      ready={
-        typeof team.teamId === 'number' &&
-        typeof organisations !== 'undefined' &&
-        typeof pmTeams !== 'undefined'
-      }
+      ready={typeof team.teamId === 'number'}
     >
       <div className="cf pb2">
         <div className="w-20 pv2 dib fl">

--- a/frontend/src/components/teamsAndOrgs/teams.js
+++ b/frontend/src/components/teamsAndOrgs/teams.js
@@ -310,6 +310,8 @@ export function TeamSideBar({ team, members, managers, requestedToJoin }: Object
           return member.username.toLowerCase().includes(searchQuery.toLowerCase());
         })
       : members;
+  const organisations = useSelector((state) => state.auth.organisations);
+  const pmTeams = useSelector((state) => state.auth.pmTeams);
 
   return (
     <ReactPlaceholder
@@ -318,8 +320,8 @@ export function TeamSideBar({ team, members, managers, requestedToJoin }: Object
       rows={20}
       ready={
         typeof team.teamId === 'number' &&
-        typeof organisations !== undefined &&
-        typeof pmTeams !== undefined
+        typeof organisations !== 'undefined' &&
+        typeof pmTeams !== 'undefined'
       }
     >
       <div className="cf pb2">

--- a/frontend/src/components/user/content.js
+++ b/frontend/src/components/user/content.js
@@ -57,7 +57,7 @@ export function OSMCard({ username }: Object) {
               showLoadingAnimation={true}
               rows={1}
               delay={100}
-              ready={typeof osmUserInfo !== undefined}
+              ready={typeof osmUserInfo !== 'undefined'}
             >
               <FormattedRelativeTime value={value} unit={unit} />
             </ReactPlaceholder>
@@ -72,7 +72,7 @@ export function OSMCard({ username }: Object) {
               showLoadingAnimation={true}
               rows={1}
               delay={100}
-              ready={typeof osmUserInfo !== undefined}
+              ready={typeof osmUserInfo !== 'undefined'}
             >
               <FormattedNumber value={osmUserInfo ? osmUserInfo.changesetCount : 0} />
             </ReactPlaceholder>


### PR DESCRIPTION
We were comparing to undefined (literal) instead of 'undefined' (string). `typeof` will always return a string, so `'undefined' !== undefined` would always return `true`.

For more details, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof .