### PR TITLE
Revert "Fix ssm permissions to pull the AMI"

### DIFF
--- a/scripts/aws/cloudformation/tasking-manager.template.js
+++ b/scripts/aws/cloudformation/tasking-manager.template.js
@@ -544,16 +544,6 @@ const Resources = {
           }]
         }
       }, {
-        PolicyName: "SSMPolicy",
-        PolicyDocument: {
-          Version: "2012-10-17",
-          Statement:[{
-            Action: ['ssm:GetParameters'],
-            Effect: 'Allow',
-            Resource: ['arn:aws:ssm:*']
-          }]
-        }
-      }, {
         PolicyName: "CloudFormationPermissions",
         PolicyDocument: {
           Version: "2012-10-17",


### PR DESCRIPTION
Reverts hotosm/tasking-manager#6514


I misread the error- It was actually a CircleCI OIDC permissions issue rather than one with the LauchTemplate itself. @tsmock thats why you didn't experience it!