### PR TITLE
Change value from `0` to `-` in My Contributions stats section

### DIFF
--- a/frontend/src/components/userDetail/elementsMapped.js
+++ b/frontend/src/components/userDetail/elementsMapped.js
@@ -146,12 +146,12 @@ export const ElementsMapped = ({ userStats, osmStats }) => {
         <StatsCard
           icon={<MarkerIcon className={iconClass} style={iconStyle} />}
           description={<FormattedMessage {...messages.poiMapped} />}
-          value={osmStats.total_poi_count_add || 0}
+          value={osmStats.total_poi_count_add || '-'}
         />
         <StatsCard
           icon={<WavesIcon className={iconClass} style={iconStyle} />}
           description={<FormattedMessage {...messages.waterwaysMapped} />}
-          value={osmStats.total_waterway_km_add || 0}
+          value={osmStats.total_waterway_km_add || '-'}
         />
       </div>
       <div className="cf w-100 relative tr pt3 pr3">


### PR DESCRIPTION
This PR addresses missing data points currently unavailable from ohsomeNow stats by changing `0` to `-` in My Contributions section.

![image](https://github.com/hotosm/tasking-manager/assets/51167861/1e7ed915-70f1-4803-833f-3180bff6d198)


- Part of #6078