### PR TITLE
Remove hard-coded ami option in favor of ssm in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,7 @@ workflows:
           name: Deploy backend production
           gitsha: $CIRCLE_SHA1
           stack_name: "tm4-production"
-          host_ami: "ami-01e5ff16fd6e8c542"
+          host_ami: "/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id"
           backend_instance_type: c6a.large
           pg_version: "13.10"
           pg_param_group: "default.postgres13"
@@ -357,7 +357,7 @@ workflows:
           name: Deploy backend production
           gitsha: $CIRCLE_SHA1
           stack_name: "tm4-production"
-          host_ami: "ami-01e5ff16fd6e8c542"
+          host_ami: "/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id"
           backend_instance_type: c6a.large
           pg_version: "13.10"
           pg_param_group: "default.postgres13"
@@ -384,7 +384,7 @@ workflows:
           name: Deploy TeachOSM Backend
           gitsha: $CIRCLECI_SHA1
           stack_name: "teachosm"
-          host_ami: "ami-01e5ff16fd6e8c542"
+          host_ami: "/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id"
           requires:
             - backend-functional-tests
           context: tasking-manager-teachosm
@@ -422,7 +422,7 @@ workflows:
           name: Deploy staging backend
           gitsha: $CIRCLE_SHA1
           stack_name: "staging"
-          host_ami: "ami-01e5ff16fd6e8c542"
+          host_ami: "/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id"
           pg_version: "14.8"
           pg_param_group: "default.postgres14"
           db_instance_type: "db.t4g.small"
@@ -453,7 +453,7 @@ workflows:
               value: << pipeline.git.branch >>
         - or:
           - equal: [ develop, << pipeline.git.branch >> ]
-          - equal: [ fix/febdeployment, << pipeline.git.branch >> ] # change this to the branch you wish to test
+          - equal: [ fix/ci-deployment-ami-perms, << pipeline.git.branch >> ] # change this to the branch you wish to test
     jobs:
       - database-backup:
           name: Backup development database
@@ -473,7 +473,7 @@ workflows:
           name: Deploy development backend
           gitsha: $CIRCLE_SHA1
           stack_name: "dev"
-          host_ami: "ami-01e5ff16fd6e8c542"
+          host_ami: "/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id"
           pg_version: "14.8"
           pg_param_group: "default.postgres14"
           db_instance_type: "db.t4g.small"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,7 +474,7 @@ workflows:
           gitsha: $CIRCLE_SHA1
           stack_name: "dev"
           host_ami: "/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id"
-          pg_version: "14.8"
+          pg_version: "14.10"
           pg_param_group: "default.postgres14"
           db_instance_type: "db.t4g.small"
           backend_instance_type: "t3.medium"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

Fixing an error in the CircleCI config where we were hard-coding the AMI. Now that it's [set automatically by SSM](https://github.com/hotosm/tasking-manager/pull/6512), there is no need for this code. 

## Review Guide

I've set this branch to deploy to dev, so if the deployment here passes then we are good to go. 

