### PR TITLE
hot-fix: migrations error fix for multiple entry

### DIFF
--- a/migrations/versions/451f6bd05a19_.py
+++ b/migrations/versions/451f6bd05a19_.py
@@ -16,9 +16,9 @@ depends_on = None
 
 
 def upgrade():
+    op.execute("DROP TRIGGER IF EXISTS tsvectorupdate ON project_info;")
     op.execute(
         """
-        DROP TRIGGER IF EXISTS tsvectorupdate ON project_info;
         CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON project_info FOR EACH ROW EXECUTE PROCEDURE
         tsvector_update_trigger(text_searchable, "pg_catalog.english", project_id_str, short_description, description)
         """


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Related Issue

- Migration was getting error with an issue `cannot insert multiple commands into a prepared statement`

## Describe this PR

- Modified the migration file `451f6bd05a19_.py` to break the operations into multiple commands
From 
```python
def upgrade():
    op.execute(
        """
        DROP TRIGGER IF EXISTS tsvectorupdate ON project_info;
        CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON project_info FOR EACH ROW EXECUTE PROCEDURE
        tsvector_update_trigger(text_searchable, "pg_catalog.english", project_id_str, short_description, description)
        """
```
To
```python
def upgrade():
    op.execute("DROP TRIGGER IF EXISTS tsvectorupdate ON project_info;")
    op.execute(
        """
        CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON project_info FOR EACH ROW EXECUTE PROCEDURE
        tsvector_update_trigger(text_searchable, "pg_catalog.english", project_id_str, short_description, description)
        """
    )
```


