### PR TITLE
fix: team delete message for associated projects

### DIFF
--- a/backend/api/teams/resources.py
+++ b/backend/api/teams/resources.py
@@ -181,8 +181,7 @@ class TeamsRestAPI(Resource):
                 "SubCode": "UserNotTeamManager",
             }, 401
 
-        TeamService.delete_team(team_id)
-        return {"Success": "Team deleted"}, 200
+        return TeamService.delete_team(team_id)
 
 
 class TeamsAllAPI(Resource):

--- a/backend/services/team_service.py
+++ b/backend/services/team_service.py
@@ -566,8 +566,12 @@ class TeamService:
 
         if team.can_be_deleted():
             team.delete()
+            return {"Success": "Team deleted"}, 200
         else:
-            raise TeamServiceError("Team has projects, cannot be deleted")
+            return {
+                "Error": "Team has projects, cannot be deleted",
+                "SubCode": "This team has projects associated. Before deleting a team, unlink any associated projects."
+            }, 400
 
     @staticmethod
     def check_team_membership(project_id: int, allowed_roles: list, user_id: int):

--- a/backend/services/team_service.py
+++ b/backend/services/team_service.py
@@ -570,7 +570,7 @@ class TeamService:
         else:
             return {
                 "Error": "Team has projects, cannot be deleted",
-                "SubCode": "This team has projects associated. Before deleting a team, unlink any associated projects."
+                "SubCode": "This team has projects associated. Before deleting team, unlink any associated projects.",
             }, 400
 
     @staticmethod


### PR DESCRIPTION
There was no appropriate error message when trying to delete a team but was not deleted because it has projects associated. Now error message is returned from the backend instead of an internal server error.

- fix #6071 