### PR TITLE
Redesign Leaderboard Stats Banner

### DIFF
--- a/frontend/src/assets/styles/_extra.scss
+++ b/frontend/src/assets/styles/_extra.scss
@@ -611,8 +611,24 @@ a[href="https://www.mapbox.com/map-feedback/"]
   color: rgba($blue-dark, 0.9);
 }
 
+.gap-0\.625 {
+  gap: 0.75rem;
+}
+
+.gap-0\.75 {
+  gap: 0.75rem;
+}
+
 .gap-1 {
   gap: 1rem;
+}
+
+.gap-1\.25 {
+  gap: 1.25rem;
+}
+
+.gap-1\.5 {
+  gap: 1.5rem;
 }
 
 // Imported from HOTOSM site to use for long texts

--- a/frontend/src/components/button.js
+++ b/frontend/src/components/button.js
@@ -10,7 +10,15 @@ export const AnimatedLoadingIcon = () => (
   </IconSpace>
 );
 
-export function Button({ onClick, children, icon, className, disabled, loading = false }: Object) {
+export function Button({
+  onClick,
+  children,
+  icon,
+  className,
+  disabled,
+  loading = false,
+  ...rest
+}: Object) {
   return (
     <button
       onClick={onClick}
@@ -19,6 +27,7 @@ export function Button({ onClick, children, icon, className, disabled, loading =
       className={`${className || ''} br1 f5 bn ${disabled || loading ? 'o-50' : 'pointer'}`}
       style={{ padding: '.75rem 1.5rem' }}
       disabled={disabled || loading}
+      {...rest}
     >
       {loading ? <AnimatedLoadingIcon /> : icon && <IconSpace>{icon}</IconSpace>}
       {children}

--- a/frontend/src/components/button.js
+++ b/frontend/src/components/button.js
@@ -17,6 +17,7 @@ export function Button({
   className,
   disabled,
   loading = false,
+  style,
   ...rest
 }: Object) {
   return (
@@ -25,7 +26,7 @@ export function Button({
       aria-pressed="false"
       focusindex="0"
       className={`${className || ''} br1 f5 bn ${disabled || loading ? 'o-50' : 'pointer'}`}
-      style={{ padding: '.75rem 1.5rem' }}
+      style={{ padding: '.75rem 1.5rem', ...style }}
       disabled={disabled || loading}
       {...rest}
     >

--- a/frontend/src/components/button.js
+++ b/frontend/src/components/button.js
@@ -17,8 +17,7 @@ export function Button({
   className,
   disabled,
   loading = false,
-  style,
-  ...rest
+  ...otherProps
 }: Object) {
   return (
     <button
@@ -26,9 +25,9 @@ export function Button({
       aria-pressed="false"
       focusindex="0"
       className={`${className || ''} br1 f5 bn ${disabled || loading ? 'o-50' : 'pointer'}`}
-      style={{ padding: '.75rem 1.5rem', ...style }}
+      style={{ padding: '.75rem 1.5rem' }}
       disabled={disabled || loading}
-      {...rest}
+      {...otherProps}
     >
       {loading ? <AnimatedLoadingIcon /> : icon && <IconSpace>{icon}</IconSpace>}
       {children}

--- a/frontend/src/components/partners/customDropdown.js
+++ b/frontend/src/components/partners/customDropdown.js
@@ -11,7 +11,7 @@ export const CustomDropdown = ({ title, data, buttonClassname }) => {
     <div className="relative">
       {/* dropdown select */}
       <Button
-        className={`white br1 f5 bn flex items-center ${buttonClassname}`}
+        className={`white br1 f5 fw5 bn flex items-center ${buttonClassname}`}
         onClick={() => setIsActive(!isActive)}
         onBlur={() => setIsActive(false)}
         style={{ padding: '0.75rem 0' }}

--- a/frontend/src/components/partners/customDropdown.js
+++ b/frontend/src/components/partners/customDropdown.js
@@ -14,31 +14,22 @@ export const CustomDropdown = ({ title, data, buttonClassname }) => {
         className={`white br1 f5 fw5 bn flex items-center ${buttonClassname}`}
         onClick={() => setIsActive(!isActive)}
         onBlur={() => setIsActive(false)}
-        style={{ padding: '0.75rem 0' }}
       >
         {title}
         {isActive ? (
-          <ChevronUpIcon style={{ width: '12px' }} className="ml2" />
+          <ChevronUpIcon className="ml2 partners-dropdown-icon" />
         ) : (
-          <ChevronDownIcon style={{ width: '12px' }} className="ml2" />
+          <ChevronDownIcon className="ml2 partners-dropdown-icon" />
         )}
       </Button>
 
       {/* dropdown list */}
       {isActive && (
-        <ul
-          className="absolute list bg-grey-dark white pv3 mt2"
-          style={{
-            width: '17rem',
-            right: '0',
-            padding: '0.5rem 2rem',
-          }}
-        >
+        <ul className="absolute list bg-grey-dark white pv3 mt2 partners-custom-dropdown">
           {data.map((option) => (
             <li
               key={option.label}
-              className="pointer"
-              style={{ padding: '0.75rem 0' }}
+              className="pointer partners-banner-button"
               onMouseDown={() => {
                 option?.onClick(option);
               }}

--- a/frontend/src/components/partners/customDropdown.js
+++ b/frontend/src/components/partners/customDropdown.js
@@ -27,8 +27,12 @@ export const CustomDropdown = ({ title, data, buttonClassname }) => {
       {/* dropdown list */}
       {isActive && (
         <ul
-          className="absolute list bg-grey-dark white pv3"
-          style={{ width: '17rem', right: '1rem', paddingInlineStart: '2rem' }}
+          className="absolute list bg-grey-dark white pv3 mt2"
+          style={{
+            width: '17rem',
+            right: '0',
+            padding: '0.5rem 2rem',
+          }}
         >
           {data.map((option) => (
             <li

--- a/frontend/src/components/partners/customDropdown.js
+++ b/frontend/src/components/partners/customDropdown.js
@@ -29,7 +29,7 @@ export const CustomDropdown = ({ title, data, buttonClassname }) => {
           {data.map((option) => (
             <li
               key={option.label}
-              className="pointer partners-banner-button"
+              className="pointer partners-dropdown-list-item"
               onMouseDown={() => {
                 option?.onClick(option);
               }}

--- a/frontend/src/components/partners/customDropdown.js
+++ b/frontend/src/components/partners/customDropdown.js
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+import { Button } from '../button';
+import { ChevronDownIcon } from '../svgIcons/chevron-down';
+import { ChevronUpIcon } from '../svgIcons/chevron-up';
+
+export const CustomDropdown = ({ title, data }) => {
+  const [isActive, setIsActive] = useState(false);
+
+  return (
+    <div className="relative">
+      {/* dropdown select */}
+      <Button
+        className="bg-grey-dark white mr3 br1 f5 bn flex items-center"
+        onClick={() => setIsActive(!isActive)}
+        onBlur={() => setIsActive(false)}
+      >
+        {isActive ? <ChevronUpIcon className="mr2" /> : <ChevronDownIcon className="mr2" />}
+        {title}
+      </Button>
+
+      {/* dropdown list */}
+      {isActive && (
+        <ul
+          className="absolute list bg-grey-dark white pv3"
+          style={{ width: '17rem', right: '1rem', paddingInlineStart: '2rem' }}
+        >
+          {data.map((option) => (
+            <li
+              key={option.label}
+              className="pointer"
+              style={{ padding: '0.75rem 0' }}
+              onMouseDown={() => {
+                option?.onClick(option);
+              }}
+            >
+              {option.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/partners/customDropdown.js
+++ b/frontend/src/components/partners/customDropdown.js
@@ -33,6 +33,7 @@ export const CustomDropdown = ({ title, data, buttonClassname }) => {
               onMouseDown={() => {
                 option?.onClick(option);
               }}
+              onKeyDown={() => {}}
             >
               {option.label}
             </li>

--- a/frontend/src/components/partners/customDropdown.js
+++ b/frontend/src/components/partners/customDropdown.js
@@ -4,19 +4,24 @@ import { Button } from '../button';
 import { ChevronDownIcon } from '../svgIcons/chevron-down';
 import { ChevronUpIcon } from '../svgIcons/chevron-up';
 
-export const CustomDropdown = ({ title, data }) => {
+export const CustomDropdown = ({ title, data, buttonClassname }) => {
   const [isActive, setIsActive] = useState(false);
 
   return (
     <div className="relative">
       {/* dropdown select */}
       <Button
-        className="bg-grey-dark white mr3 br1 f5 bn flex items-center"
+        className={`white br1 f5 bn flex items-center ${buttonClassname}`}
         onClick={() => setIsActive(!isActive)}
         onBlur={() => setIsActive(false)}
+        style={{ padding: '0.75rem 0' }}
       >
-        {isActive ? <ChevronUpIcon className="mr2" /> : <ChevronDownIcon className="mr2" />}
         {title}
+        {isActive ? (
+          <ChevronUpIcon style={{ width: '12px' }} className="ml2" />
+        ) : (
+          <ChevronDownIcon style={{ width: '12px' }} className="ml2" />
+        )}
       </Button>
 
       {/* dropdown list */}

--- a/frontend/src/components/partners/leaderboard.js
+++ b/frontend/src/components/partners/leaderboard.js
@@ -7,7 +7,7 @@ import { CurrentProjects } from './currentProjects';
 
 export const Leaderboard = ({ partner, partnerStats }) => {
   return (
-    <div className="pa4 bg-tan flex flex-column" style={{ gap: '1.25rem' }}>
+    <div className="pa4 bg-tan flex flex-column gap-1.25">
       <div className="flex justify-between items-center">
         <h3 className="f2 blue-dark fw7 ma0 barlow-condensed v-mid dib">
           {partner.primary_hashtag

--- a/frontend/src/components/partners/leaderboard.js
+++ b/frontend/src/components/partners/leaderboard.js
@@ -1,0 +1,33 @@
+import { FormattedMessage } from 'react-intl';
+import messages from '../../views/messages';
+
+import { StatsSection } from './partnersStats';
+import { Activity } from './partnersActivity';
+import { CurrentProjects } from './currentProjects';
+
+export const Leaderboard = ({ partner, partnerStats }) => {
+  return (
+    <div className="pa4 bg-tan flex flex-column" style={{ gap: '1.25rem' }}>
+      <div className="flex justify-between items-center">
+        <h3 className="f2 blue-dark fw7 ma0 barlow-condensed v-mid dib">
+          {partner.primary_hashtag
+            ?.split(',')
+            ?.map((str) => `#${str}`)
+            ?.join(', ')}
+        </h3>
+      </div>
+
+      <StatsSection partner={partnerStats} />
+
+      <CurrentProjects currentProjects={partner.current_projects} />
+
+      {/* activity section */}
+      <div className="w-100 fl cf">
+        <h3 className="f2 fw6 ttu barlow-condensed blue-dark mt0 pt2 mb3">
+          <FormattedMessage {...messages.activity} />
+        </h3>
+        <Activity partner={partner} />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/partners/partners.js
+++ b/frontend/src/components/partners/partners.js
@@ -95,7 +95,7 @@ export function PartnersCard({ details }) {
             <FormattedMessage {...messages.edit} />
           </CustomButton>
         </Link>
-        <Link to={`/partners/${details.permalink}/stats/`}>
+        <Link to={`/partners/${details.permalink}/stats/leaderboard`}>
           <CustomButton
             style={{ backgroundColor: '#e2e2e2' }}
             className="blue-dark ba b--grey-light pa2 br1 f5 pointer"

--- a/frontend/src/components/partners/partnersResources.js
+++ b/frontend/src/components/partners/partnersResources.js
@@ -1,4 +1,7 @@
-import { CustomButton } from '../button';
+import { FormattedMessage } from 'react-intl';
+
+import { CustomDropdown } from './customDropdown';
+import messages from '../../views/messages';
 
 export const Resources = ({ partner }) => {
   const renderWebsiteLinks = () => {
@@ -11,20 +14,17 @@ export const Resources = ({ partner }) => {
       name: partner[nameKey],
       url: partner[urlKeys[index]],
     }));
+
+    const resourcesData = websiteLinks.map((link) => ({
+      ...link,
+      label: link.name,
+      onClick: (item) => {
+        window.open(item.url, '_blank');
+      },
+    }));
+
     return (
-      <div className="">
-        {websiteLinks.map((link, index) => (
-          <a
-            key={index}
-            href={link.url}
-            target="_blank"
-            rel="noreferrer"
-            className="link ttu di-l dib center m1"
-          >
-            <CustomButton className="ba b--red red pa2 mv2 mh2 w4">{link.name}</CustomButton>
-          </a>
-        ))}
-      </div>
+      <CustomDropdown title={<FormattedMessage {...messages.resources} />} data={resourcesData} />
     );
   };
 

--- a/frontend/src/components/partners/partnersResources.js
+++ b/frontend/src/components/partners/partnersResources.js
@@ -24,7 +24,11 @@ export const Resources = ({ partner }) => {
     }));
 
     return (
-      <CustomDropdown title={<FormattedMessage {...messages.resources} />} data={resourcesData} />
+      <CustomDropdown
+        buttonClassname="bg-transparent"
+        title={<FormattedMessage {...messages.resources} />}
+        data={resourcesData}
+      />
     );
   };
 

--- a/frontend/src/components/partners/partnersResources.js
+++ b/frontend/src/components/partners/partnersResources.js
@@ -25,7 +25,7 @@ export const Resources = ({ partner }) => {
 
     return (
       <CustomDropdown
-        buttonClassname="bg-transparent"
+        buttonClassname="bg-transparent partners-banner-button"
         title={<FormattedMessage {...messages.resources} />}
         data={resourcesData}
       />

--- a/frontend/src/components/partners/partnersResources.js
+++ b/frontend/src/components/partners/partnersResources.js
@@ -23,6 +23,8 @@ export const Resources = ({ partner }) => {
       },
     }));
 
+    if (!resourcesData.length) return <></>;
+
     return (
       <CustomDropdown
         buttonClassname="bg-transparent partners-banner-button"

--- a/frontend/src/components/partners/styles.scss
+++ b/frontend/src/components/partners/styles.scss
@@ -48,5 +48,5 @@
 .partners-tab-item {
   border-radius: 3px 3px 0px 0px;
   padding: 0.625rem 1.375rem;
-  fontweight: 500;
+  font-weight: 500;
 }

--- a/frontend/src/components/partners/styles.scss
+++ b/frontend/src/components/partners/styles.scss
@@ -26,3 +26,27 @@
   height: 20px;
   width: 20px;
 }
+
+.partners-banner-button {
+  padding: 0.75rem 0 !important;
+}
+
+.partners-banner-logo {
+  margin: 2.25rem 0 1.75rem 0;
+}
+
+.partners-custom-dropdown {
+  width: 17rem;
+  right: 0;
+  padding: 0.5rem 2rem;
+}
+
+.partners-dropdown-icon {
+  width: 12px;
+}
+
+.partners-tab-item {
+  border-radius: 3px 3px 0px 0px;
+  padding: 0.625rem 1.375rem;
+  fontweight: 500;
+}

--- a/frontend/src/components/partners/styles.scss
+++ b/frontend/src/components/partners/styles.scss
@@ -39,6 +39,7 @@
   width: 17rem;
   right: 0;
   padding: 0.5rem 2rem;
+  z-index: 111;
 }
 
 .partners-dropdown-icon {

--- a/frontend/src/components/partners/styles.scss
+++ b/frontend/src/components/partners/styles.scss
@@ -23,6 +23,6 @@
 }
 
 .partners-social-icon {
-  height: 24px;
-  width: 24px;
+  height: 20px;
+  width: 20px;
 }

--- a/frontend/src/components/partners/styles.scss
+++ b/frontend/src/components/partners/styles.scss
@@ -38,7 +38,7 @@
 .partners-custom-dropdown {
   width: 17rem;
   right: 0;
-  padding: 0.5rem 2rem;
+  padding: 0.5rem 0;
   z-index: 111;
 }
 
@@ -50,4 +50,11 @@
   border-radius: 3px 3px 0px 0px;
   padding: 0.625rem 1.375rem;
   font-weight: 500;
+}
+
+.partners-dropdown-list-item {
+  padding: 0.75rem 2rem;
+  &:hover {
+    background-color: #4e5157;
+  }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1173,7 +1173,7 @@
   "management.partner.edit.error": "Partner name already exists",
   "management.partner.learnToMap": "Learn to Map",
   "management.partner.currentProjects": "Current Projects",
-  "management.partner.newToMapping": "¿New to Mapping?",
+  "management.partner.newToMapping": "New to Mapping?",
   "management.partner.activity": "Activity",
   "management.partner.resources": "Resources",
   "management.entity.creation.success": "{entity, select, organization {Organization} partner {Partner} license {License} project {Project} category {Category} campaign {Campaign} team {Team} other {}} created successfully",

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -113,7 +113,7 @@ export const router = createBrowserRouter(
         }}
       />
       <Route
-        path="partners/:id/stats/"
+        path="partners/:id/stats/:tabname?"
         lazy={async () => {
           const { PartnersStats } = await import(
             './views/partnersStats' /* webpackChunkName: "partnersStats" */

--- a/frontend/src/views/partnersStats.js
+++ b/frontend/src/views/partnersStats.js
@@ -63,12 +63,16 @@ export const PartnersStats = () => {
             ) : (
               <h3 className="f2 fw6 ttu barlow-condensed white">{partner.name}</h3>
             )}
-            {/* new to mapping button */}
-            <Link to={`/learn/map/`}>
-              <Button className="bg-grey-dark white mr3 br1 f5 bn">
-                <FormattedMessage {...messages.newToMapping} />
-              </Button>
-            </Link>
+            <div className="flex">
+              {/* new to mapping button */}
+              <Link to={`/learn/map/`}>
+                <Button className="bg-grey-dark white mr3 br1 f5 bn">
+                  <FormattedMessage {...messages.newToMapping} />
+                </Button>
+              </Link>
+              {/* resources button */}
+              <Resources partner={partner} />
+            </div>
           </div>
           {/* social logos */}
           <div className="pa4 bg-tan flex flex-column" style={{ gap: '1.25rem' }}>
@@ -116,16 +120,6 @@ export const PartnersStats = () => {
             <StatsSection partner={partnerStats} />
 
             <CurrentProjects currentProjects={partner.current_projects} />
-
-            {/* resources section */}
-            {Object.keys(partner).some((key) => key.includes('name_')) && (
-              <div className="w-100 fl cf">
-                <h3 className="f2 fw6 ttu barlow-condensed blue-dark mt0 pt2 mb3">
-                  <FormattedMessage {...messages.resources} />
-                </h3>
-                <Resources partner={partner} />
-              </div>
-            )}
 
             {/* activity section */}
             <div className="w-100 fl cf">

--- a/frontend/src/views/partnersStats.js
+++ b/frontend/src/views/partnersStats.js
@@ -12,6 +12,20 @@ import { OHSOME_STATS_BASE_URL } from '../config';
 import { Button } from '../components/button';
 import { TwitterIcon, FacebookIcon, InstagramIcon } from '../components/svgIcons';
 
+function getSocialIcons(link) {
+  const socialName = link.split('_')?.[1];
+  switch (socialName) {
+    case 'x':
+      return <TwitterIcon noBg className="partners-social-icon" />;
+    case 'meta':
+      return <FacebookIcon className="partners-social-icon" />;
+    case 'instagram':
+      return <InstagramIcon className="partners-social-icon" />;
+    default:
+      return <></>;
+  }
+}
+
 const tabData = [{ id: 'leaderboard', title: 'Leaderboard' }];
 
 export const PartnersStats = () => {
@@ -61,6 +75,10 @@ export const PartnersStats = () => {
         return <></>;
     }
   }
+
+  const socialLinks = Object.keys(partner)
+    .filter((key) => key.startsWith('link'))
+    .filter((link) => partner[link]);
 
   return (
     <ReactPlaceholder
@@ -116,38 +134,20 @@ export const PartnersStats = () => {
                 <Resources partner={partner} />
 
                 {/* social logos */}
-                <div className="flex items-center" style={{ gap: '0.625rem' }}>
-                  {!!partner.link_x && (
-                    <a
-                      href={partner.link_x}
-                      className="link barlow-condensed white f4 ttu di-l dib"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      <TwitterIcon noBg className="partners-social-icon" />
-                    </a>
-                  )}
-                  {!!partner.link_meta && (
-                    <a
-                      href={partner.link_meta}
-                      className="link barlow-condensed white f4 ttu di-l dib"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      <FacebookIcon className="partners-social-icon" />
-                    </a>
-                  )}
-                  {!!partner.link_instagram && (
-                    <a
-                      href={partner.link_instagram}
-                      className="link barlow-condensed white f4 ttu di-l dib"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      <InstagramIcon className="partners-social-icon" />
-                    </a>
-                  )}
-                </div>
+                {!!socialLinks.length && (
+                  <div className="flex items-center" style={{ gap: '0.625rem' }}>
+                    {socialLinks.map((link) => (
+                      <a
+                        href={partner[link]}
+                        className="link barlow-condensed white f4 ttu di-l dib"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {getSocialIcons(link)}
+                      </a>
+                    ))}
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/views/partnersStats.js
+++ b/frontend/src/views/partnersStats.js
@@ -1,23 +1,31 @@
 import React, { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useNavigate } from 'react-router-dom';
 import ReactPlaceholder from 'react-placeholder';
 import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
 import { NotFound } from './notFound';
 import { useFetch } from '../hooks/UseFetch';
-import { StatsSection } from '../components/partners/partnersStats';
-import { Activity } from '../components/partners/partnersActivity';
-import { CurrentProjects } from '../components/partners/currentProjects';
+import { Leaderboard } from '../components/partners/leaderboard';
 import { Resources } from '../components/partners/partnersResources';
 import { OHSOME_STATS_BASE_URL } from '../config';
 import { Button } from '../components/button';
 import { TwitterIcon, FacebookIcon, InstagramIcon } from '../components/svgIcons';
 
+const tabData = [{ id: 'leaderboard', title: 'Leaderboard' }];
+
 export const PartnersStats = () => {
-  const { id } = useParams();
+  const { id, tabname } = useParams();
+  const navigate = useNavigate();
   const [partnerStats, setPartnerStats] = useState(null);
   const [error, loading, partner] = useFetch(`partners/${id}/`);
+
+  // navigate to /leaderboard path when no tab param present
+  useEffect(() => {
+    if (!tabname) {
+      navigate('leaderboard');
+    }
+  }, [navigate, tabname]);
 
   const fetchData = async (name) => {
     try {
@@ -45,6 +53,15 @@ export const PartnersStats = () => {
     }
   }, [partner]);
 
+  function getTabContent() {
+    switch (tabname) {
+      case 'leaderboard':
+        return <Leaderboard partner={partner} partnerStats={partnerStats} />;
+      default:
+        return <></>;
+    }
+  }
+
   return (
     <ReactPlaceholder
       showLoadingAnimation={true}
@@ -56,79 +73,87 @@ export const PartnersStats = () => {
         <NotFound />
       ) : (
         <div className="">
-          <div className="flex items-center justify-between bg-blue-dark pa4">
+          <div className="flex flex-column bg-blue-dark ph4">
             {/* logo */}
             {partner.logo_url ? (
               <img src={partner.logo_url} alt="logo" height={70} />
             ) : (
-              <h3 className="f2 fw6 ttu barlow-condensed white">{partner.name}</h3>
-            )}
-            <div className="flex">
-              {/* new to mapping button */}
-              <Link to={`/learn/map/`}>
-                <Button className="bg-grey-dark white mr3 br1 f5 bn">
-                  <FormattedMessage {...messages.newToMapping} />
-                </Button>
-              </Link>
-              {/* resources button */}
-              <Resources partner={partner} />
-            </div>
-          </div>
-          {/* social logos */}
-          <div className="pa4 bg-tan flex flex-column" style={{ gap: '1.25rem' }}>
-            <div className="flex justify-between items-center">
-              <h3 className="f2 blue-dark fw7 ma0 barlow-condensed v-mid dib">
-                {partner.primary_hashtag
-                  ?.split(',')
-                  ?.map((str) => `#${str}`)
-                  ?.join(', ')}
+              <h3 className="f2 fw6 ttu barlow-condensed white" style={{ marginBottom: '1.75rem' }}>
+                {partner.name}
               </h3>
-              <div className="flex" style={{ gap: '0.5rem' }}>
-                {!!partner.link_x && (
-                  <a
-                    href={partner.link_x}
-                    className="link barlow-condensed white f4 ttu di-l dib"
-                    target="_blank"
-                    rel="noreferrer"
+            )}
+            <div className="flex justify-between">
+              <div className="flex" style={{ gap: '0.75rem' }}>
+                {tabData.map(({ id: tabId, title }) => (
+                  <div
+                    key={tabId}
+                    className={`flex items-center pointer ${
+                      tabname === tabId ? 'bg-tan blue-dark' : 'bg-grey-dark white'
+                    }`}
+                    style={{
+                      borderRadius: '3px 3px 0px 0px',
+                      padding: '0.625rem 1.375rem',
+                      fontWeight: '500',
+                    }}
+                    onClick={() => navigate(`/partners/${id}/stats/${tabId}`)}
                   >
-                    <TwitterIcon className="blue-dark partners-social-icon" />
-                  </a>
-                )}
-                {!!partner.link_meta && (
-                  <a
-                    href={partner.link_meta}
-                    className="link barlow-condensed white f4 ttu di-l dib"
-                    target="_blank"
-                    rel="noreferrer"
+                    <p className="ma0">{title}</p>
+                  </div>
+                ))}
+              </div>
+              <div className="flex" style={{ gap: '1.5rem' }}>
+                {/* new to mapping button */}
+                <Link to={`/learn/map/`}>
+                  <Button
+                    className="bg-transparent white br1 f5 bn"
+                    style={{ padding: '0.75rem 0' }}
                   >
-                    <FacebookIcon className="blue-dark partners-social-icon" />
-                  </a>
-                )}
-                {!!partner.link_instagram && (
-                  <a
-                    href={partner.link_instagram}
-                    className="link barlow-condensed white f4 ttu di-l dib"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    <InstagramIcon className="blue-dark partners-social-icon" />
-                  </a>
-                )}
+                    <FormattedMessage {...messages.newToMapping} />
+                  </Button>
+                </Link>
+
+                {/* resources button */}
+                <Resources partner={partner} />
+
+                {/* social logos */}
+                <div className="flex items-center" style={{ gap: '0.625rem' }}>
+                  {!!partner.link_x && (
+                    <a
+                      href={partner.link_x}
+                      className="link barlow-condensed white f4 ttu di-l dib"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      <TwitterIcon noBg className="partners-social-icon" />
+                    </a>
+                  )}
+                  {!!partner.link_meta && (
+                    <a
+                      href={partner.link_meta}
+                      className="link barlow-condensed white f4 ttu di-l dib"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      <FacebookIcon className="partners-social-icon" />
+                    </a>
+                  )}
+                  {!!partner.link_instagram && (
+                    <a
+                      href={partner.link_instagram}
+                      className="link barlow-condensed white f4 ttu di-l dib"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      <InstagramIcon className="partners-social-icon" />
+                    </a>
+                  )}
+                </div>
               </div>
             </div>
-
-            <StatsSection partner={partnerStats} />
-
-            <CurrentProjects currentProjects={partner.current_projects} />
-
-            {/* activity section */}
-            <div className="w-100 fl cf">
-              <h3 className="f2 fw6 ttu barlow-condensed blue-dark mt0 pt2 mb3">
-                <FormattedMessage {...messages.activity} />
-              </h3>
-              <Activity partner={partner} />
-            </div>
           </div>
+
+          {/* tab content */}
+          {getTabContent()}
         </div>
       )}
     </ReactPlaceholder>

--- a/frontend/src/views/partnersStats.js
+++ b/frontend/src/views/partnersStats.js
@@ -94,7 +94,9 @@ export const PartnersStats = () => {
           <div className="flex flex-column bg-blue-dark ph4">
             {/* logo */}
             {partner.logo_url ? (
-              <img src={partner.logo_url} alt="logo" height={70} />
+              <div style={{ margin: '2.25rem  0 1.75rem 0' }}>
+                <img src={partner.logo_url} alt="logo" height={70} />
+              </div>
             ) : (
               <h3 className="f2 fw6 ttu barlow-condensed white" style={{ marginBottom: '1.75rem' }}>
                 {partner.name}

--- a/frontend/src/views/partnersStats.js
+++ b/frontend/src/views/partnersStats.js
@@ -123,7 +123,7 @@ export const PartnersStats = () => {
                 {/* new to mapping button */}
                 <Link to={`/learn/map/`}>
                   <Button
-                    className="bg-transparent white br1 f5 bn"
+                    className="bg-transparent white br1 f5 fw5 bn"
                     style={{ padding: '0.75rem 0' }}
                   >
                     <FormattedMessage {...messages.newToMapping} />

--- a/frontend/src/views/partnersStats.js
+++ b/frontend/src/views/partnersStats.js
@@ -94,7 +94,7 @@ export const PartnersStats = () => {
           <div className="flex flex-column bg-blue-dark ph4">
             {/* logo */}
             {partner.logo_url ? (
-              <div style={{ margin: '2.25rem  0 1.75rem 0' }}>
+              <div className="partners-banner-logo">
                 <img src={partner.logo_url} alt="logo" height={70} />
               </div>
             ) : (
@@ -103,31 +103,23 @@ export const PartnersStats = () => {
               </h3>
             )}
             <div className="flex justify-between">
-              <div className="flex" style={{ gap: '0.75rem' }}>
+              <div className="flex gap-0.75">
                 {tabData.map(({ id: tabId, title }) => (
                   <div
                     key={tabId}
-                    className={`flex items-center pointer ${
+                    className={`flex items-center pointer partners-tab-item ${
                       tabname === tabId ? 'bg-tan blue-dark' : 'bg-grey-dark white'
                     }`}
-                    style={{
-                      borderRadius: '3px 3px 0px 0px',
-                      padding: '0.625rem 1.375rem',
-                      fontWeight: '500',
-                    }}
                     onClick={() => navigate(`/partners/${id}/stats/${tabId}`)}
                   >
                     <p className="ma0">{title}</p>
                   </div>
                 ))}
               </div>
-              <div className="flex" style={{ gap: '1.5rem' }}>
+              <div className="flex gap-1.5">
                 {/* new to mapping button */}
                 <Link to={`/learn/map/`}>
-                  <Button
-                    className="bg-transparent white br1 f5 fw5 bn"
-                    style={{ padding: '0.75rem 0' }}
-                  >
+                  <Button className="bg-transparent white br1 f5 fw5 bn partners-banner-button">
                     <FormattedMessage {...messages.newToMapping} />
                   </Button>
                 </Link>
@@ -137,7 +129,7 @@ export const PartnersStats = () => {
 
                 {/* social logos */}
                 {!!socialLinks.length && (
-                  <div className="flex items-center" style={{ gap: '0.625rem' }}>
+                  <div className="flex items-center gap-0.625">
                     {socialLinks.map((link) => (
                       <a
                         href={partner[link]}

--- a/frontend/src/views/partnersStats.js
+++ b/frontend/src/views/partnersStats.js
@@ -107,10 +107,13 @@ export const PartnersStats = () => {
                 {tabData.map(({ id: tabId, title }) => (
                   <div
                     key={tabId}
+                    role="button"
+                    tabIndex={0}
                     className={`flex items-center pointer partners-tab-item ${
                       tabname === tabId ? 'bg-tan blue-dark' : 'bg-grey-dark white'
                     }`}
                     onClick={() => navigate(`/partners/${id}/stats/${tabId}`)}
+                    onKeyDown={() => {}}
                   >
                     <p className="ma0">{title}</p>
                   </div>
@@ -132,6 +135,7 @@ export const PartnersStats = () => {
                   <div className="flex items-center gap-0.625">
                     {socialLinks.map((link) => (
                       <a
+                        key={link}
                         href={partner[link]}
                         className="link barlow-condensed white f4 ttu di-l dib"
                         target="_blank"


### PR DESCRIPTION
## What type of PR is this?

- [x] 🍕 Feature
- [x] 🧑‍💻 Refactor

## Related Issue

- Fixes #6513 

## Describe this PR
Change design for `Partner Stats` page according to [this comment](https://github.com/hotosm/tasking-manager/issues/6513#issuecomment-2326767884).

**Changes-**
- Create dropdown menu popover for `Resources` section
- Move social icons to the banner
- Add a tab layout for switching between `Leaderboard` and `Map Swipe` (further integration) dashboard
- Remove `¿` icon from `New to Mapping?` button

## Screenshots
**Before -**

![image](https://github.com/user-attachments/assets/1a27b3bd-280b-4166-9f39-e908d00ecbad)

**After -**

![image](https://github.com/user-attachments/assets/ce986aab-f2bd-485c-b74d-00a9749fd6d5)


