### PR TITLE
Fix ohsomeNow URL link on Bar Chart click in Partner Stats page

### DIFF
--- a/example.env
+++ b/example.env
@@ -87,7 +87,8 @@ OSM_REGISTER_URL=https://www.openstreetmap.org/user/new
 
 # API base URL and token(used to retrieve user stats only) for ohsomeNow Stats
 #
-OHSOME_STATS_BASE_URL=https://stats.now.ohsome.org/api
+OHSOME_STATS_BASE_URL=https://stats.now.ohsome.org
+OHSOME_STATS_API_URL=https://stats.now.ohsome.org/api
 OHSOME_STATS_TOKEN=testSuperSecretTestToken
 
 # Secret (required)

--- a/frontend/src/api/stats.js
+++ b/frontend/src/api/stats.js
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { fetchExternalJSONAPI } from '../network/genericJSONRequest';
 import api from './apiClient';
-import { OHSOME_STATS_BASE_URL, defaultChangesetComment } from '../config';
+import { OHSOME_STATS_API_URL, defaultChangesetComment } from '../config';
 
 const ohsomeProxyAPI = (url) => {
   const token = localStorage.getItem('token');
@@ -39,7 +39,7 @@ export const useProjectStatisticsQuery = (projectId) => {
 
 export const useOsmStatsQuery = () => {
   const fetchOsmStats = ({ signal }) => {
-    return api().get(`${OHSOME_STATS_BASE_URL}/stats/${defaultChangesetComment}-%2A`, {
+    return api().get(`${OHSOME_STATS_API_URL}/stats/${defaultChangesetComment}-%2A`, {
       signal,
     });
   };
@@ -54,7 +54,7 @@ export const useOsmStatsQuery = () => {
 
 export const useOsmHashtagStatsQuery = (defaultComment) => {
   const fetchOsmStats = ({ signal }) => {
-    return api().get(`${OHSOME_STATS_BASE_URL}/stats/${defaultComment[0].replace('#', '')}`, {
+    return api().get(`${OHSOME_STATS_API_URL}/stats/${defaultComment[0].replace('#', '')}`, {
       signal,
     });
   };
@@ -71,7 +71,7 @@ export const useOsmHashtagStatsQuery = (defaultComment) => {
 export const useUserOsmStatsQuery = (id) => {
   const fetchUserOsmStats = () => {
     return ohsomeProxyAPI(
-      `${OHSOME_STATS_BASE_URL}/topic/poi,highway,building,waterway/user?userId=${id}`,
+      `${OHSOME_STATS_API_URL}/topic/poi,highway,building,waterway/user?userId=${id}`,
     );
   };
 
@@ -87,7 +87,7 @@ export const useUserOsmStatsQuery = (id) => {
 
 export const useOsmStatsMetadataQuery = () => {
   const fetchOsmStatsMetadata = () => {
-    return fetchExternalJSONAPI(`${OHSOME_STATS_BASE_URL}/metadata`);
+    return fetchExternalJSONAPI(`${OHSOME_STATS_API_URL}/metadata`);
   };
 
   return useQuery({

--- a/frontend/src/components/partners/partnersActivity.js
+++ b/frontend/src/components/partners/partnersActivity.js
@@ -4,7 +4,7 @@ import ReactPlaceholder from 'react-placeholder';
 
 import PartnersProgresBar from './partnersProgresBar';
 import messages from './messages';
-import { OHSOME_STATS_BASE_URL } from '../../config';
+import { OHSOME_STATS_API_URL } from '../../config';
 
 export const Activity = ({ partner }) => {
   const [data, setData] = useState(null);
@@ -22,7 +22,7 @@ export const Activity = ({ partner }) => {
         ?.map((tag) => tag.trim().replace('#', '').toLowerCase())
         ?.join(',');
       const response = await fetch(
-        OHSOME_STATS_BASE_URL + `/stats/hashtags/${primaryHashtag},${secondaryHashtags}`,
+        OHSOME_STATS_API_URL + `/stats/hashtags/${primaryHashtag},${secondaryHashtags}`,
       );
 
       if (response.ok) {

--- a/frontend/src/components/partners/partnersProgresBar.js
+++ b/frontend/src/components/partners/partnersProgresBar.js
@@ -19,7 +19,7 @@ const ProgressBar = ({ className, firstBarValue, secondBarValue = 0, children, d
             target={'_blank'}
             rel="noreferrer"
             className="white no-underline"
-            href={OHSOME_STATS_BASE_URL + '/dashboard#hashtags=' + data.primary}
+            href={OHSOME_STATS_BASE_URL + '/dashboard#hashtag=' + data.primary}
           >
             {'#' + data.primary}{' '}
           </a>

--- a/frontend/src/components/teamsAndOrgs/featureStats.js
+++ b/frontend/src/components/teamsAndOrgs/featureStats.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
 import userDetailMessages from '../userDetail/messages';
-import { OHSOME_STATS_BASE_URL, defaultChangesetComment } from '../../config';
+import { OHSOME_STATS_API_URL, defaultChangesetComment } from '../../config';
 import { RoadIcon, HomeIcon, WavesIcon, MarkerIcon } from '../svgIcons';
 import { StatsCard } from '../statsCard';
 import StatsInfoFooter from '../statsInfoFooter';
@@ -14,7 +14,7 @@ export const FeatureStats = () => {
   const getStats = async () => {
     try {
       const response = await axios.get(
-        `${OHSOME_STATS_BASE_URL}/stats/${defaultChangesetComment}-%2A`,
+        `${OHSOME_STATS_API_URL}/stats/${defaultChangesetComment}-%2A`,
       );
       const { edits, buildings, roads } = response.data.result;
       setStats({

--- a/frontend/src/config/index.js
+++ b/frontend/src/config/index.js
@@ -4,7 +4,9 @@ export const API_URL = process.env.REACT_APP_API_URL
   ? new URL('/api/' + API_VERSION + '/', process.env.REACT_APP_API_URL)
   : 'http://127.0.0.1:5000/api/' + API_VERSION + '/';
 export const OHSOME_STATS_BASE_URL =
-  process.env.REACT_APP_OHSOME_STATS_BASE_URL || 'https://stats.now.ohsome.org/api';
+  process.env.REACT_APP_OHSOME_STATS_BASE_URL || 'https://stats.now.ohsome.org';
+export const OHSOME_STATS_API_URL =
+  process.env.REACT_APP_OHSOME_STATS_API_URL || 'https://stats.now.ohsome.org/api';
 // APPLICATION SETTINGS
 export const DEFAULT_LOCALE = process.env.REACT_APP_DEFAULT_LOCALE || 'en';
 export const ENVIRONMENT = process.env.REACT_APP_ENVIRONMENT || '';

--- a/frontend/src/config/tests/config.test.js
+++ b/frontend/src/config/tests/config.test.js
@@ -7,8 +7,8 @@ it('exports API_URL', () => {
 it('exports API_VERSION', () => {
   expect(['object', 'string']).toContain(typeof config.API_VERSION);
 });
-it('exports OHSOME_STATS_BASE_URL', () => {
-  expect(typeof config.OHSOME_STATS_BASE_URL).toBe('string');
+it('exports OHSOME_STATS_API_URL', () => {
+  expect(typeof config.OHSOME_STATS_API_URL).toBe('string');
 });
 it('exports ORG_URL', () => {
   expect(typeof config.ORG_URL).toBe('string');

--- a/frontend/src/network/tests/server-handlers.js
+++ b/frontend/src/network/tests/server-handlers.js
@@ -69,7 +69,7 @@ import {
   ohsomeNowMetadata,
 } from './mockData/miscellaneous';
 import tasksGeojson from '../../utils/tests/snippets/tasksGeometry';
-import { API_URL, OHSOME_STATS_BASE_URL, defaultChangesetComment } from '../../config';
+import { API_URL, OHSOME_STATS_API_URL, defaultChangesetComment } from '../../config';
 import { notifications, ownCountUnread } from './mockData/notifications';
 import { authLogin, setUser, userRegister } from './mockData/auth';
 import {
@@ -349,16 +349,16 @@ const handlers = [
     return res(ctx.json(systemStats));
   }),
   // EXTERNAL API
-  rest.get(`${OHSOME_STATS_BASE_URL}/stats/${defaultChangesetComment}-%2A`, (req, res, ctx) => {
+  rest.get(`${OHSOME_STATS_API_URL}/stats/${defaultChangesetComment}-%2A`, (req, res, ctx) => {
     return res(ctx.json(homepageStats));
   }),
-  rest.get(`${OHSOME_STATS_BASE_URL}/hot-tm-user`, (req, res, ctx) => {
+  rest.get(`${OHSOME_STATS_API_URL}/hot-tm-user`, (req, res, ctx) => {
     return res(ctx.json(ohsomeNowUserStats));
   }),
-  rest.get(`${OHSOME_STATS_BASE_URL}/stats/:projectId`, (req, res, ctx) => {
+  rest.get(`${OHSOME_STATS_API_URL}/stats/:projectId`, (req, res, ctx) => {
     return res(ctx.json(osmStatsProject));
   }),
-  rest.get(`${OHSOME_STATS_BASE_URL}/metadata`, (req, res, ctx) => {
+  rest.get(`${OHSOME_STATS_API_URL}/metadata`, (req, res, ctx) => {
     return res(ctx.json(ohsomeNowMetadata));
   }),
   rest.get('http://127.0.0.1:8111/version', (req, res, ctx) => {

--- a/frontend/src/views/partnersStats.js
+++ b/frontend/src/views/partnersStats.js
@@ -9,7 +9,7 @@ import { useFetch } from '../hooks/UseFetch';
 import { Leaderboard } from '../components/partners/leaderboard';
 import { PartnersMapswipeStats } from './partnersMapswipeStats';
 import { Resources } from '../components/partners/partnersResources';
-import { OHSOME_STATS_BASE_URL } from '../config';
+import { OHSOME_STATS_API_URL } from '../config';
 import { Button } from '../components/button';
 import { TwitterIcon, FacebookIcon, InstagramIcon } from '../components/svgIcons';
 
@@ -45,7 +45,7 @@ export const PartnersStats = () => {
         hashtag = hashtag.slice(1);
       }
       hashtag = hashtag.toLowerCase();
-      const response = await fetch(OHSOME_STATS_BASE_URL + '/stats/hashtags/' + hashtag);
+      const response = await fetch(OHSOME_STATS_API_URL + '/stats/hashtags/' + hashtag);
       if (response.ok) {
         const jsonData = await response.json();
         if (jsonData.result !== undefined && Object.keys(jsonData.result).length !== 0)


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug Fix

## Related Issue

- Fixes #6681 

## Describe this PR

This PR resolves the wrong URL for opening ohsomeNow stats page on Bar chart label click.

**Changes**
- Break down ohsomeNow stats environment variables to `OHSOME_STATS_BASE_URL` & `OHSOME_STATS_API_URL`
- Update `example.env`
- Correct query param `hashtag` in the ohsomeNow redirect URL

## Additional Requirements 
This PR requires some environment variables to be changed on the CI / development. 
Following env vars should be altered -
```
OHSOME_STATS_BASE_URL=https://stats.now.ohsome.org
OHSOME_STATS_API_URL=https://stats.now.ohsome.org/api
```

cc - @dakotabenjamin 