### PR TITLE
fix: update aws-actions/amazon-ecs-deploy-task-definition to v2

### DIFF
--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -91,7 +91,7 @@ jobs:
           image: ${{ needs.image-build-and-push.outputs.image_tags }}
 
       - name: Deploy task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ env.ECS_SERVICE }}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [X] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
Bumped aws-actions/amazon-ecs-deploy-task-definition version to V2 as v1 was throwing `Error: Failed to register task definition in ECS: Unexpected key 'enableFaultInjection' found in params` error


## Screenshots

<img width="1021" alt="image" src="https://github.com/user-attachments/assets/a81d0204-6364-4844-81c6-3b7f557ca214" />

