### PR TITLE
fix: associated projects in teams page

### DIFF
--- a/frontend/src/views/teams.js
+++ b/frontend/src/views/teams.js
@@ -426,7 +426,7 @@ export function TeamDetail() {
   const [error, loading, team] = useFetch(`teams/${id}/`);
   // eslint-disable-next-line
   const [projectsError, projectsLoading, projects] = useFetch(
-    `projects/?teamId=${id}&omitMapResults=true`,
+    `projects/?teamId=${id}&omitMapResults=true&projectStatuses=PUBLISHED,DRAFT,ARCHIVED`,
     id,
   );
   const [isMember, setIsMember] = useState(false);


### PR DESCRIPTION
The draft and archived projects were not visible on the teams page. This fixes the issue by adding projectStatuses query param to the api for projects in team page.

- fix #6070 