### PR TITLE
Catch exceptions raised while formatting specific tasks instruction.

### DIFF
--- a/backend/models/postgis/task.py
+++ b/backend/models/postgis/task.py
@@ -1132,7 +1132,10 @@ class Task(db.Model):
 
         try:
             instructions = instructions.format(**properties)
-        except KeyError:
+        except (KeyError, ValueError, IndexError):
+            # KeyError is raised if a format string contains a key that is not in the dictionary, e.g. {foo}
+            # ValueError is raised if a format string contains a single { or }
+            # IndexError is raised if a format string contains empty braces, e.g. {}
             pass
         return instructions
 


### PR DESCRIPTION
closes #5902 

As described in [5902 comment](https://github.com/hotosm/tasking-manager/issues/5902#issuecomment-1603922515), presence of `{`, `}` and `{}` in the specific tasks instructions breaks the endpoint `users/queries/tasks/locked/details/`. This PR captures the exceptions raised while trying to format specific task instruction and returns the instruction as it is.