### PR TITLE
Fix ssm permissions to pull the AMI

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -544,6 +544,16 @@ const Resources = {
           }]
         }
       }, {
+        PolicyName: "SSMPolicy",
+        PolicyDocument: {
+          Version: "2012-10-17",
+          Statement:[{
+            Action: ['ssm:GetParameters'],
+            Effect: 'Allow',
+            Resource: ['arn:aws:ssm:*']
+          }]
+        }
+      }, {
         PolicyName: "CloudFormationPermissions",
         PolicyDocument: {
           Version: "2012-10-17",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Example: Fixes #6512 regression

## Describe this PR

I had tested the PR using a role with admin level permissions, so I didn't catch the lack of permissions needed to GetParameters:

```
19:41:35Z *********: UPDATE_FAILED TaskingManagerLaunchTemplate: Resource handler returned message: "User: arn:aws:sts::************:assumed-role/*********************/backend-deploy is not authorized to perform: ssm:GetParameters on resource: arn:aws:ssm:*********:************:parameter/ami-01e5ff16fd6e8c542 because no identity-based policy allows the ssm:GetParameters action ...
```

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Tasking Manager Contributing Guide: <https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.

## [optional] What gif best describes this PR or how it makes you feel?
