### PR TITLE
Default changeset to discard previous default changeset comment when the project is cloned

### DIFF
--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -435,10 +435,21 @@ class Project(Base):
         if not orig:
             raise NotFound(sub_code="PROJECT_NOT_FOUND", project_id=project_id)
 
+        raw = orig.changeset_comment or ""
+
+        default_comment = settings.DEFAULT_CHANGESET_COMMENT
+        if default_comment:
+            old_prefix = f"{default_comment}-{project_id}"
+            leftover = raw.replace(old_prefix, "").strip()
+        else:
+            leftover = raw
+
         orig_metadata = dict(orig)
         items_to_remove = ["id", "allowed_users"]
         for item in items_to_remove:
             orig_metadata.pop(item, None)
+
+        orig_metadata["changeset_comment"] = leftover or None
 
         # Update metadata for the new project
         orig_metadata.update(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #6852

## Describe this PR

When the project was cloned, the new changeset included all the previous changeset comment including the original project's default changeset comment too which is now discarded in the cloned project.

