### PR TITLE
typescript-vite: fix(frontend): i18n, projects list, icon, tasks

### DIFF
--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -39,7 +39,7 @@ export const useProjectsQuery = (
   return useQuery({
     queryKey: ['projects', fullProjectsQuery, action],
     queryFn: ({ signal, queryKey }) => fetchProjects(signal, queryKey),
-    keepPreviousData: true,
+    placeholderData: (prevData) => prevData,
     ...queryOptions,
   });
 };

--- a/frontend/src/components/svgIcons/grid.tsx
+++ b/frontend/src/components/svgIcons/grid.tsx
@@ -22,7 +22,7 @@ export const NineCellsGridIcon = (props: HTMLProps<SVGSVGElement>) => (
 );
 
 export const FilledNineCellsGridIcon = (props: HTMLProps<SVGSVGElement>) => (
-  <svg enable-background="new 0 0 32 32" viewBox="0 0 32 32" {...props}>
+  <svg enableBackground="new 0 0 32 32" viewBox="0 0 32 32" {...props}>
     <g id="grid-2">
       <path
         d="M10.246,4.228c0-0.547-0.443-0.991-0.99-0.991H3.914c-0.548,0-0.991,0.443-0.991,0.991V9.57   c0,0.546,0.443,0.99,0.991,0.99h5.342c0.547,0,0.99-0.444,0.99-0.99V4.228z"

--- a/frontend/src/components/taskSelection/map.jsx
+++ b/frontend/src/components/taskSelection/map.jsx
@@ -160,7 +160,7 @@ export const TasksMap = ({
 
         let taskStatusCondition = ['case'];
 
-        if (authDetails.id !== undefined) {
+        if (authDetails?.id !== undefined) {
           const all_condition = ['all', locked, ['==', ['get', 'lockedBy'], authDetails.id]];
           taskStatusCondition = [...taskStatusCondition, ...[all_condition, 'redlock']];
         }
@@ -368,7 +368,7 @@ export const TasksMap = ({
       map.on('mousemove', 'tasks-fill', function (e) {
         // To now allow validators to select tasks that they mapped
         if (
-          e.features[0].properties.mappedBy === authDetails.id &&
+          e.features[0].properties.mappedBy === authDetails?.id &&
           e.features[0].properties.taskStatus === 'MAPPED'
         ) {
           popup.addTo(map);
@@ -378,7 +378,7 @@ export const TasksMap = ({
         }
         if (showTaskIds) {
           // when the user hover on a task they are validating, enable the task id dialog
-          if (e.features[0].properties.lockedBy === authDetails.id) {
+          if (e.features[0].properties.lockedBy === authDetails?.id) {
             setHoveredTaskId(e.features[0].properties.taskId);
           } else {
             setHoveredTaskId(null);

--- a/frontend/src/utils/internationalization.jsx
+++ b/frontend/src/utils/internationalization.jsx
@@ -59,9 +59,9 @@ async function getTranslatedMessages(locale) {
   }
   if (val) {
     const parsed = val.replace('-', '_');
-    return await import(/* webpackChunkName: "lang-[request]" */ `../locales/${parsed}.json`);
+    return await import(/* webpackChunkName: "lang-[request]" */ `../locales/${parsed}.json`).default;
   }
-  return await import(/* webpackChunkName: "lang-en" */ '../locales/en.json');
+  return await import(/* webpackChunkName: "lang-en" */ '../locales/en.json').default;
 }
 
 /* textComponent is for orderBy <select>, see codesandbox at https://github.com/facebook/react/issues/15513 */
@@ -73,7 +73,7 @@ let ConnectedIntl = (props) => {
       props.setLocale(getSupportedLocale(navigator.language).value);
     }
     getTranslatedMessages(props.locale)
-      .then((messages) => setI18nMessages(messages.default))
+      .then((messages) => setI18nMessages(messages))
       .catch((err) => console.error(err));
   }, [props]);
 

--- a/frontend/src/utils/internationalization.jsx
+++ b/frontend/src/utils/internationalization.jsx
@@ -59,9 +59,9 @@ async function getTranslatedMessages(locale) {
   }
   if (val) {
     const parsed = val.replace('-', '_');
-    return await import(/* webpackChunkName: "lang-[request]" */ `../locales/${parsed}.json`).default;
+    return (await import(/* webpackChunkName: "lang-[request]" */ `../locales/${parsed}.json`)).default;
   }
-  return await import(/* webpackChunkName: "lang-en" */ '../locales/en.json').default;
+  return (await import(/* webpackChunkName: "lang-en" */ '../locales/en.json')).default;
 }
 
 /* textComponent is for orderBy <select>, see codesandbox at https://github.com/facebook/react/issues/15513 */

--- a/frontend/src/utils/internationalization.jsx
+++ b/frontend/src/utils/internationalization.jsx
@@ -73,9 +73,7 @@ let ConnectedIntl = (props) => {
       props.setLocale(getSupportedLocale(navigator.language).value);
     }
     getTranslatedMessages(props.locale)
-      .then((messages) => {
-        setI18nMessages(messages.default)
-      })
+      .then((messages) => setI18nMessages(messages.default))
       .catch((err) => console.error(err));
   }, [props]);
 

--- a/frontend/src/utils/internationalization.jsx
+++ b/frontend/src/utils/internationalization.jsx
@@ -73,7 +73,9 @@ let ConnectedIntl = (props) => {
       props.setLocale(getSupportedLocale(navigator.language).value);
     }
     getTranslatedMessages(props.locale)
-      .then((messages) => setI18nMessages(messages))
+      .then((messages) => {
+        setI18nMessages(messages.default)
+      })
       .catch((err) => console.error(err));
   }, [props]);
 


### PR DESCRIPTION
Fixes:
- i18n not working at all, was importing just the module, not the contents
- persist project data between renders on project page - broken by tanstack query bump
- invalid svg property on grid icon - renamed property to camel case
- missing ternary when accessing authDetails in taskSelection causing runtime error/crash - added ternary