### PR TITLE
fix: unable to access draft and private projects

### DIFF
--- a/frontend/src/api/projects.js
+++ b/frontend/src/api/projects.js
@@ -37,8 +37,10 @@ export const useProjectsQuery = (fullProjectsQuery, action) => {
 };
 
 export const useProjectQuery = (projectId) => {
+  const token = useSelector((state) => state.auth.token);
+  const locale = useSelector((state) => state.preferences['locale']);
   const fetchProject = ({ signal }) => {
-    return api().get(`projects/${projectId}/`, {
+    return api(token, locale).get(`projects/${projectId}/`, {
       signal,
     });
   };


### PR DESCRIPTION
This PR addresses the issue related to the user's unable to access private and draft projects. The issue arose because the API call for project details was missing an auth token. For the fix token has been added to the API call.
 
Fix for issue #6088 