### PR TITLE
Enable ability for users to select tasks they mapped

### DIFF
--- a/frontend/src/components/taskSelection/footer.js
+++ b/frontend/src/components/taskSelection/footer.js
@@ -15,7 +15,14 @@ import { Imagery } from './imagery';
 import { MappingTypes } from '../mappingTypes';
 import { LockedTaskModalContent } from './lockedTasks';
 
-const TaskSelectionFooter = ({ defaultUserEditor, project, tasks, taskAction, selectedTasks }) => {
+const TaskSelectionFooter = ({
+  defaultUserEditor,
+  project,
+  tasks,
+  taskAction,
+  selectedTasks,
+  setSelectedTasks,
+}) => {
   const navigate = useNavigate();
   const token = useSelector((state) => state.auth.token);
   const locale = useSelector((state) => state.preferences.locale);
@@ -178,6 +185,9 @@ const TaskSelectionFooter = ({ defaultUserEditor, project, tasks, taskAction, se
               error={lockError}
               close={close}
               lockTasks={lockTasks}
+              tasks={tasks}
+              selectedTasks={selectedTasks}
+              setSelectedTasks={setSelectedTasks}
             />
           )}
         </Popup>

--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -408,6 +408,7 @@ export function TaskSelection({ project, type, loading }: Object) {
               tasks={tasks}
               taskAction={taskAction}
               selectedTasks={curatedSelectedTasks}
+              setSelectedTasks={setSelectedTasks}
             />
           </Suspense>
         </ReactPlaceholder>

--- a/frontend/src/components/taskSelection/map.js
+++ b/frontend/src/components/taskSelection/map.js
@@ -83,11 +83,8 @@ export const TasksMap = ({
 
   useLayoutEffect(() => {
     const onSelectTaskClick = (e) => {
-      const { mappedBy, taskStatus } = e.features[0].properties;
-      const task = e.features && e.features[0].properties;
-      if (!(mappedBy === authDetails.id && taskStatus === 'MAPPED')) {
-        selectTask && selectTask(task.taskId, task.taskStatus);
-      }
+      const task = e.features?.[0].properties;
+      selectTask?.(task.taskId, task.taskStatus);
     };
 
     const countryMapLayers = [
@@ -374,7 +371,6 @@ export const TasksMap = ({
           e.features[0].properties.taskStatus === 'MAPPED'
         ) {
           popup.addTo(map);
-          map.getCanvas().style.cursor = 'not-allowed';
         } else {
           map.getCanvas().style.cursor = 'pointer';
           popup.isOpen() && popup.remove();

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -28,6 +28,10 @@ export default defineMessages({
     id: 'project.tasks.unsaved_map_changes.actions.close_modal',
     defaultMessage: 'Close',
   },
+  deselectAndValidate: {
+    id: 'project.tasks.validation.cannot_validate_mapped_tasks.deselect_and_validate',
+    defaultMessage: 'Deselect and validate',
+  },
   cantValidateMappedTask: {
     id: 'project.tasks.select.cantValidateMappedTask',
     defaultMessage: 'This task was mapped by you',

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -30,7 +30,7 @@ export default defineMessages({
   },
   cantValidateMappedTask: {
     id: 'project.tasks.select.cantValidateMappedTask',
-    defaultMessage: 'You cannot validate tasks that you mapped',
+    defaultMessage: 'This task was mapped by you',
   },
   noMappedTasksSelectedError: {
     id: 'project.tasks.no_mapped_tasks_selected',

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -623,6 +623,7 @@
   "project.tasks.unsaved_map_changes.reload_editor": "Save or undo it to be able to switch editors",
   "project.tasks.unsaved_map_changes.tooltip": "You have unsaved edits. Save or undo them to submit this task.",
   "project.tasks.unsaved_map_changes.actions.close_modal": "Close",
+  "project.tasks.validation.cannot_validate_mapped_tasks.deselect_and_validate": "Deselect and validate",
   "project.tasks.select.cantValidateMappedTask": "This task was mapped by you",
   "project.tasks.no_mapped_tasks_selected": "No mapped tasks selected",
   "project.tasks.no_mapped_tasks_selected.description": "It was not possible to lock the selected tasks, as none of them are on the mapped status.",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -623,7 +623,7 @@
   "project.tasks.unsaved_map_changes.reload_editor": "Save or undo it to be able to switch editors",
   "project.tasks.unsaved_map_changes.tooltip": "You have unsaved edits. Save or undo them to submit this task.",
   "project.tasks.unsaved_map_changes.actions.close_modal": "Close",
-  "project.tasks.select.cantValidateMappedTask": "You cannot validate tasks that you mapped",
+  "project.tasks.select.cantValidateMappedTask": "This task was mapped by you",
   "project.tasks.no_mapped_tasks_selected": "No mapped tasks selected",
   "project.tasks.no_mapped_tasks_selected.description": "It was not possible to lock the selected tasks, as none of them are on the mapped status.",
   "project.tasks.invalid_task_state_errortitle": "Invalid Task State",


### PR DESCRIPTION
Resolves #5435 

#### Changes Made

- Added a new "Deselect and Validate" button to the task lock error modal, allowing users to deselect tasks they have mapped for validation.
- Conditionally displayed action buttons based on the user's selected tasks and mapping status.
- Abstracted the action buttons into a new `LockErrorButtons` component, which also handles task deselection and validation logic.
- Updated existing test cases to account for the new button behavior.

![Peek 2023-08-23 14-26](https://github.com/hotosm/tasking-manager/assets/51614993/4df25918-1e80-4a64-aea5-aae7b81daaa6)

