### PR TITLE
ReactJS: Fix "Each child in a list should have a unique 'key' prop"

### DIFF
--- a/frontend/src/views/quickstart.js
+++ b/frontend/src/views/quickstart.js
@@ -146,7 +146,7 @@ export function QuickstartPage() {
           {steps.map((v, i) => {
             const idx = i + 1;
             return (
-              <div className="pv2">
+              <div className="pv2" key={v.message}>
                 <p>
                   <span className="b mr1">{idx}.</span>
                   {<FormattedMessage {...messages[v.message]} values={v.values} />}


### PR DESCRIPTION
This is just a warning from react. Since we aren't changing the `steps` variable dynamically, all this does is silence a warning.