### PR TITLE
Use https for outlink

### DIFF
--- a/frontend/src/components/banner/index.js
+++ b/frontend/src/components/banner/index.js
@@ -34,7 +34,7 @@ export function Banner() {
 
   const privacyPolicyLink = (
     <a
-      href={`https://${ORG_PRIVACY_POLICY_URL}`}
+      href={`${ORG_PRIVACY_POLICY_URL}`}
       className="red underline link fw6"
       target="_blank"
       rel="noopener noreferrer"
@@ -53,7 +53,7 @@ export function Banner() {
           <a
             id="privlink"
             className="red link f4 fw6"
-            href={`https://${ORG_PRIVACY_POLICY_URL}`}
+            href={`${ORG_PRIVACY_POLICY_URL}`}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/frontend/src/components/footer/index.js
+++ b/frontend/src/components/footer/index.js
@@ -113,7 +113,7 @@ export function Footer() {
             </Link>
             {ORG_PRIVACY_POLICY_URL && (
               <div className="pt2 f6 lh-title">
-                <a href={`https://${ORG_PRIVACY_POLICY_URL}`} className="link white">
+                <a href={`${ORG_PRIVACY_POLICY_URL}`} className="link white">
                   <FormattedMessage {...messages.privacyPolicy} />
                 </a>
               </div>

--- a/frontend/src/components/footer/tests/index.test.js
+++ b/frontend/src/components/footer/tests/index.test.js
@@ -92,7 +92,7 @@ describe('Footer', () => {
         screen.getByRole('link', {
           name: messages.privacyPolicy.defaultMessage,
         }),
-      ).toHaveAttribute('href', `https://${ORG_PRIVACY_POLICY_URL}`);
+      ).toHaveAttribute('href', `${ORG_PRIVACY_POLICY_URL}`);
     } else {
       expect(
         screen.queryByRole('link', {

--- a/frontend/src/components/header/index.js
+++ b/frontend/src/components/header/index.js
@@ -100,7 +100,7 @@ export const Header = () => {
             </span>
           </div>
           <div className="tr red">
-            <a className="link red f6 mr2" href={`http://${ORG_URL}`}>
+            <a className="link red f6 mr2" href={`https://${ORG_URL}`}>
               {ORG_URL}
               <ExternalLinkIcon
                 title="externalLink"

--- a/frontend/src/components/header/index.js
+++ b/frontend/src/components/header/index.js
@@ -100,7 +100,7 @@ export const Header = () => {
             </span>
           </div>
           <div className="tr red">
-            <a className="link red f6 mr2" href={`${ORG_URL}`} target="_blank">
+            <a className="link red f6 mr2" href={`${ORG_URL}`} target="_blank" rel="noreferrer">
               {ORG_NAME} Website
               <ExternalLinkIcon
                 title="externalLink"

--- a/frontend/src/components/header/index.js
+++ b/frontend/src/components/header/index.js
@@ -100,8 +100,8 @@ export const Header = () => {
             </span>
           </div>
           <div className="tr red">
-            <a className="link red f6 mr2" href={`https://${ORG_URL}`}>
-              {ORG_URL}
+            <a className="link red f6 mr2" href={`${ORG_URL}`} target="_blank">
+              {ORG_NAME} Website
               <ExternalLinkIcon
                 title="externalLink"
                 className="pl2 v-btm"

--- a/frontend/src/components/header/signUp.js
+++ b/frontend/src/components/header/signUp.js
@@ -172,7 +172,7 @@ const SignupForm = ({ data, setData, step, setStep }) => {
             className="link pointer red fw5"
             target="_blank"
             rel="noopener noreferrer"
-            href={`http://${ORG_PRIVACY_POLICY_URL}`}
+            href={`${ORG_PRIVACY_POLICY_URL}`}
           >
             <FormattedMessage {...messages.privacyPolicy} />
           </a>

--- a/frontend/src/components/header/tests/index.test.js
+++ b/frontend/src/components/header/tests/index.test.js
@@ -3,7 +3,7 @@ import { screen, fireEvent, act, within, waitFor, render } from '@testing-librar
 
 import '../../../utils/mockMatchMedia';
 import { IntlProviders, ReduxIntlProviders, renderWithRouter } from '../../../utils/testWithIntl';
-import { ORG_URL, ORG_LOGO, SERVICE_DESK } from '../../../config';
+import { ORG_NAME, ORG_URL, ORG_LOGO, SERVICE_DESK } from '../../../config';
 import { AuthButtons, getMenuItemsForUser, Header, PopupItems } from '..';
 import messages from '../messages';
 import { store } from '../../../store';
@@ -23,8 +23,8 @@ describe('Header', () => {
     setup();
     expect(screen.getByText(messages.slogan.defaultMessage)).toBeInTheDocument();
     if (ORG_URL) {
-      expect(screen.getByText(ORG_URL)).toBeInTheDocument();
-      expect(screen.getByText(ORG_URL).closest('a')).toHaveAttribute('href', `http://${ORG_URL}`);
+      expect(screen.getByText(`${ORG_NAME} Website`)).toBeInTheDocument();
+      expect(screen.getByText(`${ORG_NAME} Website`).closest('a')).toHaveAttribute('href', ORG_URL);
     }
     expect(screen.getByTitle('externalLink')).toBeInTheDocument();
     const orgLogo = screen.getByRole('img');

--- a/frontend/src/components/header/updateEmail.js
+++ b/frontend/src/components/header/updateEmail.js
@@ -70,7 +70,7 @@ export const UpdateEmail = ({ closeModal }) => {
               className="link pointer red fw5"
               target="_blank"
               rel="noopener noreferrer"
-              href={`http://${ORG_PRIVACY_POLICY_URL}`}
+              href={`${ORG_PRIVACY_POLICY_URL}`}
             >
               <FormattedMessage {...messages.privacyPolicy} />
             </a>


### PR DESCRIPTION
Partially fixes #5925 

This PR updates the protocol to https. I have also updated the ORG_URL in CircleCI Context for staging and production to be "www.hotosm.org"

The reason we can't easily setup a redirect is [from AWS](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html):
> Unlike a CNAME record, you can create an alias record at the top node of a DNS namespace, also known as the zone apex. For example, if you register the DNS name [example.com](http://example.com/), the zone apex is [example.com](http://example.com/). You can't create a CNAME record for [example.com](http://example.com/), but you can create an alias record for [example.com](http://example.com/) that routes traffic to [www.example.com](http://www.example.com/) (as long as the record type for [www.example.com](http://www.example.com/) is not of type CNAME).

If this is not sufficient, we may be able to setup a redirect, but I would prefer not to, as this will likely change soon with the new hotosm website. 