### PR TITLE
Add bind mounts to docker compose dev setup + migration command override

### DIFF
--- a/docker-compose.override.sample.yml
+++ b/docker-compose.override.sample.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 name: tasking-manager-main
 
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 name: tasking-manager-main
 
 volumes:
@@ -38,6 +36,10 @@ services:
         condition: service_completed_successfully
     env_file:
       - tasking-manager.env
+    volumes:
+      - ./pyproject.toml:/usr/src/app/pyproject.toml:ro
+      - ./backend:/usr/src/app/backend:ro
+      - ./tests:/usr/src/app/tests:ro
     restart: unless-stopped
     healthcheck:
       test: curl --fail http://localhost:5000 || exit 1
@@ -64,14 +66,18 @@ services:
     image: ghcr.io/hotosm/tasking-manager/backend:main
     build:
       context: .
-    entrypoint: ["python", "manage.py", "db", "upgrade"]
+    entrypoint: ["python", "manage.py", "db"]
+    command: "upgrade"
     depends_on:
       tm-db:
         condition: service_healthy
     env_file:
       - tasking-manager.env
+    volumes:
+      - ./pyproject.toml:/usr/src/app/pyproject.toml:ro
+      - ./backend:/usr/src/app/backend:ro
+      - ./migrations:/usr/src/app/migrations:ro
     deploy:
-      replicas: ${API_REPLICAS:-1}
       resources:
         limits:
           cpus: "1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - tasking-manager.env
     restart: unless-stopped
     healthcheck:
-      test: pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}
+      test: pg_isready -U ${POSTGRES_USER:-tm} -d ${POSTGRES_DB:-tasking-manager}
       start_period: 35s
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

https://github.com/hotosm/tasking-manager/pull/6487

## Describe this PR

- Bind mounts
  - Currently there are no bind-mounts to local files inside dev containers.
  - Meaning we have to build every time to run tests or migrations.
  - Mounting the files makes it easier for: hot reload, running tests, running migrations.
- I also removed the `version` param from docker-compose.yml files, as it's now obsolete.
- Moved the `upgrade` command out of the tm-migration entrypoint. Allow for override via `command: xxx` in docker-compose.

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Tasking Manager Contributing Guide: <https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description. 

## [optional] What gif best describes this PR or how it makes you feel?
