### PR TITLE
Fix:  Markdown Parsing In Project Card Component

### DIFF
--- a/frontend/src/components/projectCard/projectCard.js
+++ b/frontend/src/components/projectCard/projectCard.js
@@ -10,6 +10,7 @@ import { ProjectStatusBox } from '../projectDetail/statusBox';
 import { PROJECTCARD_CONTRIBUTION_SHOWN_THRESHOLD } from '../../config/index';
 import { PriorityBox } from './priorityBox';
 import { DueDateBox } from './dueDateBox';
+import { htmlFromMarkdown } from '../../utils/htmlFromMarkdown';
 import './styles.scss';
 
 export function ProjectTeaser({
@@ -126,7 +127,10 @@ export function ProjectCard({
               </h3>
               <div className="tc f6">
                 <div className="w-100 tl pr2 f7 blue-grey dib mb2 project-desc">
-                  {shortDescription} {campaignTag ? ' · ' + campaignTag : ''}
+                  {shortDescription?.trim() && (
+                    <div dangerouslySetInnerHTML={htmlFromMarkdown(shortDescription)} />
+                  )}
+                  {campaignTag ? ' · ' + campaignTag : ''}
                 </div>
               </div>
             </div>

--- a/frontend/src/components/projectCard/styles.scss
+++ b/frontend/src/components/projectCard/styles.scss
@@ -24,3 +24,8 @@
   -webkit-box-orient: vertical;
   line-height: 1.4;
 }
+
+.project-desc * {
+  font-size: inherit !important;
+  font-weight: inherit;
+}


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug Fix

## Related Issue

Fixes #6674 

## Describe this PR

This PR enables markdown rendering in the project card's short description and ensures rendered markdown elements inherit typography styles from parent's for consistent and structured content display.

## Screenshots
![2025-may-19--11-55-36](https://github.com/user-attachments/assets/dd324e94-0a50-4214-a4e1-5674fde4897f)
