### PR TITLE
ReactJS: Don't use 'selected' for '<option/>' nodes

### DIFF
--- a/frontend/src/components/projectEdit/settingsForm.js
+++ b/frontend/src/components/projectEdit/settingsForm.js
@@ -32,9 +32,10 @@ export const SettingsForm = ({ languages, defaultLocale }) => {
           name="defaultLocale"
           onChange={updateDefaultLocale}
           className="pa2 bg-white ba ba--grey-light"
+          value={defaultLocale}
         >
           {languages.map((l) => (
-            <option key={l.code} selected={l.code === defaultLocale ? true : false} value={l.code}>
+            <option key={l.code} value={l.code}>
               {l.language} ({l.code})
             </option>
           ))}


### PR DESCRIPTION
This makes the language selection box down a  _controlled_ selection box.