### PR TITLE
Fix visual elements overlapping and intro text too small or gone with high zoom on project details page

### DIFF
--- a/frontend/src/components/projectDetail/styles.scss
+++ b/frontend/src/components/projectDetail/styles.scss
@@ -7,9 +7,9 @@
 }
 
 .tasks-map-height {
-  height: calc(100vh - 11.312rem); // Subtracting height of header, nav and fixed footer
+  min-height: calc(100vh - 11.312rem); // Subtracting height of header, nav and fixed footer
   @media screen and (max-width: 60em) {
-    height: 100%;
+    min-height: 100%;
   }
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Example: Fixes #6806 

## Describe this PR
On the project details page, the height of the container for the map and project details to the left of it was a fixed height so that the nav bar, footer, and this container would nicely take up all the view port height. Changing the fixed height to min height allows the container to still do this when the page is opened at normal zoom, but allows it to grow downward with very high zoom / scaling rather than disappearing the intro text and overlapping visual elements.

## Screenshots

## Before
At very high zoom, intro text is gone and visual elements overlap.
![image](https://github.com/user-attachments/assets/90120fc5-7d85-411a-8a30-5a95cd1a4290)

## After
At very high zoom, intro text is present and visual elements do not overlap.
![image](https://github.com/user-attachments/assets/7a938d44-4f77-462c-bdcb-ea3540b8d4aa)

## Normal Zoom
Maintains visual style with the container taking up 100% of vertical space minus the nav bar and footer.
![image](https://github.com/user-attachments/assets/a9b9e7d1-fd83-4763-8f9b-f64f4e8f1e2c)

## Review Guide

Go to a project at /projects/12345 and view the page with various devices, monitor scaling, zoom levels, etc.
