### PR TITLE
hotfix: backend tests failing due to Nominatim server error:403

### DIFF
--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -266,8 +266,15 @@ class Project(db.Model):
         url = "{0}/reverse?format=jsonv2&lat={1}&lon={2}&accept-language=en".format(
             current_app.config["OSM_NOMINATIM_SERVER_URL"], lat, lng
         )
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/58.0.3029.110 Safari/537.3"
+            )
+        }
         try:
-            response = requests.get(url)
+            response = requests.get(url, headers=headers)
             response.raise_for_status()
             country_info = response.json()  # returns a dict
             if country_info["address"].get("country") is not None:


### PR DESCRIPTION
## Context

The unit test `tests/backend/unit/models/postgis/test_project.py`'s `test_set_country_info` method was performing a `GET` from nominatim's reverse geocode api ie: [https://nominatim.openstreetmap.org](https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=56.11996666666666&lon=-3.9156666666666666&accept-language=en) 

This api was failing with `requests.exceptions.HTTPError: 403 Client Error: Forbidden for url. `

## Response (Before)
```
<html>\n<head>\n<title>Access blocked</title>\n</head>\n<body>\n<h1>Access blocked</h1>\n\n<p>You have been blocked because you have violated the\n<a href="https://operations.osmfoundation.org/policies/nominatim/">usage policy</a>\nof OSM\'s Nominatim geocoding service. Please be aware that OSM\'s resources are\nlimited and shared between many users. The usage policy is there to ensure that\nthe service remains usable for everybody.</p>\n\n<p>Please review the terms and make sure that your\nsoftware adheres to the terms. You should in particular verify that you have set a\n<b>custom HTTP referrer or HTTP user agent</b> that identifies your application, and\nthat you are not overusing the service with massive bulk requests.</p>\n\n<p>If you feel that this block is unjustified or remains after you have adopted\nyour usage, you may contact the Nominatim system administrator at\nnominatim@openstreetmap.org to have this block lifted.</p>\n</body>\n</head>\n
```

## Fix
I added a generic user agent headers to requests, which solved the issue.
```
        headers = {
            "User-Agent": (
                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
                "AppleWebKit/537.36 (KHTML, like Gecko) "
                "Chrome/58.0.3029.110 Safari/537.3"
            )
        }
```

## Response (After)
```
{"place_id":268185681,"licence":"Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright","osm_type":"way","osm_id":98588855,"lat":"56.1189493","lon":"-3.9187826284963583","category":"man_made","type":"wastewater_plant","place_rank":30,"importance":9.99999999995449e-06,"addresstype":"man_made","name":"","display_name":"Forthside Way, Sports Village, Stirling, Scotland, FK8 1QZ, United Kingdom","address":{"road":"Forthside Way","suburb":"Sports Village","city":"Stirling","county":"Stirling","ISO3166-2-lvl6":"GB-STG","state":"Scotland","ISO3166-2-lvl4":"GB-SCT","postcode":"FK8 1QZ","country":"United Kingdom","country_code":"gb"},"boundingbox":["56.1180820","56.1199930","-3.9213894","-3.9162879"]}
```