### PR TITLE
Fix navigation on point click

### DIFF
--- a/frontend/src/components/taskSelection/map.js
+++ b/frontend/src/components/taskSelection/map.js
@@ -11,6 +11,7 @@ import messages from './messages';
 import { MAPBOX_TOKEN, TASK_COLOURS, MAP_STYLE, MAPBOX_RTL_PLUGIN_URL } from '../../config';
 import lock from '../../assets/img/lock.png';
 import redlock from '../../assets/img/red-lock.png';
+import { useDebouncedCallback } from '../../hooks/UseThrottle';
 
 let lockIcon = new Image(17, 20);
 lockIcon.src = lock;
@@ -47,6 +48,8 @@ export const TasksMap = ({
   const [hoveredTaskId, setHoveredTaskId] = useState(null);
 
   const [map, setMapObj] = useState(null);
+
+  const [debouncedNavigateToTasks] = useDebouncedCallback(() => navigate('./tasks'), 100);
 
   useLayoutEffect(() => {
     /* May be able to refactor this to just take
@@ -392,8 +395,8 @@ export const TasksMap = ({
         map.on('mouseleave', 'point-tasks-centroid', function (e) {
           map.getCanvas().style.cursor = '';
         });
-        map.on('click', 'point-tasks-centroid', () => navigate('./tasks'));
-        map.on('click', 'point-tasks-centroid-inner', () => navigate('./tasks'));
+        map.on('click', 'point-tasks-centroid', debouncedNavigateToTasks);
+        map.on('click', 'point-tasks-centroid-inner', debouncedNavigateToTasks);
       }
 
       map.on('click', 'tasks-fill', onSelectTaskClick);
@@ -487,6 +490,7 @@ export const TasksMap = ({
     zoomedTaskId,
     authDetails.username,
     intl,
+    debouncedNavigateToTasks,
   ]);
 
   if (!mapboxgl.supported()) {


### PR DESCRIPTION
From https://github.com/hotosm/tasking-manager/pull/5721#issuecomment-1563147068

> I noticed that the circle layer for the tasks centroid on the project detail page does not navigate to the task selection page when clicked. This functionality appears to be broken.
>
> https://github.com/facebook/OSM-HOT-Tasking-Manager/blob/1ff61218946e43cec7f66c65dc225ac8410b7fa8/frontend/src/components/taskSelection/map.js#L399-L400
>
> EDIT: Something unusual is happening here: when you press the back button on the browser numerous times, you'll find that the app did navigate to the intended route, indicating that the on-click event is being triggered multiple times. We can eliminate the problem by removing the relative navigation and instead using the full path '/projects/:id/tasks,' but the back functionality still won't work.

Current (deployed) behavior (back pages):
* https://tasks.hotosm.org/projects/14678/tasks
* https://tasks.hotosm.org/projects/14678/tasks
* https://tasks.hotosm.org/projects/14678/tasks
* https://tasks.hotosm.org/projects/14678

Expected behavior:
* https://tasks.hotosm.org/projects/14678/tasks
* https://tasks.hotosm.org/projects/14678