### PR TITLE
Remove window reload from lock task for mapping logic

### DIFF
--- a/frontend/src/components/taskSelection/footer.js
+++ b/frontend/src/components/taskSelection/footer.js
@@ -110,9 +110,6 @@ const TaskSelectionFooter = ({ defaultUserEditor, project, tasks, taskAction, se
       )
         .then((res) => {
           lockSuccess('LOCKED_FOR_MAPPING', 'map', windowObjectReference);
-          if (editor !== 'JOSM') {
-            window.location.reload();
-          }
         })
         .catch((e) => lockFailed(windowObjectReference, e.message));
     }


### PR DESCRIPTION
Closes #5945 

This pull request addresses an apparent oversight introduced in #4934. The code in question pertains to the page reload when handling the locking of a mapping task.

After consulting with Wille, the previous maintainer, it has been determined that the reload behavior introduced in the codebase is not necessary and can be safely removed. 

Fingers crossed that this change doesn't cause any unexpected issues in the mapping flow :crossed_fingers:!