### PR TITLE
Fix removal of project teams while updating them.

### DIFF
--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -449,7 +449,8 @@ class Project(db.Model):
                     raise NotFound("Team not found")
 
                 role = TeamRoles[team_dto.role].value
-                ProjectTeams(project=self, team=team, role=role)
+                project_team = ProjectTeams(project=self, team=team, role=role)
+                db.session.add(project_team)
 
         # Set Project Info for all returned locales
         for dto in project_dto.project_info_locales:


### PR DESCRIPTION
closes #5916 

This commit fixes an issue where the `ProjectTeams` object was not added to the session, causing projects teams being removed while updating them. By adding the `ProjectTeams` object to the session after its creation, the subsequent add operation on Project.teams can proceed without any issues.

The changes ensure that the ProjectTeams object is properly associated with the session, allowing for the correct handling of relationships within the update method.