### PR TITLE
Unlock tasks after validation using in parallel using python threads

### DIFF
--- a/backend/models/postgis/task.py
+++ b/backend/models/postgis/task.py
@@ -97,21 +97,29 @@ class TaskInvalidationHistory(db.Model):
         db.session.commit()
 
     @staticmethod
-    def get_open_for_task(project_id, task_id):
+    def get_open_for_task(project_id, task_id, local_session=None):
+        if local_session:
+            return local_session.query(TaskInvalidationHistory).filter_by(
+                task_id=task_id, project_id=project_id, is_closed=False
+            ).one_or_none()
         return TaskInvalidationHistory.query.filter_by(
             task_id=task_id, project_id=project_id, is_closed=False
         ).one_or_none()
 
     @staticmethod
-    def close_all_for_task(project_id, task_id):
+    def close_all_for_task(project_id, task_id, local_session=None):
+        if local_session:
+            return local_session.query(TaskInvalidationHistory).filter_by(
+                task_id=task_id, project_id=project_id, is_closed=False
+            ).update({"is_closed": True})
         TaskInvalidationHistory.query.filter_by(
             task_id=task_id, project_id=project_id, is_closed=False
         ).update({"is_closed": True})
 
     @staticmethod
-    def record_invalidation(project_id, task_id, invalidator_id, history):
+    def record_invalidation(project_id, task_id, invalidator_id, history, local_session=None):
         # Invalidation always kicks off a new entry for a task, so close any existing ones.
-        TaskInvalidationHistory.close_all_for_task(project_id, task_id)
+        TaskInvalidationHistory.close_all_for_task(project_id, task_id, local_session=local_session)
 
         last_mapped = TaskHistory.get_last_mapped_action(project_id, task_id)
         if last_mapped is None:
@@ -124,11 +132,15 @@ class TaskInvalidationHistory(db.Model):
         entry.invalidator_id = invalidator_id
         entry.invalidated_date = history.action_date
         entry.updated_date = timestamp()
-        db.session.add(entry)
+        if local_session:
+            local_session.add(entry)
+        else:
+            db.session.add(entry)
+
 
     @staticmethod
-    def record_validation(project_id, task_id, validator_id, history):
-        entry = TaskInvalidationHistory.get_open_for_task(project_id, task_id)
+    def record_validation(project_id, task_id, validator_id, history, local_session=None):
+        entry = TaskInvalidationHistory.get_open_for_task(project_id, task_id, local_session=local_session)
 
         # If no open invalidation to update, then nothing to do
         if entry is None:
@@ -259,7 +271,7 @@ class TaskHistory(db.Model):
 
     @staticmethod
     def update_task_locked_with_duration(
-        task_id: int, project_id: int, lock_action, user_id: int
+        task_id: int, project_id: int, lock_action, user_id: int, local_session=None
     ):
         """
         Calculates the duration a task was locked for and sets it on the history record
@@ -270,13 +282,22 @@ class TaskHistory(db.Model):
         :return:
         """
         try:
-            last_locked = TaskHistory.query.filter_by(
-                task_id=task_id,
-                project_id=project_id,
-                action=lock_action.name,
-                action_text=None,
-                user_id=user_id,
-            ).one()
+            if local_session:
+                last_locked = local_session.query(TaskHistory).filter_by(
+                    task_id=task_id,
+                    project_id=project_id,
+                    action=lock_action.name,
+                    action_text=None,
+                    user_id=user_id,
+                ).one()
+            else:
+                last_locked = TaskHistory.query.filter_by(
+                    task_id=task_id,
+                    project_id=project_id,
+                    action=lock_action.name,
+                    action_text=None,
+                    user_id=user_id,
+                ).one()
         except NoResultFound:
             # We suspect there's some kind or race condition that is occasionally deleting history records
             # prior to user unlocking task. Most likely stemming from auto-unlock feature. However, given that
@@ -302,7 +323,10 @@ class TaskHistory(db.Model):
         last_locked.action_text = (
             (datetime.datetime.min + duration_task_locked).time().isoformat()
         )
-        db.session.commit()
+        if local_session:
+            local_session.commit()
+        else:
+            db.session.commit()
 
     @staticmethod
     def remove_duplicate_task_history_rows(
@@ -539,9 +563,12 @@ class Task(db.Model):
         db.session.add(self)
         db.session.commit()
 
-    def update(self):
+    def update(self, local_session=None):
         """Updates the DB with the current state of the Task"""
-        db.session.commit()
+        if local_session:
+            local_session.commit()
+        else:
+            db.session.commit()
 
     def delete(self):
         """Deletes the current model from the DB"""
@@ -592,7 +619,7 @@ class Task(db.Model):
         return task
 
     @staticmethod
-    def get(task_id: int, project_id: int):
+    def get(task_id: int, project_id: int, local_session=None):
         """
         Gets specified task
         :param task_id: task ID in scope
@@ -600,7 +627,10 @@ class Task(db.Model):
         :return: Task if found otherwise None
         """
         # LIKELY PROBLEM AREA
-
+        if local_session:
+            return local_session.query(Task).filter_by(
+                id=task_id, project_id=project_id
+            ).one_or_none()
         return Task.query.filter_by(id=task_id, project_id=project_id).one_or_none()
 
     @staticmethod
@@ -781,7 +811,7 @@ class Task(db.Model):
         self.update()
 
     def unlock_task(
-        self, user_id, new_state=None, comment=None, undo=False, issues=None
+        self, user_id, new_state=None, comment=None, undo=False, issues=None, local_session=None
     ):
         """Unlock task and ensure duration task locked is saved in History"""
         if comment:
@@ -812,12 +842,12 @@ class Task(db.Model):
             self.mapped_by = user_id
         elif new_state == TaskStatus.VALIDATED:
             TaskInvalidationHistory.record_validation(
-                self.project_id, self.id, user_id, history
+                self.project_id, self.id, user_id, history, local_session=local_session
             )
             self.validated_by = user_id
         elif new_state == TaskStatus.INVALIDATED:
             TaskInvalidationHistory.record_invalidation(
-                self.project_id, self.id, user_id, history
+                self.project_id, self.id, user_id, history, local_session=local_session
             )
             self.mapped_by = None
             self.validated_by = None
@@ -825,12 +855,15 @@ class Task(db.Model):
         if not undo:
             # Using a slightly evil side effect of Actions and Statuses having the same name here :)
             TaskHistory.update_task_locked_with_duration(
-                self.id, self.project_id, TaskStatus(self.task_status), user_id
+                self.id, self.project_id, TaskStatus(self.task_status), user_id, local_session=local_session
             )
 
         self.task_status = new_state.value
         self.locked_by = None
-        self.update()
+        if local_session:
+            self.update(local_session=local_session)
+        else:
+            self.update()
 
     def reset_lock(self, user_id, comment=None):
         """Removes a current lock from a task, resets to last status and

--- a/backend/models/postgis/task.py
+++ b/backend/models/postgis/task.py
@@ -99,9 +99,11 @@ class TaskInvalidationHistory(db.Model):
     @staticmethod
     def get_open_for_task(project_id, task_id, local_session=None):
         if local_session:
-            return local_session.query(TaskInvalidationHistory).filter_by(
-                task_id=task_id, project_id=project_id, is_closed=False
-            ).one_or_none()
+            return (
+                local_session.query(TaskInvalidationHistory)
+                .filter_by(task_id=task_id, project_id=project_id, is_closed=False)
+                .one_or_none()
+            )
         return TaskInvalidationHistory.query.filter_by(
             task_id=task_id, project_id=project_id, is_closed=False
         ).one_or_none()
@@ -109,17 +111,23 @@ class TaskInvalidationHistory(db.Model):
     @staticmethod
     def close_all_for_task(project_id, task_id, local_session=None):
         if local_session:
-            return local_session.query(TaskInvalidationHistory).filter_by(
-                task_id=task_id, project_id=project_id, is_closed=False
-            ).update({"is_closed": True})
+            return (
+                local_session.query(TaskInvalidationHistory)
+                .filter_by(task_id=task_id, project_id=project_id, is_closed=False)
+                .update({"is_closed": True})
+            )
         TaskInvalidationHistory.query.filter_by(
             task_id=task_id, project_id=project_id, is_closed=False
         ).update({"is_closed": True})
 
     @staticmethod
-    def record_invalidation(project_id, task_id, invalidator_id, history, local_session=None):
+    def record_invalidation(
+        project_id, task_id, invalidator_id, history, local_session=None
+    ):
         # Invalidation always kicks off a new entry for a task, so close any existing ones.
-        TaskInvalidationHistory.close_all_for_task(project_id, task_id, local_session=local_session)
+        TaskInvalidationHistory.close_all_for_task(
+            project_id, task_id, local_session=local_session
+        )
 
         last_mapped = TaskHistory.get_last_mapped_action(project_id, task_id)
         if last_mapped is None:
@@ -137,10 +145,13 @@ class TaskInvalidationHistory(db.Model):
         else:
             db.session.add(entry)
 
-
     @staticmethod
-    def record_validation(project_id, task_id, validator_id, history, local_session=None):
-        entry = TaskInvalidationHistory.get_open_for_task(project_id, task_id, local_session=local_session)
+    def record_validation(
+        project_id, task_id, validator_id, history, local_session=None
+    ):
+        entry = TaskInvalidationHistory.get_open_for_task(
+            project_id, task_id, local_session=local_session
+        )
 
         # If no open invalidation to update, then nothing to do
         if entry is None:
@@ -283,13 +294,17 @@ class TaskHistory(db.Model):
         """
         try:
             if local_session:
-                last_locked = local_session.query(TaskHistory).filter_by(
-                    task_id=task_id,
-                    project_id=project_id,
-                    action=lock_action.name,
-                    action_text=None,
-                    user_id=user_id,
-                ).one()
+                last_locked = (
+                    local_session.query(TaskHistory)
+                    .filter_by(
+                        task_id=task_id,
+                        project_id=project_id,
+                        action=lock_action.name,
+                        action_text=None,
+                        user_id=user_id,
+                    )
+                    .one()
+                )
             else:
                 last_locked = TaskHistory.query.filter_by(
                     task_id=task_id,
@@ -628,9 +643,11 @@ class Task(db.Model):
         """
         # LIKELY PROBLEM AREA
         if local_session:
-            return local_session.query(Task).filter_by(
-                id=task_id, project_id=project_id
-            ).one_or_none()
+            return (
+                local_session.query(Task)
+                .filter_by(id=task_id, project_id=project_id)
+                .one_or_none()
+            )
         return Task.query.filter_by(id=task_id, project_id=project_id).one_or_none()
 
     @staticmethod
@@ -811,7 +828,13 @@ class Task(db.Model):
         self.update()
 
     def unlock_task(
-        self, user_id, new_state=None, comment=None, undo=False, issues=None, local_session=None
+        self,
+        user_id,
+        new_state=None,
+        comment=None,
+        undo=False,
+        issues=None,
+        local_session=None,
     ):
         """Unlock task and ensure duration task locked is saved in History"""
         if comment:
@@ -855,7 +878,11 @@ class Task(db.Model):
         if not undo:
             # Using a slightly evil side effect of Actions and Statuses having the same name here :)
             TaskHistory.update_task_locked_with_duration(
-                self.id, self.project_id, TaskStatus(self.task_status), user_id, local_session=local_session
+                self.id,
+                self.project_id,
+                TaskStatus(self.task_status),
+                user_id,
+                local_session=local_session,
             )
 
         self.task_status = new_state.value

--- a/backend/services/stats_service.py
+++ b/backend/services/stats_service.py
@@ -63,7 +63,9 @@ class StatsService:
         project, user = StatsService._update_tasks_stats(
             project, user, last_state, new_state, action
         )
-        UserService.upsert_mapped_projects(user_id, project_id, local_session=local_session)
+        UserService.upsert_mapped_projects(
+            user_id, project_id, local_session=local_session
+        )
         project.last_updated = timestamp()
 
         # Transaction will be saved when task is saved

--- a/backend/services/stats_service.py
+++ b/backend/services/stats_service.py
@@ -47,6 +47,7 @@ class StatsService:
         last_state: TaskStatus,
         new_state: TaskStatus,
         action="change",
+        local_session=None,
     ):
         """Update stats when a task has had a state change"""
 
@@ -62,7 +63,7 @@ class StatsService:
         project, user = StatsService._update_tasks_stats(
             project, user, last_state, new_state, action
         )
-        UserService.upsert_mapped_projects(user_id, project_id)
+        UserService.upsert_mapped_projects(user_id, project_id, local_session=local_session)
         project.last_updated = timestamp()
 
         # Transaction will be saved when task is saved

--- a/backend/services/users/user_service.py
+++ b/backend/services/users/user_service.py
@@ -604,9 +604,9 @@ class UserService:
         return countries_dto
 
     @staticmethod
-    def upsert_mapped_projects(user_id: int, project_id: int):
+    def upsert_mapped_projects(user_id: int, project_id: int, local_session=None):
         """Add project to mapped projects if it doesn't exist, otherwise return"""
-        User.upsert_mapped_projects(user_id, project_id)
+        User.upsert_mapped_projects(user_id, project_id, local_session=local_session)
 
     @staticmethod
     def get_mapped_projects(user_name: str, preferred_locale: str):

--- a/backend/services/validator_service.py
+++ b/backend/services/validator_service.py
@@ -152,7 +152,11 @@ class ValidatorService:
             Session = scoped_session(sessionmaker(bind=db.engine))
             local_session = Session()
             task = task_to_unlock["task"]
-            task = local_session.query(Task).filter_by(id=task.id, project_id=project_id).one()
+            task = (
+                local_session.query(Task)
+                .filter_by(id=task.id, project_id=project_id)
+                .one()
+            )
 
             if task_to_unlock["comment"]:
                 # Parses comment to see if any users have been @'d

--- a/tests/backend/integration/api/tasks/test_actions.py
+++ b/tests/backend/integration/api/tasks/test_actions.py
@@ -1068,10 +1068,20 @@ class TestTasksActionsValidationUnlockAPI(BaseTestCase):
         # Assert
         self.assertEqual(response.status_code, 200)
         TestTasksActionsValidationUnlockAPI.assert_validated_task_response(
-            response.json["tasks"][0], 1, "VALIDATED", self.test_user.username
+            next(
+                (task for task in response.json["tasks"] if task["taskId"] == 1), None
+            ),
+            1,
+            "VALIDATED",
+            self.test_user.username,
         )
         TestTasksActionsValidationUnlockAPI.assert_validated_task_response(
-            response.json["tasks"][1], 2, "INVALIDATED", self.test_user.username
+            next(
+                (task for task in response.json["tasks"] if task["taskId"] == 2), None
+            ),
+            2,
+            "INVALIDATED",
+            self.test_user.username,
         )
 
     def test_validation_unlock_returns_200_if_validated_with_comment(self):


### PR DESCRIPTION
- fix #6244 
- fix #6154 
- Uses Python multiprocessing pool to run validation tasks in parallel using available CPU cores
- Local session for thread implementation for validation-related tasks
- Test case-related validation modified to get task by taskId instead of index as threading may sometimes return task which do not follow order 