### PR TITLE
Align task data menu dropdown to the right

### DIFF
--- a/frontend/src/components/dropdown.js
+++ b/frontend/src/components/dropdown.js
@@ -175,7 +175,7 @@ export function Dropdown(props) {
           eventTypes={['click', 'touchend']}
           toggleDropdown={toggleDropdown}
           toTop={props.toTop}
-          toRight={props?.toRight}
+          toRight={props.toRight}
         />
       )}
     </div>

--- a/frontend/src/components/dropdown.js
+++ b/frontend/src/components/dropdown.js
@@ -52,7 +52,9 @@ const DropdownContent = forwardRef((props, ref) => {
       ref={ref}
       className={`db tl mt1 ba b--grey-light br1 absolute shadow-1 z-5 flex flex-column${
         props.toTop ? ' bottom-3' : ''
-      }${props.options.length > 9 ? ' h5 overflow-y-scroll' : ''}`}
+      }${props.options.length > 9 ? ' h5 overflow-y-scroll' : ''}${
+        props?.toRight ? 'right-0' : ''
+      }`}
     >
       {props.options.map((i, k) => (
         <span
@@ -173,6 +175,7 @@ export function Dropdown(props) {
           eventTypes={['click', 'touchend']}
           toggleDropdown={toggleDropdown}
           toTop={props.toTop}
+          toRight={props?.toRight}
         />
       )}
     </div>

--- a/frontend/src/components/dropdown.js
+++ b/frontend/src/components/dropdown.js
@@ -51,8 +51,8 @@ const DropdownContent = forwardRef((props, ref) => {
   return (
     <div
       ref={ref}
-      className={`db tl mt1 ba b--grey-light br1 absolute shadow-1 z-5 flex flex-column ${
-        props?.toRight ? 'right-0' : ''
+      className={`db tl mt1 ba b--grey-light br1 absolute shadow-1 z-5 flex flex-column${
+        props?.toRight ? ' right-0' : ''
       }${props.toTop ? ' bottom-3' : ''}${props.options.length > 9 ? ' h5 overflow-y-scroll' : ''}`}
     >
       {props.options.map((i, k) => (

--- a/frontend/src/components/dropdown.js
+++ b/frontend/src/components/dropdown.js
@@ -1,4 +1,4 @@
-import { createRef, forwardRef, useEffect, useState } from 'react';
+import { forwardRef, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { ChevronDownIcon, CheckIcon } from './svgIcons';
@@ -120,8 +120,8 @@ const DropdownContent = forwardRef((props, ref) => {
 export function Dropdown(props) {
   const [display, setDisplay] = useState(false);
 
-  const contentRef = createRef();
-  const buttonRef = createRef();
+  const contentRef = useRef();
+  const buttonRef = useRef();
 
   useEffect(() => {
     const handleClickOutside = (event) => {

--- a/frontend/src/components/dropdown.js
+++ b/frontend/src/components/dropdown.js
@@ -1,4 +1,5 @@
 import { createRef, forwardRef, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { ChevronDownIcon, CheckIcon } from './svgIcons';
 import { CustomButton } from './button';
@@ -50,11 +51,9 @@ const DropdownContent = forwardRef((props, ref) => {
   return (
     <div
       ref={ref}
-      className={`db tl mt1 ba b--grey-light br1 absolute shadow-1 z-5 flex flex-column${
-        props.toTop ? ' bottom-3' : ''
-      }${props.options.length > 9 ? ' h5 overflow-y-scroll' : ''}${
+      className={`db tl mt1 ba b--grey-light br1 absolute shadow-1 z-5 flex flex-column ${
         props?.toRight ? 'right-0' : ''
-      }`}
+      }${props.toTop ? ' bottom-3' : ''}${props.options.length > 9 ? ' h5 overflow-y-scroll' : ''}`}
     >
       {props.options.map((i, k) => (
         <span
@@ -175,9 +174,15 @@ export function Dropdown(props) {
           eventTypes={['click', 'touchend']}
           toggleDropdown={toggleDropdown}
           toTop={props.toTop}
-          toRight={props.toRight}
         />
       )}
     </div>
   );
 }
+
+DropdownContent.propTypes = {
+  toTop: PropTypes.bool,
+  toRight: PropTypes.bool,
+  toggleDropdown: PropTypes.func.isRequired,
+  eventTypes: PropTypes.arrayOf(PropTypes.string),
+};

--- a/frontend/src/components/taskSelection/taskActivity.js
+++ b/frontend/src/components/taskSelection/taskActivity.js
@@ -237,6 +237,7 @@ export const TaskDataDropdown = ({ history, changesetComment, bbox }: Object) =>
   if (history?.taskHistory?.length > 0) {
     return (
       <Dropdown
+        toRight
         value={null}
         options={[
           { label: <FormattedMessage {...messages.taskOnOSMCha} />, href: osmchaLink },


### PR DESCRIPTION
## What type of PR is this? 

- [x] 🍕 Feature
- [x] 🐛 Bug Fix

## Related Issue

- Resolves #6509 

## Describe this PR
This PR adds support for right-aligned dropdowns via a new `toRight` prop, applied to the task data menu dropdown.

**Changes**
- Updates styling to align the dropdown items to the right when `toRight` is true
- Passes `toRight` prop to the task data menu dropdown for right alignment
