### PR TITLE
fix: misfire gracetime removed from cron interval trigger

### DIFF
--- a/backend/cron_jobs.py
+++ b/backend/cron_jobs.py
@@ -117,7 +117,7 @@ async def setup_cron_jobs():
     )
     scheduler.add_job(
         update_all_project_stats,
-        CronTrigger(hour=0, minute=0, misfire_grace_time=300),
+        CronTrigger(hour=0, minute=0),
         id="update_project_stats",
         replace_existing=True,
     )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR
Misfire gracetime removed from cron interval trigger.