### PR TITLE
Refactor request body validation using decorator

### DIFF
--- a/backend/models/dtos/__init__.py
+++ b/backend/models/dtos/__init__.py
@@ -13,16 +13,43 @@ def get_validation_errors(e):
     ]
 
 
-def validate_request_body(dto_class):
-    """Decorator to validate request body against a DTO class"""
+def validate_request(dto_class):
+    """
+    Decorator to validate request against a DTO class.
+    --------------------------------
+    NOTE: This decorator should be applied after the token_auth decorator (if used) so that
+    the authenticated user id can be set on the DTO if the DTO has a user_id field.
+    --------------------------------
+    Parameters:
+        dto_class: DTO
+            The DTO class to validate against
+    """
 
     def decorator(f):
         @wraps(f)
         def wrapper(*args, **kwargs):
+            from backend.services.users.authentication_service import token_auth
+
             try:
-                dto = dto_class(request.get_json())
+                dto = dto_class()
+
+                # Set attribute values from request body, query parameters, and path parameters
+                for attr in dto.__class__._fields:
+                    if request.is_json and attr in request.json:
+                        setattr(dto, attr, request.json[attr])
+                    elif attr in request.args:
+                        setattr(dto, attr, request.args.get(attr))
+                    elif attr in kwargs:
+                        setattr(dto, attr, kwargs[attr])
+
+                #  Set authenticated user id if user_id is a field in the DTO
+                if "user_id" in dto.__class__._fields:
+                    dto.user_id = token_auth.current_user()
+
                 dto.validate()
-                request.validated_dto = dto
+                request.validated_dto = (
+                    dto  # Set validated DTO on request object for use in view function
+                )
             except DataError as e:
                 field_errors = get_validation_errors(e)
                 raise BadRequest(field_errors=field_errors)

--- a/backend/models/dtos/__init__.py
+++ b/backend/models/dtos/__init__.py
@@ -1,0 +1,33 @@
+from functools import wraps
+from flask import request
+from schematics.exceptions import DataError
+
+
+from backend.exceptions import BadRequest
+
+
+def get_validation_errors(e):
+    """Returns a list of validation errors from a schematics DataError"""
+    return [
+        {"field": field, "message": str(error[0])} for field, error in e.errors.items()
+    ]
+
+
+def validate_request_body(dto_class):
+    """Decorator to validate request body against a DTO class"""
+
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            try:
+                dto = dto_class(request.get_json())
+                dto.validate()
+                request.validated_dto = dto
+            except DataError as e:
+                field_errors = get_validation_errors(e)
+                raise BadRequest(field_errors=field_errors)
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
This PR adds the necessary component to fix #5910 
- Creates a decorator which can be used to validate the request body against a DTO class.
    - This decorator can be applied to the route handler that requires request validation.
    - This decorator validates the request using the provided DTO class and stores the validated DTO instance in request.validated_dto.
- Adds a function to fetch validation errors from Schematics `DataError` exception class so  that we can return what and where error occurred during request validation.

**Sample validation error :**
```python
@validate_request(ProjectCreateDTO)
def post():
validated_dto = request.validated_dto # request.validated_dto will be set in the decorator after validating request against dto ProjectCreateDTO
```
If the validation error occurs due to missing project description and instruction we will have error response like:
```json
{
  "error":{
    "code": 400,
    "sub_code": "BAD_REQUEST",
    "message": "The request was invalid or cannot be otherwise served."
    "details": {
      "field_errors": {
        "field": "description", "message": "This field is required",
        "field": "instruction", "message": "This field is required"
      }
    }
  }
}
```

**Benefits:**
1. Now we can just add a decorator on the route handler (like in the example above) instead of following code to validate the request body.
```python
try:
    dto = ProjectCreateDTO(request.get_json())
    dto.validate()
except DataError as e:
   return {"Error": str(e), "SubCode": "BAD_REQUEST"}
````
2. The error message will have more information like what and where the issue occured
3. This approach improves code organization, promotes code reuse, and enhances readability.

**_NOTE_**: This decorator must me only used after decorator `token_auth.login_required` if both decorator are to be used.
```python
@token_auth.login_required
@validate_request(ProjectCreateDTO)
def post():
validated_dto = request.validated_dto 
```
