### PR TITLE
fix: unit test fail for backend tasks/statistics

### DIFF
--- a/tests/backend/integration/api/tasks/test_statistics.py
+++ b/tests/backend/integration/api/tasks/test_statistics.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from backend.models.postgis.task import Task, TaskStatus
 from backend.services.campaign_service import CampaignService, CampaignProjectDTO
@@ -105,7 +105,11 @@ class TestTasksStatisticsAPI(BaseTestCase):
         response = self.client.get(
             self.url,
             headers={"Authorization": self.user_session_token},
-            query_string={"startDate": "2023-01-01"},
+            query_string={
+                "startDate": (datetime.now() - timedelta(days=6 * 30)).strftime(
+                    "%Y-%m-%d"
+                )
+            },
         )
         # Assert
         self.assertEqual(response.status_code, 200)
@@ -130,7 +134,9 @@ class TestTasksStatisticsAPI(BaseTestCase):
             self.url,
             headers={"Authorization": self.user_session_token},
             query_string={
-                "startDate": "2023-01-01",
+                "startDate": (datetime.now() - timedelta(days=6 * 30)).strftime(
+                    "%Y-%m-%d"
+                ),
                 "projectId": self.test_project_1.id,
             },
         )
@@ -152,7 +158,9 @@ class TestTasksStatisticsAPI(BaseTestCase):
             self.url,
             headers={"Authorization": self.user_session_token},
             query_string={
-                "startDate": "2023-01-01",
+                "startDate": (datetime.now() - timedelta(days=6 * 30)).strftime(
+                    "%Y-%m-%d"
+                ),
                 "projectId": f"{self.test_project_1.id}, {self.test_project_2.id}",
             },
         )
@@ -173,7 +181,9 @@ class TestTasksStatisticsAPI(BaseTestCase):
             self.url,
             headers={"Authorization": self.user_session_token},
             query_string={
-                "startDate": "2023-01-01",
+                "startDate": (datetime.now() - timedelta(days=6 * 30)).strftime(
+                    "%Y-%m-%d"
+                ),
                 "organisationId": test_organisation.id,
             },
         )
@@ -194,7 +204,9 @@ class TestTasksStatisticsAPI(BaseTestCase):
             self.url,
             headers={"Authorization": self.user_session_token},
             query_string={
-                "startDate": "2023-01-01",
+                "startDate": (datetime.now() - timedelta(days=6 * 30)).strftime(
+                    "%Y-%m-%d"
+                ),
                 "organisationName": test_organisation.name,
             },
         )
@@ -217,7 +229,9 @@ class TestTasksStatisticsAPI(BaseTestCase):
             self.url,
             headers={"Authorization": self.user_session_token},
             query_string={
-                "startDate": "2023-01-01",
+                "startDate": (datetime.now() - timedelta(days=6 * 30)).strftime(
+                    "%Y-%m-%d"
+                ),
                 "campaign": test_campaign.name,
             },
         )
@@ -239,7 +253,9 @@ class TestTasksStatisticsAPI(BaseTestCase):
             self.url,
             headers={"Authorization": self.user_session_token},
             query_string={
-                "startDate": "2023-01-01",
+                "startDate": (datetime.now() - timedelta(days=6 * 30)).strftime(
+                    "%Y-%m-%d"
+                ),
                 "country": "Nepal",
             },
         )


### PR DESCRIPTION
- Test cases for tests/backend/integration/api/tasks/test_statistics.py were failing due to time intervals greater than 1 year. 
- There was a fixed date for the startDate value in test cases "2023-01-01". Now the startDate will get the date of the past six-month. 
- The fixed dates are now replaced with dynamic past six month date.