### PR TITLE
Typescript support for react-redux selector and dispatch

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -143,6 +143,7 @@
     "source-map-explorer": "^2.5.3",
     "typescript": "^5.7.2",
     "vite": "^5.4.2",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^2.1.8",
     "vitest-canvas-mock": "^0.3.3"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import { RouterProvider } from 'react-router-dom';
 import { Toaster } from 'react-hot-toast';
 import ReactPlaceholder from 'react-placeholder';
 import { useMeta } from 'react-meta-elements';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { ErrorBoundary } from '@sentry/react';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
@@ -11,7 +11,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import './assets/styles/index.scss';
 
 import { getUserDetails } from './store/actions/auth';
-import { RootStore, store } from './store';
+import { store } from './store';
 import { ORG_NAME, MATOMO_ID } from './config';
 import { Preloader } from './components/preloader';
 import { FallbackComponent } from './views/fallback';
@@ -40,8 +40,8 @@ const queryClient = new QueryClient({
 const App = () => {
   useMeta({ property: 'og:url', content: import.meta.env.REACT_APP_BASE_URL });
   useMeta({ name: 'author', content: ORG_NAME });
-  const isLoading = useSelector((state: RootStore) => state.loader.isLoading);
-  const locale = useSelector((state: RootStore) => state.preferences.locale);
+  const isLoading = useTypedSelector((state) => state.loader.isLoading);
+  const locale = useTypedSelector((state) => state.preferences.locale);
 
   useEffect(() => {
     // fetch user details endpoint when the user is returning to a logged in session

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -1,13 +1,12 @@
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useQuery } from '@tanstack/react-query';
 
 import { backendToQueryConversion } from '../hooks/UseInboxQueryAPI';
 import { remapParamsToAPI } from '../utils/remapParamsToAPI';
 import api from './apiClient';
-import { RootStore } from '../store';
 
 export const useNotificationsQuery = (inboxQuery: string) => {
-  const token = useSelector((state: RootStore) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const fetchNotifications = async (signal: AbortSignal, queryKey: string) => {
     const [, inboxQuery] = queryKey;
     const response = await api(token).get(`notifications/?${serializeParams(inboxQuery)}`, {
@@ -25,7 +24,7 @@ export const useNotificationsQuery = (inboxQuery: string) => {
 };
 
 export const useUnreadNotificationsCountQuery = () => {
-  const token = useSelector((state: RootStore) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const fetchUnreadNotificationCount = async (signal: AbortSignal) => {
     const response = await api(token).get('notifications/queries/own/count-unread/', {
       signal,

--- a/frontend/src/api/organisations.ts
+++ b/frontend/src/api/organisations.ts
@@ -1,11 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 
 import api from './apiClient';
-import { RootStore } from '../store';
 
 export const useUserOrganisationsQuery = (userId: string | number) => {
-  const token = useSelector((state: RootStore) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
 
   const fetchOrganisations = ({ signal }: {
     signal: AbortSignal;

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -1,20 +1,19 @@
 import axios from 'axios';
 import { subMonths, format } from 'date-fns';
 import { QueryKey, QueryOptions, useQuery, UseQueryOptions } from '@tanstack/react-query';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 
 import { remapParamsToAPI } from '../utils/remapParamsToAPI';
 import api from './apiClient';
-import { API_URL, UNDERPASS_URL } from '../config';
-import { RootStore } from '../store';
+import { UNDERPASS_URL } from '../config';
 
 export const useProjectsQuery = (
   fullProjectsQuery: string,
   action: string,
   queryOptions: QueryOptions,
 ) => {
-  const token = useSelector((state: RootStore) => state.auth.token);
-  const locale = useSelector((state: RootStore) => state.preferences['locale']);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences['locale']);
 
   const fetchProjects = async (signal: AbortSignal | undefined, queryKey: QueryKey) => {
     const [, fullProjectsQuery, action] = queryKey;
@@ -45,8 +44,8 @@ export const useProjectsQuery = (
 };
 
 export const useProjectQuery = (projectId: string, otherOptions: any) => {
-  const token = useSelector((state: RootStore) => state.auth.token);
-  const locale = useSelector((state: RootStore) => state.preferences['locale']);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences['locale']);
   const fetchProject = ({ signal }: { signal: AbortSignal }) => {
     return api(token, locale).get(`projects/${projectId}/`, {
       signal,
@@ -63,8 +62,8 @@ export const useProjectQuery = (projectId: string, otherOptions: any) => {
 type ProjectSummaryQueryOptions = Omit<UseQueryOptions<any>, ('queryKey' | 'queryFn' | 'select')>;
 
 export const useProjectSummaryQuery = (projectId: string, otherOptions?: ProjectSummaryQueryOptions) => {
-  const token = useSelector((state: RootStore) => state.auth.token);
-  const locale = useSelector((state: RootStore) => state.preferences['locale']);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences['locale']);
 
   const fetchProjectSummary = ({ signal }: { signal: AbortSignal }) => {
     return api(token, locale).get(`projects/${projectId}/queries/summary/`, {
@@ -158,7 +157,7 @@ export const useProjectTimelineQuery = (projectId: string) => {
 };
 
 export const useTaskDetail = (projectId: string, taskId: number, shouldRefetch: boolean) => {
-  const token = useSelector((state: RootStore) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
 
   const fetchTaskDetail = ({ signal }: { signal: AbortSignal }) => {
     return api(token).get(`projects/${projectId}/tasks/${taskId}/`, {

--- a/frontend/src/api/questionsAndComments.ts
+++ b/frontend/src/api/questionsAndComments.ts
@@ -1,12 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 
 import api from './apiClient';
-import { RootStore } from '../store';
 
 export const useCommentsQuery = (projectId: string, page: number) => {
-  const token = useSelector((state: RootStore) => state.auth.token);
-  const locale = useSelector((state: RootStore) => state.preferences['locale']);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences['locale']);
 
   const getComments = ({ signal }: {
     signal: AbortSignal;

--- a/frontend/src/api/teams.ts
+++ b/frontend/src/api/teams.ts
@@ -1,10 +1,9 @@
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useQuery } from '@tanstack/react-query';
 import api from './apiClient';
-import type { RootStore } from '../store';
 
 export const useTeamsQuery = (params: any, otherOptions: any) => {
-  const token = useSelector((state: RootStore) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
 
   const fetchUserTeams = ({ signal }: {
     signal: AbortSignal;

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -1,12 +1,11 @@
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useQuery } from '@tanstack/react-query';
 
 import api from './apiClient';
-import { RootStore } from '../store';
 
 export const useLockedTasksQuery = () => {
-  const token = useSelector((state: RootStore) => state.auth.token);
-  const locale = useSelector((state: RootStore) => state.preferences['locale']);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences['locale']);
 
   const fetchLockedTasks = ({ signal }: {
     signal: AbortSignal;

--- a/frontend/src/components/comments/commentInput.tsx
+++ b/frontend/src/components/comments/commentInput.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import MDEditor from '@uiw/react-md-editor';
 import Tribute from 'tributejs';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -17,7 +17,6 @@ import { htmlFromMarkdown, formatUserNamesToLink } from '../../utils/htmlFromMar
 import { iconConfig } from './editorIconConfig';
 import messages from './messages';
 import { CurrentUserAvatar } from '../user/avatar';
-import { RootStore } from '../../store';
 
 function CommentInputField({
   comment,
@@ -42,7 +41,7 @@ function CommentInputField({
   placeholderMsg?: any;
   markdownTextareaProps?: any;
 }) {
-  const token = useSelector((state: RootStore) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const textareaRef = useRef();
   const isBundle = useRef(false);
   const [isShowPreview, setIsShowPreview] = useState(false);

--- a/frontend/src/components/contributions/myProjectsDropdown.tsx
+++ b/frontend/src/components/contributions/myProjectsDropdown.tsx
@@ -1,16 +1,15 @@
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import Select from 'react-select';
 import { FormattedMessage } from 'react-intl';
 import { useFetch } from '../../hooks/UseFetch';
 import messages from './messages';
-import { RootStore } from '../../store';
 
 export default function MyProjectsDropdown({ className, setQuery, allQueryParams }: {
   className?: string;
   setQuery: any;
   allQueryParams: any;
 }) {
-  const username = useSelector((state: RootStore) => state.auth.userDetails?.username);
+  const username = useTypedSelector((state) => state.auth.userDetails?.username);
   const [, , projects] = useFetch(`projects/queries/${username}/touched/`);
 
   const onSortSelect = (projectId: string) => {

--- a/frontend/src/components/deleteModal/index.jsx
+++ b/frontend/src/components/deleteModal/index.jsx
@@ -1,5 +1,5 @@
 import { forwardRef, useState, useRef } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useNavigate } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import Popup from 'reactjs-popup';
@@ -15,7 +15,7 @@ const DeleteTrigger = forwardRef((props, ref) => <DeleteButton {...props} />);
 export function DeleteModal({ id, name, type, className, endpointURL, onDelete }) {
   const navigate = useNavigate();
   const modalRef = useRef();
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const [deleteStatus, setDeleteStatus] = useState(null);
   const [error, setErrorMessage] = useState(null);
 

--- a/frontend/src/components/editor.jsx
+++ b/frontend/src/components/editor.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 import { useIntl } from 'react-intl';
 import { gpx } from '@tmcw/togeojson';
 import * as iD from '@hotosm/id';
@@ -9,11 +9,11 @@ import { OSM_CLIENT_ID, OSM_CLIENT_SECRET, OSM_REDIRECT_URI, OSM_SERVER_URL } fr
 import messages from './messages';
 
 export default function Editor({ setDisable, comment, presets, imagery, gpxUrl }) {
-  const dispatch = useDispatch();
+  const dispatch = useTypedDispatch();
   const intl = useIntl();
-  const session = useSelector((state) => state.auth.session);
-  const iDContext = useSelector((state) => state.editor.context);
-  const locale = useSelector((state) => state.preferences.locale);
+  const session = useTypedSelector((state) => state.auth.session);
+  const iDContext = useTypedSelector((state) => state.editor.context);
+  const locale = useTypedSelector((state) => state.preferences.locale);
   const [customImageryIsSet, setCustomImageryIsSet] = useState(false);
   const windowInit = typeof window !== 'undefined';
   const customSource =

--- a/frontend/src/components/footer/index.tsx
+++ b/frontend/src/components/footer/index.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { Link, matchRoutes, useLocation } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import {
@@ -21,7 +21,6 @@ import {
   ORG_PRIVACY_POLICY_URL,
 } from '../../config';
 import './styles.scss';
-import { RootStore } from '../../store';
 
 const socialNetworks = [
   { link: ORG_TWITTER, icon: <TwitterIcon style={{ height: '20px', width: '20px' }} noBg /> },
@@ -33,7 +32,7 @@ const socialNetworks = [
 
 export function Footer() {
   const location = useLocation();
-  const userDetails = useSelector((state: RootStore) => state.auth.userDetails);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
 
   const footerDisabledPaths = [
     'projects/:id/tasks',

--- a/frontend/src/components/formInputs.jsx
+++ b/frontend/src/components/formInputs.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { Field } from 'react-final-form';
 import Select from 'react-select';
 import { FormattedMessage } from 'react-intl';
@@ -53,8 +53,8 @@ export const SwitchToggle = ({
 );
 
 export const OrganisationSelect = ({ className, orgId, onChange }) => {
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
   const [organisations, setOrganisations] = useState([]);
 
   useEffect(() => {
@@ -100,7 +100,7 @@ export function OrganisationSelectInput({ className }) {
 }
 
 export function UserCountrySelect({ className, isDisabled = false }) {
-  const locale = useSelector((state) => state.preferences.locale);
+  const locale = useTypedSelector((state) => state.preferences.locale);
   const [options, setOptions] = useState([]);
 
   useEffect(() => {

--- a/frontend/src/components/header/index.tsx
+++ b/frontend/src/components/header/index.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import Popup from 'reactjs-popup';
 import { FormattedMessage } from 'react-intl';
@@ -24,17 +24,16 @@ import { useDebouncedCallback } from '../../hooks/UseThrottle';
 import { HorizontalScroll } from '../horizontalScroll';
 
 import './styles.scss';
-import { RootStore } from '../../store/index';
 
 export const Header = () => {
-  const dispatch = useDispatch();
+  const dispatch = useTypedDispatch();
   const location = useLocation();
   const navigate = useNavigate();
   const menuItemsContainerRef = useRef(null);
 
-  const userDetails = useSelector((state: RootStore) => state.auth.userDetails);
-  const organisations = useSelector((state: RootStore) => state.auth.organisations);
-  const showOrgBar = useSelector((state: RootStore) => state.orgBarVisibility.isVisible);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const organisations = useTypedSelector((state) => state.auth.organisations);
+  const showOrgBar = useTypedSelector((state) => state.orgBarVisibility.isVisible);
 
   const linkCombo = 'link mh3 barlow-condensed blue-dark f4 ttu lh-solid nowrap pv2';
 
@@ -294,7 +293,7 @@ export const ActionItems = ({
   );
 
 export const PopupItems = (props: any) => {
-  const dispatch = useDispatch();
+  const dispatch = useTypedDispatch();
 
   return (
     <div className="v-mid tc">

--- a/frontend/src/components/header/notificationBell.jsx
+++ b/frontend/src/components/header/notificationBell.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 
 import { TopNavLink } from './NavLink';
 import { BellIcon } from '../svgIcons';
@@ -10,8 +10,8 @@ import { useOnResize } from '../../hooks/UseOnResize';
 import { useNotificationsQuery, useUnreadNotificationsCountQuery } from '../../api/notifications';
 
 export const NotificationBell = () => {
-  const token = useSelector((state) => state.auth.token);
-  const dispatch = useDispatch();
+  const token = useTypedSelector((state) => state.auth.token);
+  const dispatch = useTypedDispatch();
 
   const [bellPosition, setBellPosition] = useState(0);
   /* these below make the references stable so hooks doesn't re-request forever */

--- a/frontend/src/components/header/updateEmail.tsx
+++ b/frontend/src/components/header/updateEmail.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 import { func } from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
@@ -8,15 +8,14 @@ import { updateUserEmail } from '../../store/actions/auth';
 import { PROFILE_RELEVANT_FIELDS } from '../user/forms/personalInformation';
 import { ORG_PRIVACY_POLICY_URL } from '../../config';
 import { Button } from '../button';
-import { RootStore } from '../../store/index.js';
 
 export const UpdateEmail = ({ closeModal }: {
   closeModal: () => void;
 }) => {
-  const dispatch = useDispatch();
+  const dispatch = useTypedDispatch();
 
-  const userDetails = useSelector((state: RootStore) => state.auth.userDetails);
-  const token = useSelector((state: RootStore) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
   const [userState, setUserState] = useState({ email: '', success: false, details: '' });
 
   const onChange = (e) => {

--- a/frontend/src/components/homepage/jumbotron.jsx
+++ b/frontend/src/components/homepage/jumbotron.jsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { Link } from 'react-router-dom';
 import Popup from 'reactjs-popup';
 import { FormattedMessage } from 'react-intl';
@@ -12,7 +12,7 @@ import bannerLR from '../../assets/img/banner_824.jpg';
 import { HOMEPAGE_VIDEO_URL, HOMEPAGE_IMG_HIGH, HOMEPAGE_IMG_LOW } from '../../config';
 
 function JumbotronButtons() {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   return (
     <div className="buttons">
       <Link to={'explore'}>

--- a/frontend/src/components/notifications/actionButtons.jsx
+++ b/frontend/src/components/notifications/actionButtons.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 import { FormattedMessage } from 'react-intl';
 
 import deletionMessages from '../deleteModal/messages';
@@ -19,8 +19,8 @@ export const ActionButtons = ({
   pageOfCards,
   totalPages,
 }) => {
-  const dispatch = useDispatch();
-  const token = useSelector((state) => state.auth.token);
+  const dispatch = useTypedDispatch();
+  const token = useTypedSelector((state) => state.auth.token);
   const param = inboxQuery.types ? `?messageType=${inboxQuery.types?.join(',')}` : '';
   const payload = JSON.stringify({ messageIds: selected });
 

--- a/frontend/src/components/notifications/inboxNav.jsx
+++ b/frontend/src/components/notifications/inboxNav.jsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 
@@ -50,7 +50,7 @@ const isActiveButton = (buttonName, projectQuery) => {
 };
 
 export const InboxNavMini = ({ setPopoutFocus }) => {
-  const unreadNotificationCount = useSelector((state) => state.notifications.unreadCount);
+  const unreadNotificationCount = useTypedSelector((state) => state.notifications.unreadCount);
   return (
     /* mb1 mb2-ns (removed for map, but now small gap for more-filters) */
     <header className="notifications-header">

--- a/frontend/src/components/notifications/notificationBodyCard.jsx
+++ b/frontend/src/components/notifications/notificationBodyCard.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import ReactPlaceholder from 'react-placeholder';
 import 'react-placeholder/lib/reactPlaceholder.css';
 import { selectUnit } from '../../utils/selectUnit';
@@ -89,7 +89,7 @@ export function NotificationBodyCard({
     sentDate,
   },
 }) {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const { value, unit } = selectUnit(new Date((sentDate && new Date(sentDate)) || new Date()));
   const showASendingUser =
     fromUsername || (typesThatUseSystemAvatar.indexOf(messageType) !== -1 && ORG_NAME);

--- a/frontend/src/components/notifications/notificationCard.jsx
+++ b/frontend/src/components/notifications/notificationCard.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 import Popup from 'reactjs-popup';
 import { Tooltip } from 'react-tooltip';
 import DOMPurify from 'dompurify';
@@ -70,8 +70,8 @@ export function NotificationCard({
   selected,
   setSelected,
 }) {
-  const dispatch = useDispatch();
-  const token = useSelector((state) => state.auth.token);
+  const dispatch = useTypedDispatch();
+  const token = useTypedSelector((state) => state.auth.token);
   const ref = useRef();
   const [replacedSubjectHTML, setReplacedSubjectHTML] = useState('');
 
@@ -210,7 +210,7 @@ export function NotificationCardMini({
   retryFn,
   read,
 }) {
-  const dispatch = useDispatch();
+  const dispatch = useTypedDispatch();
   const [subjectHTML, setSubjectHTML] = useState('');
 
   useEffect(() => {

--- a/frontend/src/components/projectCreate/index.jsx
+++ b/frontend/src/components/projectCreate/index.jsx
@@ -1,5 +1,5 @@
 import { lazy, useState, useLayoutEffect, useCallback, Suspense, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useNavigate } from 'react-router-dom';
 import { useQueryParam, NumberParam } from 'use-query-params';
 import { FormattedMessage, FormattedNumber, useIntl } from 'react-intl';
@@ -40,7 +40,7 @@ const ProjectCreationMap = lazy(() =>
 
 const ProjectCreate = () => {
   const intl = useIntl();
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const navigate = useNavigate();
   const [drawModeIsActive, setDrawModeIsActive] = useState(false);
   const [showProjectsAOILayer, setShowProjectsAOILayer] = useState(false);

--- a/frontend/src/components/projectCreate/projectCreationMap.jsx
+++ b/frontend/src/components/projectCreate/projectCreationMap.jsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useEffect, useCallback, useState, createRef } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { featureCollection } from '@turf/helpers';
@@ -34,7 +34,7 @@ try {
 const ProjectCreationMap = ({ mapObj, setMapObj, metadata, updateMetadata, step, uploadFile }) => {
   const mapRef = createRef();
   const mapboxSupportedLanguage = useMapboxSupportedLanguage();
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const [showProjectsAOILayer, setShowProjectsAOILayer] = useState(true);
   const [aoiCanBeActivated, setAOICanBeActivated] = useState(false);
   const [existingProjectsList, setExistingProjectsList] = useState([]);

--- a/frontend/src/components/projectCreate/trimProject.jsx
+++ b/frontend/src/components/projectCreate/trimProject.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import area from '@turf/area';
 import { featureCollection } from '@turf/helpers';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
@@ -37,7 +37,7 @@ const removeTinyTasks = (metadata, updateMetadata) => {
 };
 
 export default function TrimProject({ metadata, mapObj, updateMetadata }) {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const [clipStatus, setClipStatus] = useState(false);
   const [tinyTasksNumber, setTinyTasksNumber] = useState(0);
 

--- a/frontend/src/components/projectDetail/favorites.jsx
+++ b/frontend/src/components/projectDetail/favorites.jsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useNavigate } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 
@@ -8,7 +8,7 @@ import messages from './messages';
 
 export const AddToFavorites = (props) => {
   const navigate = useNavigate();
-  const userToken = useSelector((state) => state.auth.token);
+  const userToken = useTypedSelector((state) => state.auth.token);
   const [state, dispatchToggle] = useFavProjectAPI(false, props.projectId, userToken);
   const isFav = state.isFav;
   const isLoading = state.isLoading;

--- a/frontend/src/components/projectDetail/footer.jsx
+++ b/frontend/src/components/projectDetail/footer.jsx
@@ -1,6 +1,6 @@
 import { useRef, Fragment } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { FormattedMessage } from 'react-intl';
 
 import { Button } from '../button';
@@ -56,7 +56,7 @@ const menuItems = [
 ];
 
 export const ProjectDetailFooter = ({ className, projectId }) => {
-  const userIsloggedIn = useSelector((state) => state.auth.token);
+  const userIsloggedIn = useTypedSelector((state) => state.auth.token);
   const menuItemsContainerRef = useRef(null);
   const { pathname } = useLocation();
 

--- a/frontend/src/components/projectDetail/header.jsx
+++ b/frontend/src/components/projectDetail/header.jsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 
@@ -39,7 +39,7 @@ export function HeaderLine({ author, projectId, priority, showEditLink, organisa
 }
 
 export const ProjectHeader = ({ project, showEditLink }) => {
-  const locale = useSelector((state) => state.preferences.locale);
+  const locale = useTypedSelector((state) => state.preferences.locale);
   const [userCanEditProject] = useEditProjectAllowed(project);
 
   return (
@@ -75,7 +75,7 @@ export const ProjectHeader = ({ project, showEditLink }) => {
 };
 
 export function TagLine({ campaigns = [], countries = [], interests = [] }) {
-  const locale = useSelector((state) => state.preferences.locale);
+  const locale = useTypedSelector((state) => state.preferences.locale);
   const formattedCampaigns = campaigns.map((campaign) => campaign.name).join(', ');
   const formattedCountries = locale.includes('en') ? countries.join(', ') : countries;
   const formattedInterests = interests.map((interest) => interest.name).join(', ');

--- a/frontend/src/components/projectDetail/questionsAndComments.jsx
+++ b/frontend/src/components/projectDetail/questionsAndComments.jsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { FormattedMessage } from 'react-intl';
 import { useMutation } from '@tanstack/react-query';
 import ReactPlaceholder from 'react-placeholder';
@@ -23,8 +23,8 @@ const CommentInputField = lazy(() =>
 );
 
 export const PostProjectComment = ({ projectId, refetchComments, contributors }) => {
-  const token = useSelector((state) => state.auth.token);
-  const locale = useSelector((state) => state.preferences['locale']);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences['locale']);
   const [comment, setComment] = useState('');
 
   const mutation = useMutation({
@@ -75,7 +75,7 @@ export const PostProjectComment = ({ projectId, refetchComments, contributors })
 };
 
 export const QuestionsAndComments = ({ project, contributors, titleClass }) => {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const [page, setPage] = useState(1);
   const [userCanEditProject] = useEditProjectAllowed(project);
   const projectId = project.projectId;
@@ -143,7 +143,7 @@ export const QuestionsAndComments = ({ project, contributors, titleClass }) => {
 };
 
 export function CommentList({ userCanEditProject, projectId, comments, retryFn }) {
-  const username = useSelector((state) => state.auth.userDetails?.username);
+  const username = useTypedSelector((state) => state.auth.userDetails?.username);
   const [commentsMessageHTML, setCommentsMessageHTML] = useState([]);
 
   useEffect(() => {

--- a/frontend/src/components/projectEdit/actionsForm.jsx
+++ b/frontend/src/components/projectEdit/actionsForm.jsx
@@ -1,5 +1,5 @@
 import { useState, useContext, useEffect, Suspense, lazy, forwardRef } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import Popup from 'reactjs-popup';
 import Select from 'react-select';
 import { useNavigate } from 'react-router-dom';
@@ -82,7 +82,7 @@ const ActionStatus = ({ status, action }) => {
 };
 
 const ResetTasksModal = ({ projectId, close }) => {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
 
   const resetTasks = () => {
     return fetchLocalJSONAPI(`projects/${projectId}/tasks/actions/reset-all/`, token, 'POST');
@@ -118,7 +118,7 @@ const ResetTasksModal = ({ projectId, close }) => {
 };
 
 const ResetBadImageryModal = ({ projectId, close }) => {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
 
   const resetBadImagery = () => {
     return fetchLocalJSONAPI(
@@ -162,7 +162,7 @@ const ResetBadImageryModal = ({ projectId, close }) => {
 };
 
 const ValidateAllTasksModal = ({ projectId, close }) => {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
 
   const validateAllTasks = () => {
     return fetchLocalJSONAPI(`projects/${projectId}/tasks/actions/validate-all/`, token, 'POST');
@@ -202,7 +202,7 @@ const ValidateAllTasksModal = ({ projectId, close }) => {
 };
 
 const InvalidateAllTasksModal = ({ projectId, close }) => {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
 
   const invalidateAllTasks = () => {
     return fetchLocalJSONAPI(`projects/${projectId}/tasks/actions/invalidate-all/`, token, 'POST');
@@ -242,7 +242,7 @@ const InvalidateAllTasksModal = ({ projectId, close }) => {
 };
 
 const MapAllTasksModal = ({ projectId, close }) => {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
 
   const mapAllTasks = () => {
     return fetchLocalJSONAPI(`projects/${projectId}/tasks/actions/map-all/`, token, 'POST');
@@ -281,7 +281,7 @@ const MapAllTasksModal = ({ projectId, close }) => {
 const MessageContributorsModal = ({ projectId, close }) => {
   const [subject, setSubject] = useState('');
   const [message, setMessage] = useState('');
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
 
   const messageAllContributors = () => {
     return pushToLocalJSONAPI(
@@ -364,7 +364,7 @@ const MessageContributorsModal = ({ projectId, close }) => {
 };
 
 const RevertTasks = ({ projectId, action }) => {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const [user, setUser] = useState(null);
   const [, contributorsLoading, contributors] = useFetch(`projects/${projectId}/contributions/`);
 
@@ -422,7 +422,7 @@ const RevertTasks = ({ projectId, action }) => {
 };
 
 const TransferProject = ({ projectId, orgId }) => {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const { projectInfo } = useContext(StateContext);
   const [username, setUsername] = useState('');
   const [managers, setManagers] = useState([]);
@@ -461,7 +461,7 @@ const TransferProject = ({ projectId, orgId }) => {
   const handleSelect = (value) => {
     setUsername(value);
   };
-  const { username: loggedInUsername, role: loggedInUserRole } = useSelector(
+  const { username: loggedInUsername, role: loggedInUserRole } = useTypedSelector(
     (state) => state.auth.userDetails,
   );
   const hasAccess =

--- a/frontend/src/components/projectEdit/metadataForm.jsx
+++ b/frontend/src/components/projectEdit/metadataForm.jsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import Select from 'react-select';
 import { FormattedMessage } from 'react-intl';
 
@@ -17,8 +17,8 @@ import { getFilterId } from '../../utils/osmchaLink';
 export const MetadataForm = () => {
   const { projectInfo, setProjectInfo } = useContext(StateContext);
   const [interests, setInterests] = useState([]);
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
   const [organisations, setOrganisations] = useState([]);
   const [campaigns, setCampaigns] = useState([]);
 

--- a/frontend/src/components/projectEdit/partnersForm.jsx
+++ b/frontend/src/components/projectEdit/partnersForm.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, forwardRef, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import Select from 'react-select';
 import ReactDatePicker from 'react-datepicker';
 import { FormattedMessage } from 'react-intl';
@@ -96,8 +96,8 @@ export const PartnersForm = () => {
     endDate: null,
   });
   const [errorMessage, setErrorMessage] = useState({});
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
   const queryClient = useQueryClient();
   const { id } = useParams();
 

--- a/frontend/src/components/projectEdit/partnersListing.jsx
+++ b/frontend/src/components/projectEdit/partnersListing.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import ReactDatePicker from 'react-datepicker';
 import { FormattedMessage } from 'react-intl';
 import Popup from 'reactjs-popup';
@@ -51,7 +51,7 @@ export const Listing = ({ partnerIdToDetailsMapping }) => {
   const [errorMessage, setErrorMessage] = useState({});
   const [actionType, setActionType] = useState(''); // "edit" or "remove"
 
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const { id } = useParams();
   const queryClient = useQueryClient();
 

--- a/frontend/src/components/projects/downloadAsCSV.jsx
+++ b/frontend/src/components/projects/downloadAsCSV.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import toast from 'react-hot-toast';
 
 import { downloadAsCSV } from '../../api/projects';
@@ -10,8 +10,8 @@ import messages from './messages';
 
 export default function DownloadAsCSV({ allQueryParams }) {
   const [isLoading, setIsLoading] = useState(false);
-  const token = useSelector((state) => state.auth.token);
-  const action = useSelector((state) => state.preferences['action']);
+  const token = useTypedSelector((state) => state.auth.token);
+  const action = useTypedSelector((state) => state.preferences['action']);
 
   const allQueryParamsCopy = { ...allQueryParams };
   allQueryParamsCopy.downloadAsCSV = true;

--- a/frontend/src/components/projects/moreFiltersForm.jsx
+++ b/frontend/src/components/projects/moreFiltersForm.jsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { Link } from 'react-router-dom';
 import { useQueryParam, BooleanParam } from 'use-query-params';
 import { FormattedMessage } from 'react-intl';
@@ -16,8 +16,8 @@ import { formatFilterCountriesData } from '../../utils/countries';
 
 export const MoreFiltersForm = (props) => {
   /* one useQueryParams for the main form */
-  const isLoggedIn = useSelector((state) => state.auth.token);
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const isLoggedIn = useTypedSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   const [formQuery, setFormQuery] = useExploreProjectsQueryParams();
   const isAdmin = userDetails && userDetails.role === 'ADMIN';
 

--- a/frontend/src/components/projects/myProjectNav.jsx
+++ b/frontend/src/components/projects/myProjectNav.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
@@ -14,11 +14,11 @@ import { ShowMapToggle, ProjectListViewToggle } from './projectNav';
 import { CustomButton } from '../button';
 
 export const MyProjectNav = (props) => {
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const isOrgManager = useSelector(
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const isOrgManager = useTypedSelector(
     (state) => state.auth.organisations && state.auth.organisations.length > 0,
   );
-  const isPMTeamMember = useSelector(
+  const isPMTeamMember = useTypedSelector(
     (state) => state.auth.pmTeams && state.auth.pmTeams.length > 0,
   );
   const [fullProjectsQuery, setQuery] = useExploreProjectsQueryParams();
@@ -236,7 +236,7 @@ export function FilterButton({ currentQuery, newQueryParams, setQuery, isActive,
 }
 
 function ManagerFilters({ query, setQuery }) {
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   const [campaignsError, campaignsLoading, campaigns] = useFetch('campaigns/');
   const [orgsError, orgsLoading, organisations] = useFetch(
     `organisations/?omitManagerList=true${

--- a/frontend/src/components/projects/partnersFilterSelect.jsx
+++ b/frontend/src/components/projects/partnersFilterSelect.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import Select from 'react-select';
 import ReactDatePicker from 'react-datepicker';
 import { FormattedMessage } from 'react-intl';
@@ -22,8 +22,8 @@ export const PartnersFilterSelect = ({
     startDate: null,
     endDate: null,
   });
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
   const { isPending, isError, data: partners } = useAllPartnersQuery(token, userDetails?.id);
 
   useEffect(() => {

--- a/frontend/src/components/projects/projectNav.jsx
+++ b/frontend/src/components/projects/projectNav.jsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
-import { useSelector, useDispatch } from 'react-redux';
+import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 import PropTypes from 'prop-types';
 
 import messages from './messages';
@@ -17,9 +17,9 @@ import DownloadAsCSV from './downloadAsCSV';
 import { GripIcon, ListIcon, FilledNineCellsGridIcon, TableListIcon } from '../svgIcons';
 
 export const ShowMapToggle = (props) => {
-  const dispatch = useDispatch();
-  const isMapShown = useSelector((state) => state.preferences['mapShown']);
-  const isExploreProjectsTableView = useSelector(
+  const dispatch = useTypedDispatch();
+  const isMapShown = useTypedSelector((state) => state.preferences['mapShown']);
+  const isExploreProjectsTableView = useTypedSelector(
     (state) => state.preferences['isExploreProjectsTableView'],
   );
 
@@ -43,8 +43,8 @@ export const ShowMapToggle = (props) => {
 };
 
 export const ProjectListViewToggle = (props) => {
-  const dispatch = useDispatch();
-  const listViewIsActive = useSelector((state) => state.preferences['projectListView']);
+  const dispatch = useTypedDispatch();
+  const listViewIsActive = useTypedSelector((state) => state.preferences['projectListView']);
   return (
     <div className="fr pv2 dib-ns dn">
       <ListIcon
@@ -66,8 +66,8 @@ export const ProjectListViewToggle = (props) => {
 };
 
 const ExploreProjectsViewToggle = () => {
-  const dispatch = useDispatch();
-  const isExploreProjectsTableView = useSelector(
+  const dispatch = useTypedDispatch();
+  const isExploreProjectsTableView = useTypedSelector(
     (state) => state.preferences['isExploreProjectsTableView'],
   );
 
@@ -124,8 +124,8 @@ export const ProjectNav = ({ isExploreProjectsPage, children }) => {
   const encodedParams = stringify(fullProjectsQuery)
     ? ['?', stringify(fullProjectsQuery)].join('')
     : '';
-  const isMapShown = useSelector((state) => state.preferences['mapShown']);
-  const isExploreProjectsTableView = useSelector(
+  const isMapShown = useTypedSelector((state) => state.preferences['mapShown']);
+  const isExploreProjectsTableView = useTypedSelector(
     (state) => state.preferences['isExploreProjectsTableView'],
   );
 

--- a/frontend/src/components/projects/projectSearchResults.jsx
+++ b/frontend/src/components/projects/projectSearchResults.jsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import ReactPlaceholder from 'react-placeholder';
 import 'react-placeholder/lib/reactPlaceholder.css';
@@ -19,8 +19,8 @@ export const ProjectSearchResults = ({
   showBottomButtons,
   isExploreProjectsPage = false,
 }) => {
-  const listViewIsActive = useSelector((state) => state.preferences['projectListView']);
-  const isExploreProjectsTableView = useSelector(
+  const listViewIsActive = useTypedSelector((state) => state.preferences['projectListView']);
+  const isExploreProjectsTableView = useTypedSelector(
     (state) => state.preferences['isExploreProjectsTableView'],
   );
 

--- a/frontend/src/components/projects/projectsActionFilter.jsx
+++ b/frontend/src/components/projects/projectsActionFilter.jsx
@@ -1,13 +1,13 @@
 import { useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useSelector, useDispatch } from 'react-redux';
+import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 import messages from './messages';
 import { Dropdown } from '../dropdown';
 
 export const ProjectsActionFilter = ({ setQuery, fullProjectsQuery }) => {
-  const dispatch = useDispatch();
-  const action = useSelector((state) => state.preferences.action);
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const dispatch = useTypedDispatch();
+  const action = useTypedSelector((state) => state.preferences.action);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
 
   useEffect(() => {
     // if action is not set on redux/localStorage,

--- a/frontend/src/components/rapidEditor.jsx
+++ b/frontend/src/components/rapidEditor.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 
 import PropTypes from 'prop-types';
 
@@ -147,11 +147,11 @@ function RapidEditor({
   powerUser = false,
   showSidebar = true,
 }) {
-  const dispatch = useDispatch();
-  const session = useSelector((state) => state.auth.session);
+  const dispatch = useTypedDispatch();
+  const session = useTypedSelector((state) => state.auth.session);
   const [rapidLoaded, setRapidLoaded] = useState(window.Rapid !== undefined);
-  const { context, dom } = useSelector((state) => state.editor.rapidContext);
-  const locale = useSelector((state) => state.preferences.locale);
+  const { context, dom } = useTypedSelector((state) => state.editor.rapidContext);
+  const locale = useTypedSelector((state) => state.preferences.locale);
   const windowInit = typeof window !== 'undefined';
 
   // This significantly reduces build time _and_ means different TM instances can share the same download of Rapid.

--- a/frontend/src/components/taskSelection/action.jsx
+++ b/frontend/src/components/taskSelection/action.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useNavigate, useLocation } from 'react-router-dom';
 import ReactPlaceholder from 'react-placeholder';
 import Popup from 'reactjs-popup';
@@ -48,8 +48,8 @@ export function TaskMapAction({ project, tasks, activeTasks, getTasks, action, e
   const location = useLocation();
   const aboutToExpireTimeoutRef = useRef();
   const expiredTimeoutRef = useRef();
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
   const [activeSection, setActiveSection] = useState('completion');
   const [activeEditor, setActiveEditor] = useState(editor);
   const [showSidebar, setShowSidebar] = useState(true);

--- a/frontend/src/components/taskSelection/actionSidebars.jsx
+++ b/frontend/src/components/taskSelection/actionSidebars.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, Suspense, lazy } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useNavigate } from 'react-router-dom';
 import Popup from 'reactjs-popup';
 import { Tooltip } from 'react-tooltip';
@@ -57,8 +57,8 @@ export function CompletionTabForMapping({
   setSelectedStatus,
 }) {
   const navigate = useNavigate();
-  const token = useSelector((state) => state.auth.token);
-  const locale = useSelector((state) => state.preferences['locale']);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences['locale']);
   const queryClient = useQueryClient();
   const [showHelp, setShowHelp] = useState(false);
   const [showMapChangesModal, setShowMapChangesModal] = useState(false);
@@ -350,8 +350,8 @@ export function CompletionTabForValidation({
   setValidationComments,
 }) {
   const navigate = useNavigate();
-  const token = useSelector((state) => state.auth.token);
-  const locale = useSelector((state) => state.preferences.locale);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences.locale);
   const queryClient = useQueryClient();
   const [showMapChangesModal, setShowMapChangesModal] = useState(false);
   const [redirectToPreviousProject, setRedirectToPreviousProject] = useState(true);
@@ -587,7 +587,7 @@ const TaskValidationSelector = ({
   copyCommentToTasks,
   isValidatingMultipleTasks,
 }) => {
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   const [showCommentInput, setShowCommentInput] = useState(false);
   const [enableCopy, setEnableCopy] = useState(false);
   const setComment = (newComment) => updateComment(id, newComment);
@@ -770,7 +770,7 @@ export function ReopenEditor({ project, action, editor, callEditor }) {
 }
 
 export function SidebarToggle({ setShowSidebar, activeEditor }) {
-  const iDContext = useSelector((state) => state.editor.context);
+  const iDContext = useTypedSelector((state) => state.editor.context);
 
   return (
     <div>

--- a/frontend/src/components/taskSelection/footer.jsx
+++ b/frontend/src/components/taskSelection/footer.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 import { useNavigate, useLocation } from 'react-router-dom';
 import Popup from 'reactjs-popup';
 import { FormattedMessage } from 'react-intl';
@@ -25,13 +25,13 @@ const TaskSelectionFooter = ({
 }) => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const token = useSelector((state) => state.auth.token);
-  const locale = useSelector((state) => state.preferences.locale);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences.locale);
   const [editor, setEditor] = useState(defaultUserEditor);
   const [editorOptions, setEditorOptions] = useState([]);
   const [isPending, setIsPending] = useState(false);
   const [lockError, setLockError] = useState(null);
-  const dispatch = useDispatch();
+  const dispatch = useTypedDispatch();
   const fetchLockedTasks = useFetchLockedTasks();
 
   const lockSuccess = (status, endpoint, windowObjectReference) => {

--- a/frontend/src/components/taskSelection/index.tsx
+++ b/frontend/src/components/taskSelection/index.tsx
@@ -1,6 +1,6 @@
 import { lazy, useState, useEffect, useCallback, Suspense, useRef } from 'react';
 import { useLocation, useParams, useNavigate } from 'react-router-dom';
-import { useSelector, useDispatch } from 'react-redux';
+import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 import { useQueryParam, StringParam } from 'use-query-params';
 import Popup from 'reactjs-popup';
 import ReactPlaceholder from 'react-placeholder';
@@ -33,7 +33,6 @@ import {
 } from '../../api/projects';
 import { useTeamsQuery } from '../../api/teams';
 
-import { RootStore } from '../../store/index.js';
 const TaskSelectionFooter = lazy(() => import('./footer'));
 
 const getRandomTaskByAction = (activities, taskAction) => {
@@ -64,10 +63,10 @@ export function TaskSelection({
   const { tabname: activeSection } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
-  const dispatch = useDispatch();
-  const token = useSelector((state: RootStore) => state.auth.token);
-  const user = useSelector((state: RootStore) => state.auth.userDetails);
-  const userOrgs = useSelector((state: RootStore) => state.auth.organisations);
+  const dispatch = useTypedDispatch();
+  const token = useTypedSelector((state) => state.auth.token);
+  const user = useTypedSelector((state) => state.auth.userDetails);
+  const userOrgs = useTypedSelector((state) => state.auth.organisations);
   const lockedTasks = useGetLockedTasks();
   const [zoomedTaskId, setZoomedTaskId] = useState(null);
   const [selected, setSelectedTasks] = useState([]);

--- a/frontend/src/components/taskSelection/lockedTasks.jsx
+++ b/frontend/src/components/taskSelection/lockedTasks.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { fetchLocalJSONAPI, pushToLocalJSONAPI } from '../../network/genericJSONRequest';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
@@ -74,7 +74,7 @@ export function SameProjectLock({ lockedTasks, action }) {
 }
 
 export const LicenseError = ({ id, close, lockTasks }) => {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const [license, setLicense] = useState(null);
 
   useEffect(() => {
@@ -157,7 +157,7 @@ function LockErrorButtons({
   selectedTasks,
   setSelectedTasks,
 }) {
-  const user = useSelector((state) => state.auth.userDetails);
+  const user = useTypedSelector((state) => state.auth.userDetails);
   const [hasTasksChanged, setHasTasksChanged] = useState(false);
 
   const handleDeselectAndValidate = () => {

--- a/frontend/src/components/taskSelection/map.jsx
+++ b/frontend/src/components/taskSelection/map.jsx
@@ -1,5 +1,5 @@
 import { createRef, useLayoutEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import bbox from '@turf/bbox';
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
@@ -44,7 +44,7 @@ export const TasksMap = ({
   const intl = useIntl();
   const mapRef = createRef();
   const mapboxSupportedLanguage = useMapboxSupportedLanguage();
-  const authDetails = useSelector((state) => state.auth.userDetails);
+  const authDetails = useTypedSelector((state) => state.auth.userDetails);
   const [hoveredTaskId, setHoveredTaskId] = useState(null);
 
   const [map, setMapObj] = useState(null);

--- a/frontend/src/components/taskSelection/tabSelector.tsx
+++ b/frontend/src/components/taskSelection/tabSelector.tsx
@@ -1,7 +1,6 @@
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { FormattedMessage } from 'react-intl';
 
-import { RootStore } from '../../store';
 import messages from './messages';
 
 export const TabSelector = ({
@@ -11,7 +10,7 @@ export const TabSelector = ({
   activeSection: string;
   setActiveSection: (section: string) => void;
 }) => {
-  const token = useSelector((state: RootStore) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const tabs = token ? ['tasks', 'instructions', 'contributions'] as const : ['instructions'] as const;
 
   return (

--- a/frontend/src/components/taskSelection/taskActivity.tsx
+++ b/frontend/src/components/taskSelection/taskActivity.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, Suspense, lazy } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 
 import { viewport } from '@placemarkio/geo-viewport';
 import { FormattedMessage } from 'react-intl';
@@ -33,8 +33,8 @@ const CommentInputField = lazy(() =>
 );
 
 const PostComment = ({ projectId, taskId, contributors, setCommentPayload }) => {
-  const token = useSelector((state) => state.auth.token);
-  const locale = useSelector((state) => state.preferences['locale']);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences['locale']);
   const [comment, setComment] = useState('');
 
   const saveComment = () => {
@@ -267,8 +267,8 @@ export const TaskActivity = ({
   updateActivities,
   userCanValidate,
 }: Object) => {
-  const token = useSelector((state) => state.auth.token);
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   // use it to hide the reset task action button
   const [resetSuccess, setResetSuccess] = useState(false);
   const queryClient = useQueryClient();

--- a/frontend/src/components/teamsAndOrgs/members.jsx
+++ b/frontend/src/components/teamsAndOrgs/members.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import axios from 'axios';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useIntl, FormattedMessage } from 'react-intl';
 import AsyncSelect from 'react-select/async';
 import toast from 'react-hot-toast';
@@ -30,7 +30,7 @@ export function Members({
   managerJoinTeamError,
   setManagerJoinTeamError,
 }) {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const [editMode, setEditMode] = useState(false);
   const [membersBackup, setMembersBackup] = useState(null);
   const selectPlaceHolder = <FormattedMessage {...messages.searchUsers} />;
@@ -175,8 +175,8 @@ export function JoinRequests({
 }) {
   const intl = useIntl();
   const { id } = useParams();
-  const token = useSelector((state) => state.auth.token);
-  const { username: loggedInUsername } = useSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
+  const { username: loggedInUsername } = useTypedSelector((state) => state.auth.userDetails);
   const showJoinRequestSwitch =
     joinMethod === 'BY_REQUEST' &&
     managers?.filter(

--- a/frontend/src/components/teamsAndOrgs/messageMembers.jsx
+++ b/frontend/src/components/teamsAndOrgs/messageMembers.jsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { FormattedMessage } from 'react-intl';
 import toast from 'react-hot-toast';
 
@@ -14,7 +14,7 @@ const CommentInputField = lazy(() =>
 );
 
 export function MessageMembers({ teamId, members }) {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const [message, setMessage] = useState('');
   const [subject, setSubject] = useState('');
   const [status, setStatus] = useState(null);

--- a/frontend/src/components/teamsAndOrgs/organisations.jsx
+++ b/frontend/src/components/teamsAndOrgs/organisations.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { Link } from 'react-router-dom';
 import { Form, Field } from 'react-final-form';
 import Select from 'react-select';
@@ -193,8 +193,8 @@ const TIER_OPTIONS = levels.map((level) => ({
 }));
 
 export function OrgInformation({ hasSlug, formState }) {
-  const token = useSelector((state) => state.auth.token);
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   const [uploadError, uploading, uploadImg] = useUploadImage();
   const intl = useIntl();
   //eslint-disable-next-line

--- a/frontend/src/components/teamsAndOrgs/teams.jsx
+++ b/frontend/src/components/teamsAndOrgs/teams.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { Link } from 'react-router-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
 import ReactPlaceholder from 'react-placeholder';
@@ -26,7 +26,7 @@ export function TeamsManagement({
   query,
   setQuery,
 }) {
-  const isOrgManager = useSelector(
+  const isOrgManager = useTypedSelector(
     (state) => state.auth.organisations && state.auth.organisations.length > 0,
   );
 

--- a/frontend/src/components/user/avatar.tsx
+++ b/frontend/src/components/user/avatar.tsx
@@ -1,15 +1,14 @@
 import { Link } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 
 import { ProfilePictureIcon, CloseIcon } from '../svgIcons';
 import { getRandomArrayItem } from '../../utils/random';
 import { useAvatarStyle } from '../../hooks/UseAvatarStyle';
 import { useAvatarText } from '../../hooks/UseAvatarText';
 import { HtmlHTMLAttributes } from 'react';
-import { RootStore } from '../../store';
 
 export const CurrentUserAvatar = (props: HtmlHTMLAttributes<any>) => {
-  const userPicture = useSelector((state: RootStore) => state.auth.userDetails?.pictureUrl);
+  const userPicture = useTypedSelector((state) => state.auth.userDetails?.pictureUrl);
   if (userPicture) {
     return (
       <div

--- a/frontend/src/components/user/content.jsx
+++ b/frontend/src/components/user/content.jsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { Link } from 'react-router-dom';
 import { FormattedMessage, FormattedNumber, FormattedRelativeTime } from 'react-intl';
 import { selectUnit } from '../../utils/selectUnit';
@@ -37,7 +37,7 @@ export function APIKeyCard({ token }) {
 }
 
 export function OSMCard({ username }) {
-  const osmUserInfo = useSelector((state) => state.auth.osm);
+  const osmUserInfo = useTypedSelector((state) => state.auth.osm);
   const { value, unit } = selectUnit(
     osmUserInfo ? new Date(osmUserInfo.accountCreated) : new Date(),
   );

--- a/frontend/src/components/user/forms/interests.jsx
+++ b/frontend/src/components/user/forms/interests.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { FormattedMessage } from 'react-intl';
 
 import messages from '../messages';
@@ -8,8 +8,8 @@ import { InterestsList } from '../../formInputs';
 import { fetchLocalJSONAPI, pushToLocalJSONAPI } from '../../../network/genericJSONRequest';
 
 export function UserInterestsForm() {
-  const token = useSelector((state) => state.auth.token);
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   const [interests, setInterests] = useState([]);
   const [enableSaveButton, setEnableSaveButton] = useState(false);
   const [success, setSuccess] = useState(null);

--- a/frontend/src/components/user/list.jsx
+++ b/frontend/src/components/user/list.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { FormattedMessage } from 'react-intl';
 import ReactPlaceholder from 'react-placeholder';
 import toast from 'react-hot-toast';
@@ -144,9 +144,9 @@ export const SearchNav = ({ filters, setFilters, initialFilters }) => {
 };
 
 export const UsersTable = ({ filters, setFilters }) => {
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const [response, setResponse] = useState(null);
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 

--- a/frontend/src/components/user/topBar.jsx
+++ b/frontend/src/components/user/topBar.jsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 import ReactPlaceholder from 'react-placeholder';
 import { TextRow } from 'react-placeholder/lib/placeholders';
@@ -42,8 +42,8 @@ export function NextMappingLevel({ changesetsCount }) {
 }
 
 export function UserTopBar() {
-  const user = useSelector((state) => state.auth.userDetails);
-  const osmUserInfo = useSelector((state) => state.auth.osm);
+  const user = useTypedSelector((state) => state.auth.userDetails);
+  const osmUserInfo = useTypedSelector((state) => state.auth.osm);
 
   const placeholder = (
     <div className="pl2 dib">

--- a/frontend/src/components/userDetail/headerProfile.jsx
+++ b/frontend/src/components/userDetail/headerProfile.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import messages from '../user/messages';
@@ -125,7 +125,7 @@ export const MyContributionsNav = ({ username, authUser }) => {
 };
 
 export const HeaderProfile = ({ userDetails, changesets, selfProfile }) => {
-  const authDetails = useSelector((state) => state.auth.userDetails);
+  const authDetails = useTypedSelector((state) => state.auth.userDetails);
   const [user, setUser] = useState({});
 
   useEffect(() => {

--- a/frontend/src/hooks/UseFetch.ts
+++ b/frontend/src/hooks/UseFetch.ts
@@ -1,13 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 
 import { fetchLocalJSONAPI, fetchLocalJSONAPIWithAbort } from '../network/genericJSONRequest';
 import { useInterval } from './UseInterval';
-import { RootStore } from '../store';
 
 export const useFetch = (url: string, trigger: boolean = true) => {
-  const token = useSelector((state: RootStore) => state.auth.token);
-  const locale = useSelector((state: RootStore) => state.preferences['locale']);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences['locale']);
   const [error, setError] = useState<null | string>(null);
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<unknown>({});
@@ -39,8 +38,8 @@ export const useFetch = (url: string, trigger: boolean = true) => {
 };
 
 export const useFetchWithAbort = <T extends object>(url: string, trigger: boolean = true) => {
-  const token = useSelector((state: RootStore) => state.auth.token);
-  const locale = useSelector((state: RootStore) => state.preferences['locale']);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences['locale']);
   const [error, setError] = useState<null | string>(null);
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<T | null>(null);
@@ -85,8 +84,8 @@ export const useFetchWithAbort = <T extends object>(url: string, trigger: boolea
 };
 
 export function useFetchIntervaled(url: string, delay: number, trigger = true) {
-  const token = useSelector((state: RootStore) => state.auth.token);
-  const locale = useSelector((state: RootStore) => state.preferences['locale']);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences['locale']);
   const [data, setData] = useState();
   const [error, setError] = useState<null | string>(null);
 

--- a/frontend/src/hooks/UseHasLiveMonitoringFeature.js
+++ b/frontend/src/hooks/UseHasLiveMonitoringFeature.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useParams } from 'react-router-dom';
 
 import { useProjectQuery } from '../api/projects';
@@ -13,7 +13,7 @@ import { useAvailableCountriesQuery } from '../api/projects';
  */
 export default function useHasLiveMonitoringFeature() {
   const { id: projectId } = useParams();
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   const [hasLiveMonitoringFeature, setHasLiveMonitoringFeature] = useState(null);
 
   const { data: project } = useProjectQuery(projectId);

--- a/frontend/src/hooks/UseInboxQueryAPI.js
+++ b/frontend/src/hooks/UseInboxQueryAPI.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 import { useQueryParams, StringParam, NumberParam } from 'use-query-params';
 import queryString from 'query-string';
 import axios from 'axios';
@@ -61,10 +61,10 @@ export const useInboxQueryAPI = (
 ) => {
   const throttledExternalQueryParamsState = useThrottle(ExternalQueryParamsState, 1500);
   /* Get the user bearer token from the Redux store */
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
 
-  const state = useSelector((state) => state.notifications);
-  const dispatch = useDispatch();
+  const state = useTypedSelector((state) => state.notifications);
+  const dispatch = useTypedDispatch();
 
   useEffect(() => {
     let didCancel = false;

--- a/frontend/src/hooks/UseLockedTasks.js
+++ b/frontend/src/hooks/UseLockedTasks.js
@@ -1,16 +1,16 @@
 import { useCallback } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 
 import { fetchLocalJSONAPI } from '../network/genericJSONRequest';
 
 export const useGetLockedTasks = (taskId) => {
-  const lockedTasks = useSelector((state) => state.lockedTasks);
+  const lockedTasks = useTypedSelector((state) => state.lockedTasks);
   return lockedTasks;
 };
 
 export const useFetchLockedTasks = () => {
-  const token = useSelector((state) => state.auth.token);
-  const dispatch = useDispatch();
+  const token = useTypedSelector((state) => state.auth.token);
+  const dispatch = useTypedDispatch();
   const memoCallback = useCallback(async () => {
     if (token) {
       const lockedTasks = await fetchLocalJSONAPI('users/queries/tasks/locked/', token);
@@ -23,7 +23,7 @@ export const useFetchLockedTasks = () => {
 };
 
 export const useClearLockedTasks = () => {
-  const dispatch = useDispatch();
+  const dispatch = useTypedDispatch();
   const memoCallback = useCallback(() => {
     dispatch({ type: 'SET_LOCKED_TASKS', tasks: [] });
     dispatch({ type: 'SET_PROJECT', project: null });

--- a/frontend/src/hooks/UseMapboxSupportedLanguage.js
+++ b/frontend/src/hooks/UseMapboxSupportedLanguage.js
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import MapboxLanguage from '@mapbox/mapbox-gl-language';
 
 const { supportedLanguages } = new MapboxLanguage();
@@ -12,7 +12,7 @@ const defaultLocale = 'en';
  *
  */
 export default function useMapboxSupportedLanguage() {
-  const locale = useSelector((state) => state.preferences.locale);
+  const locale = useTypedSelector((state) => state.preferences.locale);
 
   if (!locale) return defaultLocale;
 

--- a/frontend/src/hooks/UseOrgYearStats.js
+++ b/frontend/src/hooks/UseOrgYearStats.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { startOfYear, format, startOfToday, parse } from 'date-fns';
 
 import { fetchLocalJSONAPI } from '../network/genericJSONRequest';
@@ -27,7 +27,7 @@ export function useIsOrgYearQuery(query) {
 export function useCurrentYearStats(organisationId, query, stats) {
   const isOrgYearQuery = useIsOrgYearQuery(query);
   const [yearStats, setYearStats] = useState([]);
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
 
   useEffect(() => {
     if (!isOrgYearQuery) {

--- a/frontend/src/hooks/UsePermissions.js
+++ b/frontend/src/hooks/UsePermissions.js
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 
 export function useEditProjectAllowed(project) {
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const organisations = useSelector((state) => state.auth.organisations);
-  const pmTeams = useSelector((state) => state.auth.pmTeams);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const organisations = useTypedSelector((state) => state.auth.organisations);
+  const pmTeams = useTypedSelector((state) => state.auth.pmTeams);
   const [isAllowed, setIsAllowed] = useState(false);
 
   useEffect(() => {
@@ -27,9 +27,9 @@ export function useEditProjectAllowed(project) {
 }
 
 export function useEditTeamAllowed(team) {
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const organisations = useSelector((state) => state.auth.organisations);
-  const pmTeams = useSelector((state) => state.auth.pmTeams);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const organisations = useTypedSelector((state) => state.auth.organisations);
+  const pmTeams = useTypedSelector((state) => state.auth.pmTeams);
   const [isAllowed, setIsAllowed] = useState(false);
 
   useEffect(() => {
@@ -54,8 +54,8 @@ export function useEditTeamAllowed(team) {
 }
 
 export function useEditOrgAllowed(org) {
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const organisations = useSelector((state) => state.auth.organisations);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const organisations = useTypedSelector((state) => state.auth.organisations);
   const [isAllowed, setIsAllowed] = useState(false);
 
   useEffect(() => {

--- a/frontend/src/hooks/UseProjectsQueryAPI.js
+++ b/frontend/src/hooks/UseProjectsQueryAPI.js
@@ -1,5 +1,5 @@
 import { useEffect, useReducer } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import {
   useQueryParams,
   encodeQueryParams,
@@ -124,9 +124,9 @@ export const useProjectsQueryAPI = (
   const throttledExternalQueryParamsState = useThrottle(ExternalQueryParamsState, 1500);
 
   /* Get the user bearer token from the Redux store */
-  const token = useSelector((state) => state.auth.token);
-  const locale = useSelector((state) => state.preferences['locale']);
-  const action = useSelector((state) => state.preferences['action']);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences['locale']);
+  const action = useTypedSelector((state) => state.preferences['action']);
 
   const [state, dispatch] = useReducer(dataFetchReducer, {
     isLoading: true,

--- a/frontend/src/hooks/UseTagAPI.js
+++ b/frontend/src/hooks/UseTagAPI.js
@@ -1,5 +1,5 @@
 import { useEffect, useReducer } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import axios from 'axios';
 
 import { API_URL } from '../config';
@@ -32,8 +32,8 @@ const dataFetchReducer = (state, action) => {
 };
 
 export const useTagAPI = (initialData, tagType, processDataFn) => {
-  const token = useSelector((state) => state.auth.token);
-  const locale = useSelector((state) => state.preferences.locale);
+  const token = useTypedSelector((state) => state.auth.token);
+  const locale = useTypedSelector((state) => state.preferences.locale);
   const [state, dispatch] = useReducer(dataFetchReducer, {
     isLoading: true,
     isError: false,

--- a/frontend/src/hooks/UseTaskContributionAPI.js
+++ b/frontend/src/hooks/UseTaskContributionAPI.js
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useEffect, useReducer } from 'react';
 import axios from 'axios';
 
@@ -101,8 +101,8 @@ export const useTaskContributionAPI = (
   const throttledExternalQueryParamsState = useThrottle(ExternalQueryParamsState, 1500);
 
   /* Get the user bearer token from the Redux store */
-  const token = useSelector((state) => state.auth.token);
-  const user_id = useSelector((state) => state.auth.userDetails && state.auth.userDetails?.id);
+  const token = useTypedSelector((state) => state.auth.token);
+  const user_id = useTypedSelector((state) => state.auth.userDetails && state.auth.userDetails?.id);
 
   const [state, dispatch] = useReducer(dataFetchReducer, {
     isLoading: true,

--- a/frontend/src/hooks/UseTasksStatsQueryAPI.js
+++ b/frontend/src/hooks/UseTasksStatsQueryAPI.js
@@ -1,5 +1,5 @@
 import { useEffect, useReducer } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import {
   useQueryParams,
   encodeQueryParams,
@@ -85,7 +85,7 @@ export const useTasksStatsQueryAPI = (
   extraQuery = '',
 ) => {
   const throttledExternalQueryParamsState = useThrottle(ExternalQueryParamsState, 1500);
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const controller = new AbortController();
 
   const [state, dispatch] = useReducer(dataFetchReducer, {

--- a/frontend/src/hooks/UseUploadImage.ts
+++ b/frontend/src/hooks/UseUploadImage.ts
@@ -1,9 +1,8 @@
 import { useState, useCallback } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 
 import { pushToLocalJSONAPI } from '../network/genericJSONRequest';
 import { slugifyFileName } from '../utils/slugifyFileName';
-import { RootStore } from '../store';
 
 export const useUploadImage = () => {
   const [uploading, setUploading] = useState(false);
@@ -52,7 +51,7 @@ export const useUploadImage = () => {
 };
 
 export const useOnDrop = (appendImgToComment: string) => {
-  const token = useSelector((state: RootStore) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const [uploadError, uploading, uploadImg] = useUploadImage();
 
   const onDrop = useCallback(

--- a/frontend/src/store/hooks/index.ts
+++ b/frontend/src/store/hooks/index.ts
@@ -1,0 +1,6 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import { RootState, AppDispatch } from '..';
+
+export const useTypedDispatch = () => useDispatch<AppDispatch>();
+
+export const useTypedSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -40,4 +40,3 @@ export { store, persistor };
 
 export type AppDispatch = typeof store.dispatch;
 export type RootState = ReturnType<typeof store.getState>;
-

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -37,3 +37,7 @@ store.subscribe(() => {
 });
 
 export { store, persistor };
+
+export type AppDispatch = typeof store.dispatch;
+export type RootState = ReturnType<typeof store.getState>;
+

--- a/frontend/src/views/authorized.tsx
+++ b/frontend/src/views/authorized.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
+import { useTypedDispatch } from '@Store/hooks';
 import { setAuthDetails } from '../store/actions/auth';
 
 export function Authorized(props) {
   const navigate = useNavigate();
   const location = useLocation();
-  const dispatch = useDispatch();
+  const dispatch = useTypedDispatch();
   const [isReadyToRedirect, setIsReadyToRedirect] = useState(false);
 
   useEffect(() => {

--- a/frontend/src/views/campaigns.jsx
+++ b/frontend/src/views/campaigns.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { Form } from 'react-final-form';
@@ -37,7 +37,7 @@ export const CampaignError = ({ error }) => {
 
 export function ListCampaigns() {
   useSetTitleTag('Manage campaigns');
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   // TO DO: filter teams of current user
   const [error, loading, campaigns] = useFetch(`campaigns/`);
   const isCampaignsFetched = !loading && !error;
@@ -54,7 +54,7 @@ export function ListCampaigns() {
 export function CreateCampaign() {
   useSetTitleTag('Create new campaign');
   const navigate = useNavigate();
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const [isError, setIsError] = useState(false);
 
   const createCampaign = (payload) => {
@@ -124,8 +124,8 @@ export function CreateCampaign() {
 
 export function EditCampaign() {
   const { id } = useParams();
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
   const [error, loading, campaign] = useFetch(`campaigns/${id}/`, id);
   useSetTitleTag(`Edit ${campaign.name}`);
   const [projectsError, projectsLoading, projects] = useFetch(

--- a/frontend/src/views/contributions.jsx
+++ b/frontend/src/views/contributions.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 
 import useForceUpdate from '../hooks/UseForceUpdate';
 import {
@@ -27,7 +27,7 @@ export const ContributionsPage = () => {
   };
 
   const location = useLocation();
-  const userToken = useSelector((state) => state.auth.token);
+  const userToken = useTypedSelector((state) => state.auth.token);
   //eslint-disable-next-line
   const [contributionsQuery, setContributionsQuery] = useTaskContributionQueryParams();
   const [forceUpdated, forceUpdate] = useForceUpdate();
@@ -71,7 +71,7 @@ export const ContributionsPageIndex = (props) => {
 
 export const UserStats = () => {
   useSetTitleTag('My stats');
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
 
   return <UserDetail username={userDetails?.username} withHeader={false} />;
 };

--- a/frontend/src/views/interests.jsx
+++ b/frontend/src/views/interests.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useFetch } from '../hooks/UseFetch';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { Form } from 'react-final-form';
@@ -19,7 +19,7 @@ import { EntityError } from '../components/alert';
 export const CreateInterest = () => {
   useSetTitleTag('Create new category');
   const navigate = useNavigate();
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const [isError, setIsError] = useState(false);
 
   const createInterest = (payload) => {
@@ -89,7 +89,7 @@ export const CreateInterest = () => {
 
 export const ListInterests = () => {
   useSetTitleTag('Manage categories');
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   // TO DO: filter teams of current user
   const [error, loading, interests] = useFetch(`interests/`);
   const isInterestsFetched = !loading && !error;
@@ -105,8 +105,8 @@ export const ListInterests = () => {
 
 export const EditInterest = () => {
   const { id } = useParams();
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
   const [isError, setIsError] = useState(false);
   const [error, loading, interest] = useFetch(`interests/${id}/`);
   useSetTitleTag(`Edit ${interest.name}`);

--- a/frontend/src/views/licenses.jsx
+++ b/frontend/src/views/licenses.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useFetch } from '../hooks/UseFetch';
 import { useSetTitleTag } from '../hooks/UseMetaTags';
 import { Link, useNavigate, useParams } from 'react-router-dom';
@@ -17,8 +17,8 @@ import { EntityError } from '../components/alert';
 
 export const EditLicense = () => {
   const { id } = useParams();
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
   const [error, loading, license] = useFetch(`licenses/${id}/`);
   const [isError, setIsError] = useState(false);
   useSetTitleTag(`Edit ${license.name}`);
@@ -52,7 +52,7 @@ export const EditLicense = () => {
 
 export const ListLicenses = () => {
   useSetTitleTag('Manage licenses');
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   // TO DO: filter teams of current user
   const [error, loading, licenses] = useFetch(`licenses/`);
   const isLicensesFetched = !loading && !error;
@@ -69,7 +69,7 @@ export const ListLicenses = () => {
 export const CreateLicense = () => {
   useSetTitleTag('Create new license');
   const navigate = useNavigate();
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const [isError, setIsError] = useState(false);
 
   const createLicense = (payload) => {

--- a/frontend/src/views/login.jsx
+++ b/frontend/src/views/login.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 
@@ -13,7 +13,7 @@ export function Login({ redirectTo }) {
   useSetTitleTag('Login');
   const navigate = useNavigate();
   const location = useLocation();
-  const userIsloggedIn = useSelector((state) => state.auth.token);
+  const userIsloggedIn = useTypedSelector((state) => state.auth.token);
 
   useEffect(() => {
     if (userIsloggedIn) {

--- a/frontend/src/views/management.jsx
+++ b/frontend/src/views/management.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { FormattedMessage } from 'react-intl';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
@@ -12,7 +12,7 @@ import { useSetTitleTag } from '../hooks/UseMetaTags';
 
 export function ManagementPageIndex() {
   useSetTitleTag('Manage');
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   const [projectsError, projectsLoading, projects] = useFetch(
     `projects/?managedByMe=true&omitMapResults=true`,
   );
@@ -42,9 +42,9 @@ export function ManagementPageIndex() {
 export const ManagementSection = (props) => {
   const location = useLocation();
   const navigate = useNavigate();
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
-  const isOrgManager = useSelector(
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
+  const isOrgManager = useTypedSelector(
     (state) => state.auth.organisations && state.auth.organisations.length > 0,
   );
 

--- a/frontend/src/views/notifications.jsx
+++ b/frontend/src/views/notifications.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 
 import { useInboxQueryParams } from '../hooks/UseInboxQueryAPI';
 import { InboxNav, InboxNavMini, InboxNavMiniBottom } from '../components/notifications/inboxNav';
@@ -59,7 +59,7 @@ export const NotificationsPage = () => {
   useSetTitleTag('Notifications');
   const navigate = useNavigate();
   const location = useLocation();
-  const userToken = useSelector((state) => state.auth.token);
+  const userToken = useTypedSelector((state) => state.auth.token);
   const [inboxQuery, setInboxQuery] = useInboxQueryParams();
   const { data: notifications, isError, isLoading, refetch } = useNotificationsQuery(inboxQuery);
 

--- a/frontend/src/views/organisationManagement.jsx
+++ b/frontend/src/views/organisationManagement.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import ReactPlaceholder from 'react-placeholder';
 import { FormattedMessage } from 'react-intl';
@@ -29,9 +29,9 @@ import { updateEntity } from '../utils/management';
 
 export function ListOrganisations() {
   useSetTitleTag('Manage organizations');
-  const token = useSelector((state) => state.auth.token);
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const isOrgManager = useSelector(
+  const token = useTypedSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const isOrgManager = useTypedSelector(
     (state) => state.auth.organisations && state.auth.organisations.length > 0,
   );
   const [organisations, setOrganisations] = useState(null);
@@ -75,8 +75,8 @@ export function ListOrganisations() {
 export function CreateOrganisation() {
   useSetTitleTag('Create new organization');
   const navigate = useNavigate();
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
   const {
     members: managers,
     setMembers: setManagers,
@@ -168,8 +168,8 @@ export function CreateOrganisation() {
 
 export function EditOrganisation() {
   const { id } = useParams();
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
   const [initManagers, setInitManagers] = useState(false);
   const {
     members: managers,

--- a/frontend/src/views/organisationStats.jsx
+++ b/frontend/src/views/organisationStats.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useNavigate, useParams } from 'react-router-dom';
 import ReactPlaceholder from 'react-placeholder';
 import { FormattedMessage } from 'react-intl';
@@ -18,8 +18,8 @@ import { OrganisationProjectStats } from '../components/teamsAndOrgs/organisatio
 export const OrganisationStats = () => {
   const navigate = useNavigate();
   const { id } = useParams();
-  const token = useSelector((state) => state.auth.token);
-  const isOrgManager = useSelector(
+  const token = useTypedSelector((state) => state.auth.token);
+  const isOrgManager = useTypedSelector(
     (state) =>
       state.auth.userDetails?.role === 'ADMIN' || state.auth.organisations?.includes(Number(id)),
   );

--- a/frontend/src/views/partnersManagement.jsx
+++ b/frontend/src/views/partnersManagement.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import ReactPlaceholder from 'react-placeholder';
 import { FormattedMessage } from 'react-intl';
@@ -24,8 +24,8 @@ import '../components/partners/styles.scss';
 export function ListPartners() {
   useSetTitleTag('Manage partners');
   const navigate = useNavigate();
-  const token = useSelector((state) => state.auth.token);
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   const [partners, setPartners] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -57,8 +57,8 @@ export function ListPartners() {
 export function CreatePartner() {
   useSetTitleTag('Create new partner');
   const navigate = useNavigate();
-  const token = useSelector((state) => state.auth.token);
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   const [error, setError] = useState(null);
   const createPartner = (payload) => {
     pushToLocalJSONAPI('partners/', JSON.stringify(payload), token, 'POST')
@@ -152,8 +152,8 @@ export function CreatePartner() {
 
 export function EditPartners() {
   const { id } = useParams();
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
 
   const [error, loading, partner] = useFetch(`partners/${id}/`, id);
 

--- a/frontend/src/views/project.jsx
+++ b/frontend/src/views/project.jsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy, useEffect, useState, useLayoutEffect, useRef } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import ReactPlaceholder from 'react-placeholder';
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom';
 import PropTypes from 'prop-types';
@@ -42,10 +42,10 @@ export const CreateProject = () => {
 export const ProjectsPage = () => {
   useSetTitleTag('Explore projects');
   const { pathname } = useLocation();
-  const action = useSelector((state) => state.preferences['action']);
+  const action = useTypedSelector((state) => state.preferences['action']);
   const [fullProjectsQuery, setProjectQuery] = useExploreProjectsQueryParams();
-  const isMapShown = useSelector((state) => state.preferences['mapShown']);
-  const isExploreProjectsTableView = useSelector(
+  const isMapShown = useTypedSelector((state) => state.preferences['mapShown']);
+  const isExploreProjectsTableView = useTypedSelector(
     (state) => state.preferences['isExploreProjectsTableView'],
   );
   const searchResultWidth = isMapShown ? 'two-column' : 'one-column';
@@ -100,10 +100,10 @@ export const UserProjectsPage = ({ management }) => {
   const location = useLocation();
   const navigate = useNavigate();
   useSetTitleTag(management ? 'Manage projects' : 'My projects');
-  const userToken = useSelector((state) => state.auth.token);
+  const userToken = useTypedSelector((state) => state.auth.token);
 
   const [fullProjectsQuery, setProjectQuery] = useExploreProjectsQueryParams();
-  const isMapShown = useSelector((state) => state.preferences['mapShown']);
+  const isMapShown = useTypedSelector((state) => state.preferences['mapShown']);
   const searchResultWidth = isMapShown ? 'two-column' : 'one-column';
 
   const { data: projects, status, refetch } = useProjectsQuery(fullProjectsQuery);

--- a/frontend/src/views/projectEdit.jsx
+++ b/frontend/src/views/projectEdit.jsx
@@ -1,5 +1,5 @@
 import { createContext, useState, useLayoutEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useParams } from 'react-router-dom';
 import ReactPlaceholder from 'react-placeholder';
 import { FormattedMessage } from 'react-intl';
@@ -69,7 +69,7 @@ export function ProjectEdit() {
   useSetTitleTag(`Edit project #${id}`);
   const [errorLanguages, loadingLanguages, languages] = useFetch('system/languages/');
   const mandatoryFields = ['name', 'shortDescription', 'description', 'instructions'];
-  const token = useSelector((state) => state.auth.token);
+  const token = useTypedSelector((state) => state.auth.token);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
   const [option, setOption] = useState('description');

--- a/frontend/src/views/projectLiveMonitoring.jsx
+++ b/frontend/src/views/projectLiveMonitoring.jsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import ReactPlaceholder from 'react-placeholder';
 import Select from 'react-select';
 import { useNavigate, useParams, Link } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
+import { useTypedDispatch } from '@Store/hooks';
 import centroid from '@turf/centroid';
 import {
   UnderpassFeatureList,
@@ -31,7 +31,7 @@ const availableImageryValues = availableImageryOptions.map((item) => item.value)
 
 export function ProjectLiveMonitoring() {
   const { id } = useParams();
-  const dispatch = useDispatch();
+  const dispatch = useTypedDispatch();
   const navigate = useNavigate();
   const [coords, setCoords] = useState([0, 0]);
   const [activeFeature, setActiveFeature] = useState(null);

--- a/frontend/src/views/settings.jsx
+++ b/frontend/src/views/settings.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useNavigate } from 'react-router-dom';
 
 import { UserTopBar } from '../components/user/topBar';
@@ -13,8 +13,8 @@ import { useSetTitleTag } from '../hooks/UseMetaTags';
 export function Settings() {
   useSetTitleTag(`Settings`);
   const navigate = useNavigate();
-  const token = useSelector((state) => state.auth.token);
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
 
   useEffect(() => {
     if (!token) {

--- a/frontend/src/views/taskAction.jsx
+++ b/frontend/src/views/taskAction.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useQueryParam, StringParam } from 'use-query-params';
 import { FormattedMessage } from 'react-intl';
@@ -24,8 +24,8 @@ export function ValidateTask() {
 
 export function TaskAction({ projectId, action }) {
   const navigate = useNavigate();
-  const dispatch = useDispatch();
-  const token = useSelector((state) => state.auth.token);
+  const dispatch = useTypedDispatch();
+  const token = useTypedSelector((state) => state.auth.token);
   // eslint-disable-next-line
   const [editor, setEditor] = useQueryParam('editor', StringParam);
 

--- a/frontend/src/views/taskSelection.tsx
+++ b/frontend/src/views/taskSelection.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 
 import { TaskSelection } from '../components/taskSelection';
@@ -7,7 +7,6 @@ import { NotFound } from './notFound';
 import { useProjectSummaryQuery, useProjectQuery } from '../api/projects';
 import { Preloader } from '../components/preloader';
 import PrivateProjectError from '../components/projectDetail/privateProjectError';
-import { RootStore } from '../store';
 
 const publicRoutes = ['/instructions'];
 
@@ -15,7 +14,7 @@ export function SelectTask() {
   const { id } = useParams();
   const { pathname } = useLocation();
   const navigate = useNavigate();
-  const token = useSelector((state: RootStore) => state?.auth.token);
+  const token = useTypedSelector((state) => state?.auth.token);
   const {
     data: projectSummaryData,
     error: projectSummaryError,

--- a/frontend/src/views/teams.jsx
+++ b/frontend/src/views/teams.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { Link, useNavigate, useParams, useLocation } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { Form } from 'react-final-form';
@@ -60,7 +60,7 @@ export function MyTeams() {
 }
 
 export function ListTeams({ managementView = false }) {
-  const userDetails = useSelector((state) => state.auth.userDetails);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
   const [query, setQuery] = useQueryParams({
     page: withDefault(NumberParam, 1),
     showAll: BooleanParam,
@@ -132,8 +132,8 @@ const leaveTeamRequest = (team_id, username, role, token) => {
 export function CreateTeam() {
   useSetTitleTag('Create new team');
   const navigate = useNavigate();
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
   const {
     members: managers,
     setMembers: setManagers,
@@ -234,8 +234,8 @@ export function CreateTeam() {
 
 export function EditTeam(props) {
   const { id } = useParams();
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
   const [forceUpdated, forceUpdate] = useForceUpdate();
   const [error, loading, team] = useFetch(`teams/${id}/`, forceUpdated);
   const [initManagers, setInitManagers] = useState(false);
@@ -425,8 +425,8 @@ export function TeamDetail() {
   useSetTitleTag(`Team #${id}`);
   const location = useLocation();
   const navigate = useNavigate();
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const token = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
   const [error, loading, team] = useFetch(`teams/${id}/`);
   // eslint-disable-next-line
   const [projectsError, projectsLoading, projects] = useFetch(

--- a/frontend/src/views/userDetail.jsx
+++ b/frontend/src/views/userDetail.jsx
@@ -1,6 +1,6 @@
 import { lazy, useEffect, useState, Suspense } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { FormattedMessage } from 'react-intl';
 import ReactPlaceholder from 'react-placeholder';
 
@@ -24,12 +24,12 @@ const TopCauses = lazy(() =>
 
 export const UserDetail = ({ withHeader = true }) => {
   const navigate = useNavigate();
-  const loggedInUsername = useSelector((state) => state.auth.userDetails?.username);
+  const loggedInUsername = useTypedSelector((state) => state.auth.userDetails?.username);
   const { username: usernameParam } = useParams();
   const username = usernameParam || loggedInUsername;
   useSetTitleTag(username);
-  const token = useSelector((state) => state.auth.token);
-  const currentUser = useSelector((state) => state.auth.userDetails);
+  const token = useTypedSelector((state) => state.auth.token);
+  const currentUser = useTypedSelector((state) => state.auth.userDetails);
   const [userOsmDetails, setUserOsmDetails] = useState({});
   const [errorDetails, loadingDetails, userDetails] = useFetch(
     `users/queries/${username}/`,

--- a/frontend/src/views/welcome.jsx
+++ b/frontend/src/views/welcome.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useTypedSelector } from '@Store/hooks';
 import { useNavigate } from 'react-router-dom';
 import ReactPlaceholder from 'react-placeholder';
 import 'react-placeholder/lib/reactPlaceholder.css';
@@ -67,8 +67,8 @@ function NewContributor({ username, userIsloggedIn }) {
 export function Welcome() {
   useSetTitleTag('Welcome');
   const navigate = useNavigate();
-  const userDetails = useSelector((state) => state.auth.userDetails);
-  const userIsloggedIn = useSelector((state) => state.auth.token);
+  const userDetails = useTypedSelector((state) => state.auth.userDetails);
+  const userIsloggedIn = useTypedSelector((state) => state.auth.token);
   const completeness = calculateCompleteness(userDetails);
 
   useEffect(() => {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -25,6 +25,18 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
     "types": ["vitest/globals", "@testing-library/jest-dom/vitest"],
+    "baseUrl": "./src/",
+    "paths": {
+      "@Api/*": ["api/*"],
+      "@Assets/*": ["assets/*"],
+      "@Components/*": ["components/*"],
+      "@Config/*": ["config/*"],
+      "@Hooks/*": ["hooks/*"],
+      "@Network/*": ["network/*"],
+      "@Store/*": ["store/*"],
+      "@Utils/*": ["utils/*"],
+      "@Views/*": ["views/*"]
+    }
   },
   "include": [
     "src"

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,26 +1,12 @@
 // vite.config.js
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
+import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsconfigPaths()],
   envPrefix: 'REACT_APP_',
   server: {
     port: 3000
-  },
-  resolve: {
-    extensions: ['.js', '.jsx', '.ts', '.tsx'],
-    alias: {
-      '@': new URL('./src/', import.meta.url).pathname,
-      '@Api': new URL('./src/api/', import.meta.url).pathname,
-      '@Assets': new URL('./src/assets/', import.meta.url).pathname,
-      '@Components': new URL('./src/components/', import.meta.url).pathname,
-      '@Config': new URL('./src/config/', import.meta.url).pathname,
-      '@Hooks': new URL('./src/hooks/', import.meta.url).pathname,
-      '@Network': new URL('./src/network/', import.meta.url).pathname,
-      '@Store': new URL('./src/store/', import.meta.url).pathname,
-      '@Utils': new URL('./src/utils/', import.meta.url).pathname,
-      '@Views': new URL('./src/views/', import.meta.url).pathname
-    },
   },
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,5 +7,20 @@ export default defineConfig({
   envPrefix: 'REACT_APP_',
   server: {
     port: 3000
-  }
+  },
+  resolve: {
+    extensions: ['.js', '.jsx', '.ts', '.tsx'],
+    alias: {
+      '@': new URL('./src/', import.meta.url).pathname,
+      '@Api': new URL('./src/api/', import.meta.url).pathname,
+      '@Assets': new URL('./src/assets/', import.meta.url).pathname,
+      '@Components': new URL('./src/components/', import.meta.url).pathname,
+      '@Config': new URL('./src/config/', import.meta.url).pathname,
+      '@Hooks': new URL('./src/hooks/', import.meta.url).pathname,
+      '@Network': new URL('./src/network/', import.meta.url).pathname,
+      '@Store': new URL('./src/store/', import.meta.url).pathname,
+      '@Utils': new URL('./src/utils/', import.meta.url).pathname,
+      '@Views': new URL('./src/views/', import.meta.url).pathname
+    },
+  },
 });

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,29 +1,16 @@
 // vitest.config.ts
 import react from '@vitejs/plugin-react-swc'
 import { defineConfig } from 'vitest/config'
+import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsconfigPaths()],
   test: {
     globals: true,
     clearMocks: true,
     setupFiles: ['./src/setup.ts', './src/network/tests/server.ts'],
     environment: "happy-dom",
     testTimeout: 20000
-  },
-  resolve: {
-    alias: {
-      '@': new URL('./src/', import.meta.url).pathname,
-      '@Api': new URL('./src/api/', import.meta.url).pathname,
-      '@Assets': new URL('./src/assets/', import.meta.url).pathname,
-      '@Components': new URL('./src/components/', import.meta.url).pathname,
-      '@Config': new URL('./src/config/', import.meta.url).pathname,
-      '@Hooks': new URL('./src/hooks/', import.meta.url).pathname,
-      '@Network': new URL('./src/network/', import.meta.url).pathname,
-      '@Store': new URL('./src/store/', import.meta.url).pathname,
-      '@Utils': new URL('./src/utils/', import.meta.url).pathname,
-      '@Views': new URL('./src/views/', import.meta.url).pathname
-    },
   },
   envPrefix: 'REACT_APP_'
 })

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -11,5 +11,19 @@ export default defineConfig({
     environment: "happy-dom",
     testTimeout: 20000
   },
-  envPrefix: 'REACT_APP_',
+  resolve: {
+    alias: {
+      '@': new URL('./src/', import.meta.url).pathname,
+      '@Api': new URL('./src/api/', import.meta.url).pathname,
+      '@Assets': new URL('./src/assets/', import.meta.url).pathname,
+      '@Components': new URL('./src/components/', import.meta.url).pathname,
+      '@Config': new URL('./src/config/', import.meta.url).pathname,
+      '@Hooks': new URL('./src/hooks/', import.meta.url).pathname,
+      '@Network': new URL('./src/network/', import.meta.url).pathname,
+      '@Store': new URL('./src/store/', import.meta.url).pathname,
+      '@Utils': new URL('./src/utils/', import.meta.url).pathname,
+      '@Views': new URL('./src/views/', import.meta.url).pathname
+    },
+  },
+  envPrefix: 'REACT_APP_'
 })

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7996,6 +7996,11 @@ globby@^11.0.4, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+globrex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
+
 goober@^2.1.10:
   version "2.1.14"
   resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.14.tgz#4a5c94fc34dc086a8e6035360ae1800005135acd"
@@ -13881,7 +13886,16 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13997,7 +14011,14 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -14524,6 +14545,11 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
+tsconfck@^3.0.3:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/tsconfck/-/tsconfck-3.1.4.tgz#de01a15334962e2feb526824339b51be26712229"
+  integrity sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==
+
 tsconfig-paths@^3.15.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz#5299ec605e55b1abb23ec939ef15edaf483070d4"
@@ -14999,6 +15025,15 @@ vite-node@2.1.8:
     es-module-lexer "^1.5.4"
     pathe "^1.1.2"
     vite "^5.0.0"
+
+vite-tsconfig-paths@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz#d9a71106a7ff2c1c840c6f1708042f76a9212ed4"
+  integrity sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==
+  dependencies:
+    debug "^4.1.1"
+    globrex "^0.1.2"
+    tsconfck "^3.0.3"
 
 vite@^5.0.0, vite@^5.4.2:
   version "5.4.11"
@@ -15627,7 +15662,7 @@ workbox-window@6.6.1:
     "@types/trusted-types" "^2.0.2"
     workbox-core "6.6.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15640,6 +15675,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## What type of PR is this?

- [x] 🧑‍💻 Refactor

## Describe this PR
The code changes in the PR will remove the requirement to specify type for redux state in each selector.
This results in better typescript code.

**Changes**
- Setup Typescript support for `useSelector` & `useDispatch` hooks
- Configure import path aliases for folders