### PR TITLE
#5331 - Eliminate Possibilities of Sending Multiple Project Update Emails

### DIFF
--- a/backend/models/postgis/message.py
+++ b/backend/models/postgis/message.py
@@ -119,7 +119,8 @@ class Message(db.Model):
                 .filter(Task.project_id == project_id)
                 .filter(Task.validated_by.isnot(None))
             )
-        )
+            .distinct()
+        ).all()
         return contributors
 
     @staticmethod

--- a/backend/services/messaging/smtp_service.py
+++ b/backend/services/messaging/smtp_service.py
@@ -116,6 +116,9 @@ class SMTPService:
                     and contributor.is_email_verified
                     and contributor.projects_notifications
                 ):
+                    current_app.logger.debug(
+                        f"Sending {email_type} email to {contributor.email_address} for project {project_id}"
+                    )
                     SMTPService._send_message(
                         contributor.email_address, subject, html_template
                     )

--- a/backend/services/project_service.py
+++ b/backend/services/project_service.py
@@ -605,6 +605,7 @@ class ProjectService:
                 project_id, project.default_locale
             ).name
             project.progress_email_sent = True
+            project.save()
             threading.Thread(
                 target=SMTPService.send_email_to_contributors_on_project_progress,
                 args=(


### PR DESCRIPTION
This PR addresses the issue #5331, which was not reproducible locally. The aim of this fix is to identify and eliminate potential factors that may contribute to the problem of sending multiple project update emails.

- Makes sure distinct project contributors are fetched from database.
- Makes sure project is `project_update_email` field is updated before starting to send project update emails.
- Adds a logger to capture email type, project id and email address so that we can examine logs to make sure if the issue has been fixed.