### PR TITLE
Fix: Speed up CSV generation by minimizing DB probes

### DIFF
--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -206,13 +206,13 @@ class Project(db.Model):
     def percent_mapped(self):
         return (
             (self.tasks_mapped + self.tasks_validated)
-            / (self.total_tasks - self.tasks_bad_imagery)
             * 100
+            // (self.total_tasks - self.tasks_bad_imagery)
         )
 
     @hybrid_property
     def percent_validated(self):
-        return self.tasks_validated / (self.total_tasks - self.tasks_bad_imagery) * 100
+        return self.tasks_validated * 100 // (self.total_tasks - self.tasks_bad_imagery)
 
     # Mapped Objects
     tasks = db.relationship(

--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -221,9 +221,12 @@ class ProjectSearchService:
             ProjectSearchService.create_result_dto(
                 project,
                 search_dto.preferred_locale,
-                next(filter(lambda c: c[0] == project.id, contributors_by_project_id))[
-                    1
-                ],
+                next(
+                    filter(
+                        lambda c, p=project: c[0] == p.id,
+                        contributors_by_project_id,
+                    )
+                )[1],
                 with_partner_names=is_user_admin,
                 with_author_name=False,
             ).to_primitive()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Describe this PR

Download CSV feature was unreasonably slow when the number of projects was high - 8 minutes for 2700 projects.
I moved the expensive DB calls outside the loop into just one query. It should be much faster now.

## Review Guide

Use an DB with multiple users and lots of projects and task history. Preferably 2000+ projects in the search results. Press the download CSV button. Look for the right contributor count and the CSV file getting downloaded without a gateway timeout.

