### PR TITLE
Fix/project pagination

### DIFF
--- a/.github/workflows/pr_test_backend.yml
+++ b/.github/workflows/pr_test_backend.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run PEP8 checks
         run: |
-          flake8 manage.py backend tests migrations
+          flake8 manage.py backend tests migrations --ignore=E203,W503
           black --check manage.py backend tests migrations
 
   pytest:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #6939

## Describe this PR

By default the ordering was based only on priority of the project which was non deterministic causing some projects to jump between pages or appear duplicated. This was made deterministic by adding id as a secondary sort key which results consistent results during pagination.

Projects list all results fetched only during csv generation and displaying map results.

