### PR TITLE
typescript-vite: chore(frontend): switch port from 5173 -> 3000

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,4 +5,7 @@ import react from '@vitejs/plugin-react-swc';
 export default defineConfig({
   plugins: [react()],
   envPrefix: 'REACT_APP_',
+  server: {
+    port: 3000
+  }
 });


### PR DESCRIPTION
Switches frontend port from 5173 to 3000, as we already use 3000 in our env's.

Requested by @royallsilwallz 