### PR TITLE
Fix dev swagger docs, update example env defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,19 @@ services:
       - traefik.http.routers.frontend.rule=Host(`127.0.0.1`) || Host(`localhost`)
       - traefik.http.services.frontend.loadbalancer.server.port=3000
 
+  swagger:
+    image: swaggerapi/swagger-ui:v5.11.10
+    container_name: tm-swagger-docs
+    restart: always
+    networks:
+      - tm-web
+    environment:
+      - BASE_URL=/docs
+      - SWAGGER_JSON_URL=http://127.0.0.1:${TM_DEV_PORT:-3000}/api/v2/system/docs/json/
+    labels:
+      - traefik.http.routers.swagger.rule=(Host(`127.0.0.1`) || Host(`localhost`)) && PathPrefix(`/docs/`)
+      - traefik.http.services.swagger.loadbalancer.server.port=8080
+
   postgresql:
     image: postgis/postgis:14-3.3
     container_name: tm-postgresql
@@ -50,7 +63,7 @@ services:
     container_name: tm-traefik
     restart: always
     ports:
-      - "${TM_DEV_PORT:-80}:80"
+      - "${TM_DEV_PORT:-3000}:80"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     command:

--- a/docs/developers/development-setup.md
+++ b/docs/developers/development-setup.md
@@ -25,7 +25,7 @@ In order to use the frontend, you may need to create keys for OSM:
 
 2. Register your Tasking Manager instance to OAuth 2 applications.
 
-   Put your login redirect url as `http://127.0.0.1:880/authorized/`
+   Put your login redirect url as `http://127.0.0.1:3000/authorized/`
 
    > Note: `127.0.0.1` is required for debugging instead of `localhost`
    > due to OSM restrictions.
@@ -44,23 +44,12 @@ In order to use the frontend, you may need to create keys for OSM:
     cp example.env tasking-manager.env
     ```
 
-2. Uncomment or update the following variables
+2. Update the following variables
 
     ```dotenv
-    TM_DEV_PORT=880
-    TM_APP_BASE_URL=http://127.0.0.1:880
-    TM_APP_API_URL=http://127.0.0.1:880/api
-    # 'postgresql' if using docker, else 'localhost' or comment out
-    POSTGRES_ENDPOINT=postgresql
-    TM_REDIRECT_URI=http://127.0.0.1:880/authorized
     TM_CLIENT_ID=from-previous-step
     TM_CLIENT_SECRET=from-previous-step
     ```
-
-    - Note that the port 880 can be swapped to any available port on
-      your system.
-    - If you change this, don't forget to update the OAuth login redirect
-      URL from the step above.
 
 > If you are a frontend developer and do not wish to configure the
 > backend, you can use our staging server API.
@@ -95,11 +84,24 @@ Once the steps above have been complete, simply run:
 ```bash
 docker compose pull
 docker compose build
-docker compose --env-file tasking-manager.env up --detach
+docker compose up --detach
 ```
 
 Tasking Manager should be available from:
-[http://127.0.0.1:880](http://127.0.0.1:880)
+[http://127.0.0.1:3000](http://127.0.0.1:3000)
+
+#### (Optional) Changing the dev port or dotenv file
+
+You change the default port from 3000 to any other port.
+
+However, you must change your OAuth redirect URL to reflect this,
+in addition to any variables including a port, e.g. TM_APP_BASE_URL.
+
+The default dotenv file can also be changed.
+
+```bash
+TM_DEV_PORT=9000 ENV_FILE=.env docker compose up --detach
+```
 
 ## Running Components Standalone
 

--- a/example.env
+++ b/example.env
@@ -5,22 +5,20 @@
 
 # The TM_APP_BASE_URL defines the URL of the frontend and is used by the backend
 # to configure links on emails and some authentication callbacks.
-# On development instances it should be 127.0.0.1:3000 or localhost:3000
+# On development instances it should be 127.0.0.1:3000
+# Note: 127.0.0.1 is a hard requirement for OSM Auth (instead of `localhost`)
 # On production instances, use the public URL of your frontend
 # TM_APP_BASE_URL=https://tasks.hotosm.org
 TM_APP_BASE_URL=http://127.0.0.1:3000
 
 # The TM_APP_API_URL defines the URL of your backend server. It will be used by
 # both the backend and by the frontend
-# On development instances it should be 127.0.0.1:5000 or localhost:5000
+# On development instances it should be 127.0.0.1:3000
 # On production instances, use the public URL of your backend
-TM_APP_API_URL=http://127.0.0.1:5000
+TM_APP_API_URL=http://127.0.0.1:3000/api
 
 # Defines the version of the API and will be used after /api/ on the url
 TM_APP_API_VERSION=v2
-
-# Override default port 80 during development
-# TM_DEV_PORT=880
 
 # Information about the hosting organization
 TM_ORG_NAME="Humanitarian OpenStreetMap Team"
@@ -136,7 +134,7 @@ TM_SCOPE=read_prefs write_api
 POSTGRES_DB=tasking-manager
 POSTGRES_USER=tm
 POSTGRES_PASSWORD=tm
-# POSTGRES_ENDPOINT=localhost
+POSTGRES_ENDPOINT=postgresql
 # POSTGRES_PORT=5432
 
 # The postgres database name used for testing (required).


### PR DESCRIPTION
### Issue

1. The swagger docs could not be loaded during local development, as they rely on https://hotosm.github.io/swagger/, which is a HTTPS website, while the openapi.json under `/api/v2/system/docs/json/` is HTTP. This causes a mixed content error.
2. The `example.env` defaults are for running locally, while the recommended approach for the entire stack is via docker.

### Solution

1. Add a docker compose service for Swagger docs, accessible via `http://URL:PORT/docs/`.
    The prod deploy does not use docker compose, so I believe this will not be an issue.
2. Updated `example.env` and dev documentation to use port `3000` by default, and `postgresql` as the database host (instead of `localhost`).

### Usage

- Remove your old `tasking-manager.env`: `mv tasking-manager.env old.tasking-manager.env`.
- Create a new one with the defaults: `cp example.env tasking-manager.env`.
- Run the docker compose services: `docker compose up -d`
- Access via:
  - Frontend: http://127.0.0.1:3000
  - API: http://127.0.0.1:3000/api/
  - Docs: http://127.0.0.1:3000/docs/

@robsavoye this should help using TM via docker.
Credit to @kshitijrajsharma for the idea of running the swagger-ui container within the compose stack 🙏 