### PR TITLE
Upgrade deployment python version to 3.11

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -368,7 +368,7 @@ const Resources = {
         'sudo apt-get -q -y update',
         'sudo DEBIAN_FRONTEND=noninteractive apt-get -q -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade',
         'sudo apt-get -q -y install awscli curl git gnupg ruby wget',
-        'sudo apt-get -q -y install python3.9 python3-pip python3-psycopg2 python-is-python3',
+        'sudo apt-get -q -y install python3.11 python3-pip python3-psycopg2 python-is-python3',
         'sudo apt-get -q -y install postgresql-client postgis libpq-dev',
         'sudo apt-get -q -y install libxml2 libxml2-dev',
         'sudo apt-get -q -y install libgeos-3.9.0 libgeos-dev',


### PR DESCRIPTION
Fix for staging deployments. ref #6013 

I was unable to test this in a new environment, because of other unrelated issues with frontend bucket permissions, which I am working out with @eternaltyro . We can discuss whether to push the changes (since staging is non-functional at the moment anyways) and just see if it works in staging. 