### PR TITLE
Update query-string to v8.1.0 from v7.1.3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "mapbox-gl-draw-rectangle-mode": "^1.0.4",
     "marked": "^4.3.0",
     "osmtogeojson": "^3.0.0-beta.5",
-    "query-string": "^7.1.3",
+    "query-string": "^8.1.0",
     "react": "^17.0.2",
     "react-accessible-accordion": "^4.0.0",
     "react-calendar-heatmap": "^1.9.0",

--- a/frontend/src/components/projects/tests/moreFiltersForm.test.js
+++ b/frontend/src/components/projects/tests/moreFiltersForm.test.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { parse } from 'query-string';
+import queryString from 'query-string';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
@@ -52,7 +52,7 @@ describe('MoreFiltersForm', () => {
           {
             basedOnMyInterests: BooleanParam,
           },
-          parse(router.state.location.search),
+          queryString.parse(router.state.location.search),
         ),
       ).toEqual({ basedOnMyInterests: true }),
     );

--- a/frontend/src/components/projects/tests/projectNav.test.js
+++ b/frontend/src/components/projects/tests/projectNav.test.js
@@ -11,7 +11,7 @@ import {
 } from '../../../utils/testWithIntl';
 import { ProjectNav } from '../projectNav';
 import messages from '../messages';
-import { parse } from 'query-string';
+import queryString from 'query-string';
 
 describe('Project Navigation Bar', () => {
   it('should render component details', () => {
@@ -40,7 +40,9 @@ describe('Project Navigation Bar', () => {
       { route: '?text=something' },
     );
 
-    expect(decodeQueryParams({ text: StringParam }, parse(router.state.location.search))).toEqual({
+    expect(
+      decodeQueryParams({ text: StringParam }, queryString.parse(router.state.location.search)),
+    ).toEqual({
       text: 'something',
     });
   });

--- a/frontend/src/hooks/UseInboxQueryAPI.js
+++ b/frontend/src/hooks/UseInboxQueryAPI.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useQueryParams, StringParam, NumberParam } from 'use-query-params';
-import { stringify as stringifyUQP } from 'query-string';
+import queryString from 'query-string';
 import axios from 'axios';
 
 import { CommaArrayParam } from '../utils/CommaArrayParam';
@@ -163,4 +163,4 @@ export const useInboxQueryAPI = (
   return [state, dispatch];
 };
 
-export const stringify = stringifyUQP;
+export const stringify = queryString.stringify;

--- a/frontend/src/hooks/UseProjectsQueryAPI.js
+++ b/frontend/src/hooks/UseProjectsQueryAPI.js
@@ -7,7 +7,7 @@ import {
   NumberParam,
   BooleanParam,
 } from 'use-query-params';
-import { stringify as stringifyUQP } from 'query-string';
+import queryString from 'query-string';
 import axios from 'axios';
 import { subMonths, format } from 'date-fns';
 
@@ -226,5 +226,5 @@ export const useProjectsQueryAPI = (
 
 export const stringify = (obj) => {
   const encodedQuery = encodeQueryParams(projectQueryAllSpecification, obj);
-  return stringifyUQP(encodedQuery);
+  return queryString.stringify(encodedQuery);
 };

--- a/frontend/src/hooks/UseTaskContributionAPI.js
+++ b/frontend/src/hooks/UseTaskContributionAPI.js
@@ -3,7 +3,7 @@ import { useEffect, useReducer } from 'react';
 import axios from 'axios';
 
 import { useQueryParams, StringParam, NumberParam } from 'use-query-params';
-import { stringify as stringifyUQP } from 'query-string';
+import queryString from 'query-string';
 import { CommaArrayParam } from '../utils/CommaArrayParam';
 import { useThrottle } from '../hooks/UseThrottle';
 import { remapParamsToAPI } from '../utils/remapParamsToAPI';
@@ -204,4 +204,4 @@ export const useTaskContributionAPI = (
   return [state, dispatch];
 };
 
-export const stringify = stringifyUQP;
+export const stringify = queryString.stringify;

--- a/frontend/src/hooks/UseTasksStatsQueryAPI.js
+++ b/frontend/src/hooks/UseTasksStatsQueryAPI.js
@@ -7,7 +7,7 @@ import {
   NumberParam,
   withDefault,
 } from 'use-query-params';
-import { stringify as stringifyUQP } from 'query-string';
+import queryString from 'query-string';
 import axios from 'axios';
 import { format, startOfYear } from 'date-fns';
 
@@ -151,5 +151,5 @@ export const useTasksStatsQueryAPI = (
 
 export const stringify = (obj) => {
   const encodedQuery = encodeQueryParams(statsQueryAllSpecification, obj);
-  return stringifyUQP(encodedQuery);
+  return queryString.stringify(encodedQuery);
 };

--- a/frontend/src/views/teams.js
+++ b/frontend/src/views/teams.js
@@ -11,7 +11,7 @@ import {
   useQueryParams,
   withDefault,
 } from 'use-query-params';
-import { stringify } from 'query-string';
+import queryString from 'query-string';
 import toast from 'react-hot-toast';
 import Popup from 'reactjs-popup';
 
@@ -84,7 +84,9 @@ export function ListTeams({ managementView = false }: Object) {
   );
 
   const pageParam = `${
-    stringify(encodedQuery) ? `&${stringify(encodedQuery)}` : stringify(encodedQuery)
+    queryString.stringify(encodedQuery)
+      ? `&${queryString.stringify(encodedQuery)}`
+      : queryString.stringify(encodedQuery)
   }`;
 
   useEffect(() => {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5785,10 +5785,15 @@ decode-named-character-reference@^1.0.0:
   dependencies:
     character-entities "^2.0.0"
 
-decode-uri-component@^0.2.0, decode-uri-component@^0.2.2:
+decode-uri-component@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
+
+decode-uri-component@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.4.1.tgz#2ac4859663c704be22bf7db760a1494a49ab2cc5"
+  integrity sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==
 
 decompress-response@^6.0.0:
   version "6.0.0"
@@ -7115,10 +7120,10 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-filter-obj@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
-  integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
+filter-obj@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-5.1.0.tgz#5bd89676000a713d7db2e197f660274428e524ed"
+  integrity sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==
 
 final-form@^4.20.9:
   version "4.20.9"
@@ -12398,15 +12403,14 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.3.tgz#a1cf90e994abb113a325804a972d98276fe02328"
-  integrity sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==
+query-string@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-8.1.0.tgz#e7f95367737219544cd360a11a4f4ca03836e115"
+  integrity sha512-BFQeWxJOZxZGix7y+SByG3F36dA0AbTy9o6pSmKFcFz7DAj0re9Frkty3saBn3nHo3D0oZJ/+rx3r8H8r8Jbpw==
   dependencies:
-    decode-uri-component "^0.2.2"
-    filter-obj "^1.1.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
+    decode-uri-component "^0.4.1"
+    filter-obj "^5.1.0"
+    split-on-first "^3.0.0"
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -14105,10 +14109,10 @@ splaytree@^3.1.0:
   resolved "https://registry.yarnpkg.com/splaytree/-/splaytree-3.1.2.tgz#d1db2691665a3c69d630de98d55145a6546dc166"
   integrity sha512-4OM2BJgC5UzrhVnnJA4BkHKGtjXNzzUfpQjCO8I05xYPsfS/VuQDwjCGGMi8rYQilHEV4j8NBqTFbls/PZEE7A==
 
-split-on-first@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
-  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+split-on-first@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-3.0.0.tgz#f04959c9ea8101b9b0bbf35a61b9ebea784a23e7"
+  integrity sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -14219,11 +14223,6 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
-  integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
The major change is that it is now pure ESM and no longer exports specific functions. It also requires Node.js 14+.