### PR TITLE
Fix react-placeholder peerDependency conflict (React v18)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,7 @@
     "react-hot-toast": "^2.4.1",
     "react-intl": "^6.4.4",
     "react-meta-elements": "^1.0.0",
-    "react-placeholder": "^4.1.0",
+    "react-placeholder": "git+https://github.com/hotosm/react-placeholder.git",
     "react-redux": "^8.1.1",
     "react-router-dom": "^6.13.0",
     "react-select": "^5.7.3",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -12258,10 +12258,9 @@ react-onclickoutside@^6.13.0:
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz#e165ea4e5157f3da94f4376a3ab3e22a565f4ffc"
   integrity sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==
 
-react-placeholder@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/react-placeholder/-/react-placeholder-4.1.0.tgz#943128820b3b0a6f94371655aadec18d306e05e3"
-  integrity sha512-z1HGD86NWJTYTQumHsmGH9jkozv4QHa9dju/vHVUd4f1svu23pf5v7QoBLBfs3kA1S9GLJaCeRMHLbO2SCdz5A==
+"react-placeholder@git+https://github.com/hotosm/react-placeholder.git":
+  version "4.2.0"
+  resolved "git+https://github.com/hotosm/react-placeholder.git#ef6301c4a017b91513c2c4b091d291d82d8b5916"
 
 react-popper@^2.3.0:
   version "2.3.0"

--- a/scripts/docker/Dockerfile.frontend
+++ b/scripts/docker/Dockerfile.frontend
@@ -5,7 +5,7 @@ COPY frontend .
 
 ## SETUP
 RUN git config --global url.https://github.com/.insteadOf git@github.com: \
-    && npm install
+    && npm install --ignore-scripts
 
 # SERVE
 COPY tasking-manager.env ..

--- a/scripts/docker/Dockerfile.frontend
+++ b/scripts/docker/Dockerfile.frontend
@@ -4,7 +4,8 @@ WORKDIR /usr/src/app/frontend
 COPY frontend .
 
 ## SETUP
-RUN npm install
+RUN git config --global url.https://github.com/.insteadOf git@github.com: \
+    && npm install
 
 # SERVE
 COPY tasking-manager.env ..


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- The react-placeholder frontend dependency is out of date and unmaintained.
- It has a peerDependency lock for React `16 || 17`.
- Upgrading to React 18 has resulted in a conflict when installing frontend dependencies:

```
36.30 npm ERR! ERESOLVE unable to resolve dependency tree
36.30 npm ERR!
36.30 npm ERR! While resolving: TaskingManager-frontend@0.1.0
36.30 npm ERR! Found: react@18.3.1
36.30 npm ERR! node_modules/react
36.30 npm ERR!   react@"^18.2.0" from the root project
36.30 npm ERR!
36.30 npm ERR! Could not resolve dependency:
36.30 npm ERR! peer react@"^16.8.0 || ^17" from react-placeholder@4.1.0
36.30 npm ERR! node_modules/react-placeholder
36.30 npm ERR!   react-placeholder@"^4.1.0" from the root project
```

## Describe this PR

- The code is actually compatible with React 18, but the repo maintainers have not updated the specified `peerDependencies`.
- This is a short term solution to use a forked repo with peerDependency as react v18.
- In the long term we should probably remove and replace the dependency entirely.

## Review Guide

`docker compose build tm-frontend`

## Checklist before requesting a review

- 📖 Read the Tasking Manager Contributing Guide: <https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.

## Addtional considerations

Many outdated frontend packages:

```
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated rimraf@2.6.3: Rimraf versions prior to v4 are no longer supported
npm warn deprecated @humanwhocodes/config-array@0.11.14: Use @eslint/config-array instead
npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm warn deprecated @humanwhocodes/object-schema@2.0.3: Use @eslint/object-schema instead
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated workbox-sw@6.6.1: this package has been deprecated
npm warn deprecated rollup-plugin-terser@7.0.2: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
npm warn deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
npm warn deprecated workbox-navigation-preload@6.6.1: this package has been deprecated
npm warn deprecated workbox-google-analytics@6.6.1: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
npm warn deprecated workbox-range-requests@6.6.1: this package has been deprecated
npm warn deprecated workbox-streams@6.6.1: this package has been deprecated
npm warn deprecated workbox-broadcast-update@6.6.1: this package has been deprecated
npm warn deprecated workbox-background-sync@6.6.1: this package has been deprecated
npm warn deprecated workbox-window@6.6.1: this package has been deprecated
npm warn deprecated workbox-build@6.6.1: this package has been deprecated
npm warn deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
npm warn deprecated q@1.5.1: You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
npm warn deprecated
npm warn deprecated (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
npm warn deprecated memfs@3.6.0: this will be v4
npm warn deprecated w3c-hr-time@1.0.2: Use your platform's native performance.now() and performance.timeOrigin.
npm warn deprecated domexception@2.0.1: Use your platform's native DOMException instead
npm warn deprecated abab@2.0.6: Use your platform's native atob() and btoa() methods instead
npm warn deprecated @babel/plugin-proposal-private-methods@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
npm warn deprecated @babel/plugin-proposal-numeric-separator@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
npm warn deprecated @babel/plugin-proposal-optional-chaining@7.21.0: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
npm warn deprecated @babel/plugin-proposal-class-properties@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
npm warn deprecated @babel/plugin-proposal-nullish-coalescing-operator@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
npm warn deprecated svgo@1.3.2: This SVGO version is no longer supported. Upgrade to v2.x.x.
npm warn deprecated workbox-webpack-plugin@6.6.1: this package has been deprecated
npm warn deprecated @formatjs/intl-utils@2.3.0: the package is rather renamed to @formatjs/ecma-abstract with some changes in functionality (primarily selectUnit is removed and we don't plan to make any further changes to this package
npm warn deprecated babel-plugin-react-intl@5.1.18: this package has been renamed to babel-plugin-formatjs
npm warn deprecated intl-messageformat-parser@3.6.4: We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser
npm warn deprecated @ideditor/location-conflation@1.0.2: This module is now under the @rapideditor scope: install @rapideditor/location-conflation instead
npm warn deprecated @formatjs/intl-unified-numberformat@3.3.7: We have renamed the package to @formatjs/intl-numberformat
npm warn deprecated @ideditor/country-coder@5.0.4: This module is now under the @rapideditor scope: install @rapideditor/country-coder instead
npm warn deprecated @babel/plugin-proposal-private-property-in-object@7.21.11: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.
npm warn deprecated workbox-core@6.6.1: this package has been deprecated
npm warn deprecated workbox-core@6.6.1: this package has been deprecated
npm warn deprecated workbox-routing@6.6.1: this package has been deprecated
npm warn deprecated workbox-routing@6.6.1: this package has been deprecated
npm warn deprecated workbox-core@6.6.1: this package has been deprecated
npm warn deprecated workbox-core@6.6.1: this package has been deprecated
npm warn deprecated workbox-core@6.6.1: this package has been deprecated
npm warn deprecated workbox-core@6.6.1: this package has been deprecated
npm warn deprecated workbox-strategies@6.6.1: this package has been deprecated
npm warn deprecated workbox-core@6.6.1: this package has been deprecated
npm warn deprecated workbox-recipes@6.6.1: this package has been deprecated
npm warn deprecated workbox-routing@6.6.1: this package has been deprecated
npm warn deprecated workbox-expiration@6.6.1: this package has been deprecated
npm warn deprecated workbox-core@6.6.1: this package has been deprecated
npm warn deprecated workbox-strategies@6.6.1: this package has been deprecated
npm warn deprecated workbox-cacheable-response@6.6.1: workbox-background-sync@6.6.1
npm warn deprecated workbox-precaching@6.6.1: this package has been deprecated
```

## [optional] What gif best describes this PR or how it makes you feel?

![giphy](https://github.com/hotosm/tasking-manager/assets/78538841/5dda6816-7601-47d4-b285-4befe1af2627)
