### PR TITLE
Addresses #6165 by removing incorrect and conflicting instruction

### DIFF
--- a/example.env
+++ b/example.env
@@ -24,8 +24,7 @@ TM_APP_API_VERSION=v2
 TM_ORG_NAME="Humanitarian OpenStreetMap Team"
 TM_ORG_CODE=HOT
 TM_ORG_LOGO=https://cdn.img.url/logo.png
-# Don't use http or https on the following two variables
-TM_ORG_URL=example.com
+TM_ORG_URL=https://example.com
 TM_ORG_PRIVACY_POLICY_URL=https://www.hotosm.org/privacy
 TM_ORG_TWITTER=http://twitter.com/hotosm
 TM_ORG_FB=https://www.facebook.com/hotosm


### PR DESCRIPTION
Removes incorrect and conflicting instruction about not using scheme on "next two variables". Second example does indeed include scheme and first example produces an incorrect link without scheme included.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Example: Fixes #6165

## Describe this PR

See above.

## Screenshots

Please provide screenshots of the change.

## Review Guide

Notes for the reviewer. Probably look at your own variables in production. Barring that, set up a server using these instructions and check the website link in the upper right header; the domain name will appear as a path on the base server domain not as its own domain. 

## Checklist before requesting a review

- 📖 Read the Tasking Manager Contributing Guide: <https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.
