### PR TITLE
Make auth callback URL relative to base API_URL

### DIFF
--- a/frontend/src/views/authorized.js
+++ b/frontend/src/views/authorized.js
@@ -10,7 +10,7 @@ import { AnimatedLoadingIcon } from '../components/button';
 export function Authorized(props) {
 
   const authComplete = (authCode, state) => {
-      let callback_url = `/api/v2/system/authentication/callback/?redirect_uri=${OSM_REDIRECT_URI}&code=${authCode}`;
+      let callback_url = `system/authentication/callback/?redirect_uri=${OSM_REDIRECT_URI}&code=${authCode}`;
       const emailAddress = getItem('email_address');
       if (emailAddress !== null) {
         callback_url += `&email_address=${emailAddress}`;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

This is a tweak to the changes made in #6933. That PR works correctly AFAIK for tasks.hotosm.org's use case, but I discovered when backporting the fix to [osmus/tasking-manager](https://github.com/osmus/tasking-manager) (which powers tasks.openstreetmap.us and tasks.teachosm.org) that it does not work if the backend is deployed to a nonstandard URL path.

This change makes the callback URL string a relative path (removing the hardcoded `/api/v2` prefix). The appropriate prefix will then be [prepended in `fetchLocalJSONAPI()`](https://github.com/hotosm/tasking-manager/blob/develop/frontend/src/network/genericJSONRequest.js#L27) when the string is converted to a `URL` object. This prefix may be `/api/v2` or it may be another value depending on the configuration environment variables provided at runtime.

This change is running in production on tasks.openstreetmap.us and tasks.teachosm.org already, so I am fairly confident that it works.