### PR TITLE
Add Date Filter to MapSwipe Partners Page

### DIFF
--- a/frontend/src/assets/styles/_extra.scss
+++ b/frontend/src/assets/styles/_extra.scss
@@ -611,8 +611,8 @@ a[href="https://www.mapbox.com/map-feedback/"]
   color: rgba($blue-dark, 0.9);
 }
 
-.gap-0\.625 {
-  gap: 0.75rem;
+.gap-0\.5 {
+  gap: 0.5rem;
 }
 
 .gap-0\.75 {

--- a/frontend/src/components/partnerMapswipeStats/contributionsGrid.js
+++ b/frontend/src/components/partnerMapswipeStats/contributionsGrid.js
@@ -1,11 +1,13 @@
 import CalendarHeatmap from 'react-calendar-heatmap';
 import { Tooltip } from 'react-tooltip';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { format } from 'date-fns';
 import PropTypes from 'prop-types';
 
 import messages from './messages';
 
 const LEGEND_INDEXES = [30, 50, 70, 100];
+
 const Legend = () => {
   const legendFontStyle = 'ph2 f7 blue-grey ttc';
 
@@ -25,26 +27,12 @@ const Legend = () => {
   );
 };
 
-export const ContributionsGrid = ({ contributionsByDate = [] }) => {
+export const ContributionsGrid = ({ contributionsByDate = [], startDate, endDate }) => {
   const gridData = contributionsByDate.map((contribution) => ({
     date: contribution.taskDate,
     count: contribution.totalcontributions,
   }));
   const intl = useIntl();
-
-  const getDate = (isEndDate = false) => {
-    const today = new Date();
-    const currentYear = today.getFullYear();
-
-    const formatDate = (date) => {
-      const offset = date.getTimezoneOffset();
-      return new Date(date.getTime() - offset * 60 * 1000);
-    };
-
-    return !isEndDate
-      ? formatDate(new Date(currentYear - 1, 11, 31))
-      : formatDate(new Date(currentYear, 11, 31));
-  };
 
   const countValues = gridData.map((contribution) => contribution.count);
   const maxValue = Math.max(...countValues);
@@ -69,6 +57,9 @@ export const ContributionsGrid = ({ contributionsByDate = [] }) => {
     }
   };
 
+  const endDateYear = endDate.split('-')[0];
+  const formattedEndDate = format(new Date(endDateYear, 11, 31), 'yyyy-MM-dd');
+
   return (
     <div>
       <h3 className="f2 fw6 ttu barlow-condensed blue-dark mt0 mb4">
@@ -77,8 +68,8 @@ export const ContributionsGrid = ({ contributionsByDate = [] }) => {
 
       <div className="bg-white pv4 pr4 shadow-6" style={{ fontSize: '1rem' }}>
         <CalendarHeatmap
-          startDate={getDate()}
-          endDate={getDate(true)}
+          startDate={startDate}
+          endDate={formattedEndDate}
           values={gridData}
           classForValue={(value) => {
             if (!value) return 'fill-tan';
@@ -114,4 +105,6 @@ ContributionsGrid.propTypes = {
       totalcontributions: PropTypes.number,
     }),
   ),
+  startDate: PropTypes.instanceOf(Date),
+  endDate: PropTypes.instanceOf(Date),
 };

--- a/frontend/src/components/partnerMapswipeStats/contributionsGrid.js
+++ b/frontend/src/components/partnerMapswipeStats/contributionsGrid.js
@@ -71,7 +71,7 @@ export const ContributionsGrid = ({ contributionsByDate = [] }) => {
 
   return (
     <div>
-      <h3 className="f2 fw6 ttu barlow-condensed blue-dark mt0 pt2 mb4">
+      <h3 className="f2 fw6 ttu barlow-condensed blue-dark mt0 mb4">
         <FormattedMessage {...messages.contributions} />
       </h3>
 

--- a/frontend/src/components/partnerMapswipeStats/dateFilter.js
+++ b/frontend/src/components/partnerMapswipeStats/dateFilter.js
@@ -1,0 +1,72 @@
+import { useEffect } from 'react';
+import { FormattedMessage } from 'react-intl';
+import DatePicker from 'react-datepicker';
+import { format, parse } from 'date-fns';
+
+import { CalendarIcon } from '../svgIcons';
+import messages from './messages';
+
+const today = new Date();
+const currentYear = today.getFullYear();
+const dateFormat = 'yyyy-MM-dd';
+
+const initialState = {
+  fromDate: format(new Date(currentYear, 0, 1), dateFormat),
+  toDate: format(today, dateFormat),
+};
+
+export const DateFilter = ({ isLoading, filters, setFilters }) => {
+  // set initial date filter state
+  useEffect(() => {
+    setFilters((prev) => ({
+      ...prev,
+      ...initialState,
+    }));
+  }, [setFilters]);
+
+  const handleDateSelect = (key, date) => {
+    setFilters((prev) => ({
+      ...prev,
+      [key]: date,
+    }));
+  };
+
+  if (isLoading) return <></>;
+
+  return (
+    <div className="w-100 mt4 flex justify-end">
+      <div className="flex flex-column items-end gap-0.5">
+        <div className="flex items-center">
+          <CalendarIcon className="blue-grey dib w1 pr2 v-mid" />
+          <DatePicker
+            selected={filters.fromDate ? parse(filters.fromDate, dateFormat, new Date()) : null}
+            onChange={(date) => {
+              handleDateSelect('fromDate', format(date, dateFormat));
+            }}
+            dateFormat={dateFormat}
+            className="w4 pv2 ph1 ba b--grey-light"
+            showYearDropdown
+            scrollableYearDropdown
+          />
+
+          <span className="ph3">to</span>
+
+          <CalendarIcon className="blue-grey dib w1 pr2 v-mid" />
+          <DatePicker
+            selected={filters.toDate ? parse(filters.toDate, dateFormat, new Date()) : null}
+            onChange={(date) => {
+              handleDateSelect('toDate', format(date, dateFormat));
+            }}
+            dateFormat={dateFormat}
+            className="w4 pv2 ph1 ba b--grey-light"
+            showYearDropdown
+            scrollableYearDropdown
+          />
+        </div>
+        <span className="blue-grey f6">
+          <FormattedMessage {...messages.dateFilterSubText} />
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/partnerMapswipeStats/dateFilter.js
+++ b/frontend/src/components/partnerMapswipeStats/dateFilter.js
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
-import DatePicker from 'react-datepicker';
 import { format, parse } from 'date-fns';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
 
 import { CalendarIcon } from '../svgIcons';
 import messages from './messages';
@@ -24,10 +25,28 @@ export const DateFilter = ({ isLoading, filters, setFilters }) => {
     }));
   }, [setFilters]);
 
-  const handleDateSelect = (key, date) => {
+  const handleDateSelect = (key, selectedDate) => {
+    let { fromDate, toDate } = filters;
+    const selectedDateValue = new Date(selectedDate).valueOf();
+    const toDateValue = new Date(toDate).valueOf();
+    const fromDateValue = new Date(fromDate).valueOf();
+    // adjust from and to date based on greater/lesser value
+    if (key === 'fromDate' && selectedDateValue > toDateValue) {
+      fromDate = toDate;
+      toDate = selectedDate;
+    } else if (key === 'toDate' && selectedDateValue < fromDateValue) {
+      toDate = fromDate;
+      fromDate = selectedDate;
+    } else if (key === 'toDate') {
+      toDate = selectedDate;
+    } else {
+      fromDate = selectedDate;
+    }
+    // set filters state
     setFilters((prev) => ({
       ...prev,
-      [key]: date,
+      fromDate,
+      toDate,
     }));
   };
 

--- a/frontend/src/components/partnerMapswipeStats/messages.js
+++ b/frontend/src/components/partnerMapswipeStats/messages.js
@@ -56,6 +56,14 @@ export default defineMessages({
     id: 'management.partners.stats.mapswipe.groupMembers.error',
     defaultMessage: 'Something went wrong!',
   },
+  groupStatsboard: {
+    id: 'management.partners.stats.mapswipe.groupStatsboard',
+    defaultMessage: 'Group Statsboard',
+  },
+  dateFilterSubText: {
+    id: 'management.partners.stats.mapswipe.dateFilterSubText',
+    defaultMessage: 'All dates are calculated in UTC',
+  },
   contributions: {
     id: 'management.partners.stats.mapswipe.contributions',
     defaultMessage: 'Contributions',

--- a/frontend/src/components/partnerMapswipeStats/overview.js
+++ b/frontend/src/components/partnerMapswipeStats/overview.js
@@ -59,7 +59,7 @@ export const getShortNumber = (value) => {
     <span>
       <FormattedNumber value={Number(shortNumberValue.substr(0, shortNumberValue.length - 1))} />
       &nbsp;
-      <span className="fw1">{shortNumberValue.substr(-1)}</span>
+      <span>{shortNumberValue.substr(-1)}</span>
     </span>
   );
 };

--- a/frontend/src/views/partnersMapswipeStats.js
+++ b/frontend/src/views/partnersMapswipeStats.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import ReactPlaceholder from 'react-placeholder';
@@ -9,6 +10,7 @@ import {
   getShortNumber,
   formatSecondsToTwoUnits,
 } from '../components/partnerMapswipeStats/overview';
+import { DateFilter } from '../components/partnerMapswipeStats/dateFilter';
 import { GroupMembers } from '../components/partnerMapswipeStats/groupMembers';
 import { ContributionsGrid } from '../components/partnerMapswipeStats/contributionsGrid';
 import { ContributionsHeatmap } from '../components/partnerMapswipeStats/contributionsHeatmap';
@@ -19,7 +21,10 @@ import { SwipesByProjectType } from '../components/partnerMapswipeStats/swipesBy
 import { SwipesByOrganization } from '../components/partnerMapswipeStats/swipesByOrganization';
 import messages from './messages';
 import { fetchLocalJSONAPI } from '../network/genericJSONRequest';
+
 import './partnersMapswipeStats.scss';
+import 'react-placeholder/lib/reactPlaceholder.css';
+import 'react-datepicker/dist/react-datepicker.css';
 
 const PagePlaceholder = () => (
   <div className="bg-tan flex flex-column" style={{ gap: '1.25rem' }}>
@@ -57,23 +62,18 @@ const InfoBanner = () => {
 
 export const PartnersMapswipeStats = () => {
   const { id: partnerPermalink } = useParams();
+  const [filters, setFilters] = useState({}); // state for date filter
   const { isLoading, isError, data, isRefetching } = useQuery({
-    queryKey: ['partners-mapswipe-filtered-statistics', partnerPermalink],
+    queryKey: [
+      'partners-mapswipe-filtered-statistics',
+      partnerPermalink,
+      filters.fromDate,
+      filters.toDate,
+    ],
     queryFn: async () => {
-      const today = new Date();
-      const currentYear = today.getFullYear();
-
-      const formatDate = (date) => {
-        const offset = date.getTimezoneOffset();
-        const adjustedDate = new Date(date.getTime() - offset * 60 * 1000);
-        return adjustedDate.toISOString().split('T')[0];
-      };
-
-      const fromDate = formatDate(new Date(currentYear, 0, 1));
-      const endDate = formatDate(today);
-
+      const { fromDate, toDate } = filters;
       const response = await fetchLocalJSONAPI(
-        `partners/${partnerPermalink}/filtered-statistics/?fromDate=${fromDate}&toDate=${endDate}`,
+        `partners/${partnerPermalink}/filtered-statistics/?fromDate=${fromDate}&toDate=${toDate}`,
       );
       return response;
     },
@@ -104,6 +104,8 @@ export const PartnersMapswipeStats = () => {
     <div className="pa4 bg-tan flex flex-column" style={{ gap: '1.25rem' }}>
       <InfoBanner />
       <Overview />
+
+      <DateFilter isLoading={isLoading} filters={filters} setFilters={setFilters} />
 
       <ReactPlaceholder customPlaceholder={<PagePlaceholder />} ready={!isLoading && !isRefetching}>
         {!isLoading && isError ? (

--- a/frontend/src/views/partnersMapswipeStats.js
+++ b/frontend/src/views/partnersMapswipeStats.js
@@ -120,7 +120,11 @@ export const PartnersMapswipeStats = () => {
         ) : (
           <>
             <div className="mt3">
-              <ContributionsGrid contributionsByDate={data?.contributionsByDate} />
+              <ContributionsGrid
+                startDate={filters?.fromDate}
+                endDate={filters?.toDate}
+                contributionsByDate={data?.contributionsByDate}
+              />
             </div>
 
             <div className="mt3">

--- a/frontend/src/views/partnersMapswipeStats.js
+++ b/frontend/src/views/partnersMapswipeStats.js
@@ -23,8 +23,6 @@ import messages from './messages';
 import { fetchLocalJSONAPI } from '../network/genericJSONRequest';
 
 import './partnersMapswipeStats.scss';
-import 'react-placeholder/lib/reactPlaceholder.css';
-import 'react-datepicker/dist/react-datepicker.css';
 
 const PagePlaceholder = () => (
   <div className="bg-tan flex flex-column" style={{ gap: '1.25rem' }}>


### PR DESCRIPTION
## What type of PR is this?

- [x] 🍕 Feature

## Related Issue

- Resolves #6620

## Describe this PR

Add `Date Filter` for date-wise filter of charts & visualizations in MapSwipe Partners page. 

## Screenshots
![image](https://github.com/user-attachments/assets/d666f3e3-32f6-4a2b-8c2f-ee6ebbd0f206)
