### PR TITLE
Added functionality to omit results when specified

### DIFF
--- a/backend/api/projects/resources.py
+++ b/backend/api/projects/resources.py
@@ -477,6 +477,9 @@ class ProjectSearchBase(Resource):
         search_dto.omit_map_results = strtobool(
             request.args.get("omitMapResults", "false")
         )
+        search_dto.omit_results = strtobool(
+            request.args.get("omitResults", "false")
+        )
         search_dto.last_updated_gte = request.args.get("lastUpdatedFrom")
         search_dto.last_updated_lte = request.args.get("lastUpdatedTo")
         search_dto.created_gte = request.args.get("createdFrom")

--- a/backend/api/projects/resources.py
+++ b/backend/api/projects/resources.py
@@ -477,9 +477,7 @@ class ProjectSearchBase(Resource):
         search_dto.omit_map_results = strtobool(
             request.args.get("omitMapResults", "false")
         )
-        search_dto.omit_results = strtobool(
-            request.args.get("omitResults", "false")
-        )
+        search_dto.omit_results = strtobool(request.args.get("omitResults", "false"))
         search_dto.last_updated_gte = request.args.get("lastUpdatedFrom")
         search_dto.last_updated_lte = request.args.get("lastUpdatedTo")
         search_dto.created_gte = request.args.get("createdFrom")

--- a/backend/models/dtos/project_dto.py
+++ b/backend/models/dtos/project_dto.py
@@ -330,6 +330,7 @@ class ProjectSearchDTO(Model):
     last_updated_gte = StringType(required=False)
     created_lte = StringType(required=False)
     created_gte = StringType(required=False)
+    omit_results = BooleanType(required=False)
 
     def __hash__(self):
         """Make object hashable so we can cache user searches"""

--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -180,15 +180,22 @@ class ProjectSearchService:
             raise NotFound(sub_code="PROJECTS_NOT_FOUND")
 
         dto = ProjectSearchResultsDTO()
-        dto.results = [
-            ProjectSearchService.create_result_dto(
-                p,
-                search_dto.preferred_locale,
-                Project.get_project_total_contributions(p[0]),
-            )
-            for p in paginated_results.items
-        ]
-        dto.pagination = Pagination(paginated_results)
+
+        if search_dto.omit_results:
+            # If omit_results is True, return dto with map_results only
+            dto.results = []
+
+        else:
+            dto.results = [
+                ProjectSearchService.create_result_dto(
+                    p,
+                    search_dto.preferred_locale,
+                    Project.get_project_total_contributions(p[0]),
+                )
+                for p in paginated_results.items
+            ]
+            dto.pagination = Pagination(paginated_results)
+
         if search_dto.omit_map_results:
             return dto
 


### PR DESCRIPTION
- Resolve #6216 
- Send empty result and pagination when `omitResults=true` in query params
- If there is no `omitResults` or `omitResults=false` in query params then project results and pagination will be included in response  
- Added `omit_results` Boolean field to ProjectSearchDTO