### PR TITLE
Hide scrollbar in Firefox

### DIFF
--- a/frontend/src/components/header/styles.scss
+++ b/frontend/src/components/header/styles.scss
@@ -2,6 +2,11 @@
   display: none;
 }
 
+/* Hide the scrollbar in Firefox */
+.navigation-items-container {
+  scrollbar-width: none;
+}
+
 @media screen and (max-width: 45em) {
   .dn-sm {
     display: none;

--- a/frontend/src/components/projectDetail/styles.scss
+++ b/frontend/src/components/projectDetail/styles.scss
@@ -21,3 +21,8 @@
 .menu-items-container::-webkit-scrollbar {
   display: none;
 }
+
+/* Hide the scrollbar in Firefox */
+.menu-items-container {
+  scrollbar-width: none;
+}


### PR DESCRIPTION
Resolves #5893 

This hides the scrollbar while supporting horizontal scrolling in Firefox. The previous implementation only worked in Chrome but not in Firefox.

![scrollbar-firefox](https://github.com/hotosm/tasking-manager/assets/51614993/31caeff0-f6f9-4c43-98de-59816e956a82)
