### PR TITLE
Fix Error Message not displaying issue in Create Project page

### DIFF
--- a/frontend/src/components/projectCreate/index.js
+++ b/frontend/src/components/projectCreate/index.js
@@ -179,7 +179,7 @@ const ProjectCreate = () => {
       };
     }
     setErr(err);
-  }, [metadata]);
+  }, [metadata.area]);
 
   const drawOptions = {
     displayControlsDefault: false,


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug Fix

## Related Issue

- Fixes #6644

## Describe this PR

This PR resolves "error message not displaying on error" in Create Project page.

## Screenshots
![image](https://github.com/user-attachments/assets/a7cb0f2f-49cb-4f59-b405-815b9ec298e2)

