### PR TITLE
Update node to node 22 from node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   frontend-code-test:
     resource_class: large
     docker:
-      - image: cimg/node:18.19.1
+      - image: cimg/node:22.13.0
     working_directory: /home/circleci/tasking-manager
     steps:
       - checkout
@@ -184,7 +184,7 @@ jobs:
     working_directory: /home/circleci/tasking-manager
     resource_class: medium
     docker:
-      - image: cimg/node:18.19.1
+      - image: cimg/node:22.13.0
     steps:
       - checkout
       - aws-cli/setup:
@@ -236,7 +236,7 @@ jobs:
     working_directory: /home/circleci/tasking-manager
     resource_class: large
     docker:
-      - image: cimg/node:18.19.1
+      - image: cimg/node:22.13.0
     parameters:
       stack_name:
         description: "the name of the stack for cfn-config"

--- a/scripts/docker/Dockerfile.frontend
+++ b/scripts/docker/Dockerfile.frontend
@@ -1,4 +1,4 @@
-FROM node:18.19.1 as build
+FROM node:22.13.0 as build
 
 WORKDIR /usr/src/app/frontend
 COPY frontend .

--- a/scripts/docker/Dockerfile.frontend_development
+++ b/scripts/docker/Dockerfile.frontend_development
@@ -1,4 +1,4 @@
-FROM node:18.19.1
+FROM node:22.13.0
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

Update to Node 22 from Node 18. Node 18 is losing support this year (2025-04-30).

Of some interest, node now has a built-in test runner (as of node 20).

Node on Linux
||Node Version|EOL|
|---|---|---|
|Ubuntu 20.04|v10.19.0|2025-04|
|Ubuntu 22.04|v12.22.9|2027-04|
|Ubuntu 24.04|v18.19.1|2029-04|

Realistically, that only matters in a dev environment -- production environments _should_ be using static builds.

## Review Guide

1. Install node 22
2. Install dependencies
3. `CI=true yarn test` -- note: node 