### PR TITLE
Fix `Manage` section not displaying on smaller screen issue

### DIFF
--- a/frontend/src/components/header/index.js
+++ b/frontend/src/components/header/index.js
@@ -147,7 +147,7 @@ export const Header = () => {
                 <div>
                   <PopupItems
                     userDetails={userDetails}
-                    menuItems={getMenuItemsForUser(userDetails)}
+                    menuItems={getMenuItemsForUser(userDetails, organisations)}
                     linkCombo={linkCombo}
                     location={location}
                     close={close}


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug Fix

## Related Issue

- Resolves #6864

## Describe this PR

The PR addresses the issue related to `Manage section` not populating for organization admins in small screen.

## Screenshot
![image](https://github.com/user-attachments/assets/3336082f-065d-4d25-b767-68d32060238f)
 