### PR TITLE
Fix/ faster load project list with no map omit

### DIFF
--- a/frontend/src/components/projects/projectNav.js
+++ b/frontend/src/components/projects/projectNav.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { useSelector, useDispatch } from 'react-redux';
@@ -84,7 +84,18 @@ export const ProjectNav = (props) => {
   const encodedParams = stringify(fullProjectsQuery)
     ? ['?', stringify(fullProjectsQuery)].join('')
     : '';
+  const isMapShown = useSelector((state) => state.preferences['mapShown']);
 
+  useEffect(() => {
+    setQuery(
+      {
+        ...fullProjectsQuery,
+        omitMapResults:!isMapShown
+      },
+      'pushIn',
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[isMapShown])
   const linkCombo = 'link ph3 f6 pv2 ba b--tan br1 ph3 fw5';
 
   const moreFiltersAnyActive =

--- a/frontend/src/hooks/UseProjectsQueryAPI.js
+++ b/frontend/src/hooks/UseProjectsQueryAPI.js
@@ -38,6 +38,7 @@ const projectQueryAllSpecification = {
   stale: BooleanParam,
   createdFrom: StringParam,
   basedOnMyInterests: BooleanParam,
+  omitMapResults: BooleanParam,
 };
 
 /* This can be passed into project API or used independently */
@@ -70,6 +71,7 @@ const backendToQueryConversion = {
   stale: 'lastUpdatedTo',
   createdFrom: 'createdFrom',
   basedOnMyInterests: 'basedOnMyInterests',
+  omitMapResults:'omitMapResults',
 };
 
 const dataFetchReducer = (state, action) => {


### PR DESCRIPTION
## What does this PR do ? 

- Enhances Project Lists Page Project List API and overall execution time, when Map is not turned on. 

## Consideration 

- On previous approach , We were using project list api without omitMapResults true and even if the map was not open, It was still fetching all the geojson of projects.
- Current approach : We are using omitMapResults params so that when we don't need geojson we can only fetch the project related data and only fetch geojson when the map is turned on.

## How to test ? 

- Try using the projectlist page it's response time has decreased and projects card loads faster.

## Screenshot
![image](https://github.com/hotosm/tasking-manager/assets/37866666/89f01fab-c40d-4cf0-bb8e-923784f959fd)

