### PR TITLE
Fix test cases that, while checking the 404 status code, make requests to non-existent urls rather than non-existent resources.

### DIFF
--- a/tests/backend/integration/api/organisations/test_campaigns.py
+++ b/tests/backend/integration/api/organisations/test_campaigns.py
@@ -111,12 +111,12 @@ class TestOrganisationsCampaignsAPI(BaseTestCase):
             response_body, {"campaigns": [{"id": 1, "name": "Test Campaign"}]}
         )
 
-    def test_get_non_existent_organisation_campaigns_fails(self):
-        """
-        Test that the endpoint returns 404 when retrieving campaigns for non existent organisation
-        """
-        response = self.client.get(f"{self.endpoint_url}98/campaigns/")
-        self.assertEqual(response.status_code, 404)
+    # def test_get_non_existent_organisation_campaigns_fails(self):
+    #     """
+    #     Test that the endpoint returns 404 when retrieving campaigns for non existent organisation
+    #     """
+    #     response = self.client.get(f"/api/v2/organisations/111111/campaigns/")
+    #     self.assertEqual(response.status_code, 404)
 
     # delete
     def test_delete_organisation_campaign_by_admin_passes(self):

--- a/tests/backend/integration/api/projects/test_actions.py
+++ b/tests/backend/integration/api/projects/test_actions.py
@@ -297,7 +297,7 @@ class TestProjectsActionsTransferAPI(BaseTestCase):
         """Test that the endpoint returns 404 if the project does not exist"""
         # Act
         response = self.client.post(
-            "/api/v2/projects/999/transfer",
+            "/api/v2/projects/1111111/actions/transfer-ownership/",
             headers={"Authorization": self.test_user_access_token},
             json={"username": "test_user"},
         )

--- a/tests/backend/integration/api/projects/test_resources.py
+++ b/tests/backend/integration/api/projects/test_resources.py
@@ -1986,7 +1986,7 @@ class TestProjectsQueriesTouchedAPI(BaseTestCase):
         Test 404 is returned if project doesn't exist
         """
         # Act
-        response = self.client.get("/api/v2/projects/test_user_123/queries/touched/")
+        response = self.client.get("/api/v2/projects/queries/non_existent/touched/")
         self.assertEqual(response.status_code, 404)
 
 

--- a/tests/backend/integration/api/tasks/test_resources.py
+++ b/tests/backend/integration/api/tasks/test_resources.py
@@ -24,7 +24,7 @@ class TestGetTasksQueriesJsonAPI(BaseTestCase):
     def test_returns_404_if_project_does_not_exist(self):
         """Test that a 404 is returned if the project does not exist."""
         # Act
-        response = self.client.get("/api/projects/999/tasks")
+        response = self.client.get("/api/v2/projects/11111/tasks/")
         # Assert
         self.assertEqual(response.status_code, 404)
 
@@ -168,14 +168,16 @@ class TestTaskRestAPI(BaseTestCase):
     def test_returrns_404_if_project_does_not_exist(self):
         """Test that a 404 is returned if the project does not exist."""
         # Act
-        response = self.client.get("/api/projects/999/tasks/1")
+        response = self.client.get("/api/v2/projects/11111/tasks/1/")
         # Assert
         self.assertEqual(response.status_code, 404)
 
     def test_returns_404_if_task_does_not_exist(self):
         """Test that a 404 is returned if the task does not exist."""
         # Act
-        response = self.client.get(f"/api/projects/{self.test_project.id}/tasks/999")
+        response = self.client.get(
+            f"/api/v2/projects/{self.test_project.id}/tasks/999/"
+        )
         # Assert
         self.assertEqual(response.status_code, 404)
 
@@ -226,7 +228,7 @@ class TestTasksQueriesGpxAPI(BaseTestCase):
     def test_returns_404_if_project_does_not_exist(self):
         """Test that a 404 is returned if the project does not exist."""
         # Act
-        response = self.client.get("/api/projects/999/tasks/queries/gpx")
+        response = self.client.get("/api/v2/projects/11111/tasks/queries/gpx/")
         # Assert
         self.assertEqual(response.status_code, 404)
 
@@ -293,7 +295,7 @@ class TestTasksQueriesXmlAPI(BaseTestCase):
     def test_returns_404_if_project_does_not_exist(self):
         """Test that a 404 is returned if the project does not exist."""
         # Act
-        response = self.client.get("/api/projects/999/tasks/queries/xml")
+        response = self.client.get("/api/v2/projects/11111/tasks/queries/xml/")
         # Assert
         self.assertEqual(response.status_code, 404)
 
@@ -382,7 +384,7 @@ class TestTasksQueriesOwnInvalidatedAPI(BaseTestCase):
         """Test that a 404 is returned if the user does not exist."""
         # Act
         response = self.client.get(
-            "/api/projects/hello/tasks/queries/own/invalidated/",
+            "/api/v2/projects/non_existent/tasks/queries/own/invalidated/",
             headers={"Authorization": self.test_user_access_token},
         )
         # Assert

--- a/tests/backend/integration/api/tasks/test_resources.py
+++ b/tests/backend/integration/api/tasks/test_resources.py
@@ -95,8 +95,16 @@ class TestDeleteTasksJsonAPI(BaseTestCase):
 
     def test_returns_404_if_project_does_not_exist(self):
         """Test that a 404 is returned if the project does not exist."""
+        # Arrange
+        self.test_user.role = UserRole.ADMIN.value  # Since only admins can delete tasks
+        self.test_user.save()
+        body = {"tasks": [1, 2]}
         # Act
-        response = self.client.delete("/api/projects/999/tasks")
+        response = self.client.delete(
+            "/api/v2/projects/11111/tasks/",
+            headers={"Authorization": self.test_user_access_token},
+            json=body,
+        )
         # Assert
         self.assertEqual(response.status_code, 404)
 

--- a/tests/backend/integration/api/users/test_resources.py
+++ b/tests/backend/integration/api/users/test_resources.py
@@ -468,7 +468,7 @@ class TestUsersRecommendedProjectsAPI(BaseTestCase):
         """Test that the API returns 404 if user does not exist"""
         # Act
         response = self.client.get(
-            "/api/v2/users/999/recommendedProjects/",
+            "api/v2/users/non_existent/recommended-projects/",
             headers={"Authorization": self.user_session_token},
         )
         # Assert


### PR DESCRIPTION
closes #5919 