### PR TITLE
Enhance : Active Projects API 

### DIFF
--- a/backend/services/project_service.py
+++ b/backend/services/project_service.py
@@ -2,7 +2,7 @@ import threading
 from cachetools import TTLCache, cached
 from flask import current_app
 import geojson
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 from backend.exceptions import NotFound
 

--- a/backend/services/project_service.py
+++ b/backend/services/project_service.py
@@ -5,7 +5,6 @@ import geojson
 from datetime import datetime, timedelta, timezone
 
 from backend.exceptions import NotFound
-from sqlalchemy import func
 
 from backend.models.dtos.mapping_dto import TaskDTOs
 from backend.models.dtos.project_dto import (
@@ -30,13 +29,13 @@ from backend.models.postgis.statuses import (
     EncouragingEmailType,
     MappingLevel,
 )
-from backend.models.postgis.task import Task, TaskHistory, ProjectComment
+from backend.models.postgis.task import Task, TaskHistory
 from backend.services.messaging.smtp_service import SMTPService
 from backend.services.users.user_service import UserService
 from backend.services.project_search_service import ProjectSearchService
 from backend.services.project_admin_service import ProjectAdminService
 from backend.services.team_service import TeamService
-from sqlalchemy import or_
+from sqlalchemy import func, or_
 from sqlalchemy.sql.expression import true
 
 summary_cache = TTLCache(maxsize=1024, ttl=600)


### PR DESCRIPTION
## What does this PR do ? 

- This PR enhances the active projects API by : 
   - Fixing bug on UTC timestamp comparison while fetching projects 
   - if Project has a comment / conversation happening then that project is also considered as active 
  

## Consideration 

- I am aware of performance of the API , I will wait for the multi process approach that's going on before adding enhancement on this endpoint for the consistency 

## How to test ? 

- I have compared number of projects returned with following query in database directly and from the API endpoint : ```http://127.0.0.1:5000/api/v2/projects/queries/active/?interval=1```

```sql 
with t1 as (
select distinct  project_id 
from project_chat pc 
WHERE "time_stamp" > (CURRENT_TIMESTAMP AT TIME ZONE 'UTC') - INTERVAL '1 hours'
UNION
SELECT DISTINCT project_id 
FROM task_history 
WHERE action_date > (CURRENT_TIMESTAMP AT TIME ZONE 'UTC') - INTERVAL '1 hours'
)
select count(distinct  project_id)
from t1
```

