### PR TITLE
Use AWS SSM instead of static AMI for Ubuntu base image in cloudformation

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -2,9 +2,9 @@ const cf = require('@mapbox/cloudfriend');
 
 const Parameters = {
   TaskingManagerBackendAMI: {
-    Type: "AWS::EC2::Image::Id",
+    Type: "String",
     Description: 'AMI ID of Backend VM, currently Ubuntu 20.04 LTS - Was ami-00fa576fb10a52a1c',
-    Default: "ami-0aa2b7722dc1b5612",
+    Default: "/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id",
   },
   TaskingManagerBackendInstanceType: {
     Type: 'String',
@@ -370,7 +370,7 @@ const Resources = {
         IamInstanceProfile: {
           Name: cf.ref('TaskingManagerEC2InstanceProfile'),
         },
-        ImageId: cf.ref('TaskingManagerBackendAMI'),
+        ImageId: cf.join(':', ["resolve:ssm", cf.ref('TaskingManagerBackendAMI')]),
         InstanceType: cf.ref('TaskingManagerBackendInstanceType'),
         KeyName: 'mbtiles',
         Monitoring: {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🤖 Build or CI
- [x] ❓ Other (please specify)

## Related Issue

Fixes #6506

## Describe this PR

Use SSM ("Systems Manager") to find the newest AMI for Ubuntu 20.04.

The current method hardcodes a single AMI (in this case [ami-0aa2b7722dc1b5612](https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#ImageDetails:imageId=ami-0aa2b7722dc1b5612)). The problem with this method is that:
1. It is region specific (example: [ami-081a3b9eded47f0f3](https://us-west-1.console.aws.amazon.com/ec2/home?region=us-west-1#ImageDetails:imageId=ami-081a3b9eded47f0f3) is the equivalent AMI for us-west-1).
2. It doesn't automatically update/start with the (almost) latest updates (current latest version for us-west-1 is [ami-023e8dfe2208927a7](https://us-west-1.console.aws.amazon.com/ec2/home?region=us-west-1#Images:visibility=public-images;imageId=ami-023e8dfe2208927a7), which was created on 2024-07-23). This can be problematic when there is a significant vulnerability that must be patched ASAP (think of the recent SSH vulnerability; it doesn't affect [Ubuntu 20.04](https://ubuntu.com/blog/ubuntu-regresshion-security-fix), but having a period of time where a remote attacker can get into a system isn't a good idea).

## Review Guide

Apply the cloudformation stack. Observe that the base AMI is significantly newer and that the deployment finishes.

## Additional notes:
Updating the base AMI from Ubuntu 20.04 to 24.04 should be done soonish (EOL is [2025-04](https://ubuntu.com/about/release-cycle)). The packages in `LaunchTemplateData.UserData` will need to be updated.
The scope for that is outside of this PR.