### PR TITLE
Frontend tests now has parallel workers & removed cluttered warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: Run yarn test
           command: |
             cd ${CIRCLE_WORKING_DIRECTORY}/frontend/
-            CI=true yarn test -w 1
+            CI=true yarn test -w 3 --silent
             CI=true GENERATE_SOURCEMAP=false yarn build
 
   backend-code-check-PEP8:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [x] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Description
Frontend build despite using a Large resource class (4 core, 8GB) takes 6-7 Minutes. We can use parallel workers with `-w` flag to get most out of available cpu cores.
Also cluttered warnings has been removed with `--silent`. This reduced CircleCI console logs from `5000` lines to `900`ish lines, making it easier to conceive.
## Screenshots
### Before
<img width="1144" alt="Screenshot 2024-05-07 at 1 04 32 PM" src="https://github.com/hotosm/tasking-manager/assets/72002075/1ab14ba1-9fe1-4f4c-b302-25f342a34c01">

### After
<img width="1144" alt="Screenshot 2024-05-07 at 1 04 17 PM" src="https://github.com/hotosm/tasking-manager/assets/72002075/2b5dcc8c-c0b4-49a2-a0d6-650b37417d8b">

### Before
<img width="1118" alt="Screenshot 2024-05-07 at 1 06 51 PM" src="https://github.com/hotosm/tasking-manager/assets/72002075/80e221a5-4614-432c-b4b7-e8d27a0fc160">

### After
<img width="1118" alt="Screenshot 2024-05-07 at 1 12 17 PM" src="https://github.com/hotosm/tasking-manager/assets/72002075/3faed201-52d1-4c02-b710-ecc842029080">

## Alternative Approaches Considered
For 4 cores, with some testing i found out that `-w 3` worked the best, setting `-w 4` or higher increased the test time also in cases freezed the VM instance.

With more CPU compute this can be improved, Testing on `X-large`  resource class had this time reduced to a minute.

