### PR TITLE
Fix Missing task extension duration in action_text.

### DIFF
--- a/backend/services/mapping_service.py
+++ b/backend/services/mapping_service.py
@@ -471,11 +471,16 @@ class MappingService:
             if task.task_status == TaskStatus.LOCKED_FOR_VALIDATION:
                 action = TaskAction.EXTENDED_FOR_VALIDATION
 
+            # Update the duration of the lock/extension before creating new history
+            last_history = TaskHistory.get_last_action(task.project_id, task.id)
+            # To reset a lock the last action must have been either lock or extension
+            last_action = TaskAction[last_history.action]
             TaskHistory.update_task_locked_with_duration(
                 task_id,
                 extend_dto.project_id,
-                TaskStatus(task.task_status),
+                last_action,
                 extend_dto.user_id,
             )
+
             task.set_task_history(action, extend_dto.user_id)
             task.update()

--- a/tests/backend/integration/api/tasks/test_actions.py
+++ b/tests/backend/integration/api/tasks/test_actions.py
@@ -578,6 +578,10 @@ class TestTasksActionsMappingUnlockAPI(BaseTestCase):
         self.assertEqual(last_task_history["action"], TaskAction.STATE_CHANGE.name)
         self.assertEqual(last_task_history["actionText"], TaskStatus.MAPPED.name)
         self.assertEqual(last_task_history["actionBy"], self.test_user.username)
+        # Check if lock duration is saved
+        # Since locked duration is saved in entry with action as "LOCKED_FOR_MAPPING"
+        # we need to look for second entry in task history
+        self.assertIsNotNone(response.json["taskHistory"][1]["actionText"])
 
     def test_mapping_unlock_returns_200_on_success_with_comment(self):
         """Test returns 200 on success."""
@@ -609,6 +613,11 @@ class TestTasksActionsMappingUnlockAPI(BaseTestCase):
         self.assertEqual(last_comment_history["action"], TaskAction.COMMENT.name)
         self.assertEqual(last_comment_history["actionText"], "cannot map")
         self.assertEqual(last_comment_history["actionBy"], self.test_user.username)
+
+        # Check if lock duration is saved
+        # Since locked duration is saved in entry with action as "LOCKED_FOR_MAPPING"
+        # we need to look for third entry in task history as second entry is comment
+        self.assertIsNotNone(response.json["taskHistory"][2]["actionText"])
 
 
 class TestTasksActionsMappingStopAPI(BaseTestCase):
@@ -1242,6 +1251,11 @@ class TestTasksActionsValidationStopAPI(BaseTestCase):
         self.assertEqual(task_history_comment["action"], "COMMENT")
         self.assertEqual(task_history_comment["actionText"], "Test comment")
         self.assertEqual(task_history_comment["actionBy"], self.test_user.username)
+
+        # Check if lock duration is saved
+        # Since locked duration is saved in entry with action as "LOCKED_FOR_MAPPING"
+        # we need to look for third entry in task history as second entry is comment
+        self.assertIsNotNone(response.json["tasks"][0]["taskHistory"][2]["actionText"])
 
 
 class TestTasksActionsSplitAPI(BaseTestCase):

--- a/tests/backend/integration/api/tasks/test_actions.py
+++ b/tests/backend/integration/api/tasks/test_actions.py
@@ -561,9 +561,8 @@ class TestTasksActionsMappingUnlockAPI(BaseTestCase):
         """Test returns 200 on success."""
         # Arrange
         task = Task.get(1, self.test_project.id)
-        task.task_status = TaskStatus.LOCKED_FOR_MAPPING.value
-        task.locked_by = self.test_user.id
-        task.update()
+        task.status = TaskStatus.READY.value
+        task.lock_task_for_mapping(self.test_user.id)
         # Act
         response = self.client.post(
             self.url,
@@ -584,9 +583,8 @@ class TestTasksActionsMappingUnlockAPI(BaseTestCase):
         """Test returns 200 on success."""
         # Arrange
         task = Task.get(1, self.test_project.id)
-        task.task_status = TaskStatus.LOCKED_FOR_MAPPING.value
-        task.locked_by = self.test_user.id
-        task.update()
+        task.status = TaskStatus.READY.value
+        task.lock_task_for_mapping(self.test_user.id)
         # Act
         response = self.client.post(
             self.url,
@@ -685,9 +683,8 @@ class TestTasksActionsMappingStopAPI(BaseTestCase):
         """Test returns 200 on success."""
         # Arrange
         task = Task.get(1, self.test_project.id)
-        task.task_status = TaskStatus.LOCKED_FOR_MAPPING.value
-        task.locked_by = self.test_user.id
-        task.update()
+        task.status = TaskStatus.READY.value
+        task.lock_task_for_mapping(self.test_user.id)
         # Act
         response = self.client.post(
             self.url,
@@ -703,9 +700,8 @@ class TestTasksActionsMappingStopAPI(BaseTestCase):
         """Test returns 200 on success."""
         # Arrange
         task = Task.get(1, self.test_project.id)
-        task.task_status = TaskStatus.LOCKED_FOR_MAPPING.value
-        task.locked_by = self.test_user.id
-        task.update()
+        task.status = TaskStatus.READY.value
+        task.lock_task_for_mapping(self.test_user.id)
         # Act
         response = self.client.post(
             self.url,
@@ -992,11 +988,14 @@ class TestTasksActionsValidationUnlockAPI(BaseTestCase):
     def lock_task_for_validation(task_id, project_id, user_id, mapped_by=None):
         """Lock task for validation."""
         task = Task.get(task_id, project_id)
-        task.task_status = TaskStatus.LOCKED_FOR_VALIDATION.value
-        task.locked_by = user_id
+
         if mapped_by:
-            task.mapped_by = mapped_by
-        task.update()
+            task.status = TaskStatus.READY.value
+            task.lock_task_for_mapping(mapped_by)
+            task.unlock_task(mapped_by, TaskStatus.MAPPED)
+
+        task.status = TaskStatus.MAPPED.value
+        task.lock_task_for_validating(user_id)
 
     def test_validation_unlock_returns_403_if_task_locked_by_other_user(self):
         """Test returns 403 if task locked by other user."""
@@ -1197,7 +1196,6 @@ class TestTasksActionsValidationStopAPI(BaseTestCase):
         """Test returns 200 if task locked by user."""
         # Arrange
         task = Task.get(1, self.test_project.id)
-        task.unlock_task(self.test_user.id, TaskStatus.MAPPED)
         last_task_status = TaskStatus(task.task_status).name
         TestTasksActionsValidationUnlockAPI.lock_task_for_validation(
             1, self.test_project.id, self.test_user.id, self.test_user.id
@@ -1218,7 +1216,6 @@ class TestTasksActionsValidationStopAPI(BaseTestCase):
         """Test returns 200 if task locked by user with comment."""
         # Arrange
         task = Task.get(1, self.test_project.id)
-        task.unlock_task(self.test_user.id, TaskStatus.MAPPED)
         last_task_status = TaskStatus(task.task_status).name
         TestTasksActionsValidationUnlockAPI.lock_task_for_validation(
             1, self.test_project.id, self.test_user.id, self.test_user.id


### PR DESCRIPTION
closes #6014 

In the previous implementation, there was an issue where the duration of a task extension was not being recorded when a task was extended and then unlocked/stopped. Prior to the implementation of the task lock extension feature, the last recorded action for a task was always either "LOCKED_FOR_MAPPING" or "LOCKED_FOR_VALIDATION," which matched the task status. To update the duration, we used the current task status as the last action to filter the task history and update the last entry with the lock duration.

However, after the task extension feature was introduced, two additional last actions were possible: "EXTENDED_FOR_MAPPING" and "EXTENDED_FOR_VALIDATION." This introduced a discrepancy between the last recorded action and the task status. For example, the task status could still be "LOCKED_FOR_MAPPING" even when a user had extended the task. As a result, the entry with the action "EXTENDED_FOR_MAPPING" in the task history was not being updated with the correct duration.

To address this issue, this PR fixes the problem by retrieving the last task action and using it as the filter criteria for updating the task history, rather than relying on the task status as the last action.

#### Cases:
- **Task is stopped mapping/validating after extension.** -> The entry with extension is updated with extension duration.
- **Task's state is changed after extension.** -> The entry with extension is updated with duration and new entry with state changed is added.
- **Task's lock is extended multiple times.**  -> After each extension previous entry with extension is updated with the duration and new entry with extension is added.
- **Task is auto unlocked after extension.** -> The entry with extension is updated with duration and name of the action is changed from "EXTENDED_FOR_MAPPING" to "AUTO_UNLOCKED_FOR_MAPPING".