### PR TITLE
Fix/Enable removing last member of team with confirmation dialog

### DIFF
--- a/frontend/src/components/teamsAndOrgs/members.js
+++ b/frontend/src/components/teamsAndOrgs/members.js
@@ -30,6 +30,7 @@ export function Members({
   setMemberJoinTeamError,
   managerJoinTeamError,
   setManagerJoinTeamError,
+  totalMembersOnTeam,
 }: Object) {
   const token = useSelector((state) => state.auth.token);
   const [editMode, setEditMode] = useState(false);
@@ -85,10 +86,10 @@ export function Members({
   );
 
   const enableMemberEditMode = useCallback(() => {
-    if (type === 'members' && editMode) return true;
+    if (type === 'members' && editMode && totalMembersOnTeam > 1) return true;
     if (!type && members.length > 1 && editMode) return true;
     return false;
-  }, [members, type, editMode]);
+  }, [members, type, editMode, totalMembersOnTeam]);
 
   const removeTeamMember = (username) => {
     if (members.length > 1) return removeMembers(username);

--- a/frontend/src/components/teamsAndOrgs/members.js
+++ b/frontend/src/components/teamsAndOrgs/members.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import axios from 'axios';
 import { useSelector } from 'react-redux';
+import Popup from 'reactjs-popup';
 import { useIntl, FormattedMessage } from 'react-intl';
 import AsyncSelect from 'react-select/async';
 import toast from 'react-hot-toast';
@@ -33,6 +34,7 @@ export function Members({
   const token = useSelector((state) => state.auth.token);
   const [editMode, setEditMode] = useState(false);
   const [membersBackup, setMembersBackup] = useState(null);
+  const [lastRemovingUsername, setLastRemovingUsername] = useState(null);
   const selectPlaceHolder = <FormattedMessage {...messages.searchUsers} />;
   let title = <FormattedMessage {...messages.managers} />;
   if (type === 'members') {
@@ -82,6 +84,17 @@ export function Members({
     </div>
   );
 
+  const enableMemberEditMode = useCallback(() => {
+    if (type === 'members' && editMode) return true;
+    if (!type && members.length > 1 && editMode) return true;
+    return false;
+  }, [members, type, editMode]);
+
+  const removeTeamMember = (username) => {
+    if (members.length > 1) return removeMembers(username);
+    setLastRemovingUsername(username);
+  };
+
   return (
     <>
       <div className={`bg-white b--grey-light pa4 ${editMode ? 'bt bl br' : 'ba'}`}>
@@ -119,8 +132,8 @@ export function Members({
               picture={user.pictureUrl}
               size="large"
               colorClasses="white bg-blue-grey mv1"
-              removeFn={members.length > 1 && removeMembers}
-              editMode={members.length > 1 && editMode}
+              removeFn={removeTeamMember}
+              editMode={enableMemberEditMode()}
             />
           ))}
           {members.length === 0 && (
@@ -159,6 +172,44 @@ export function Members({
           </div>
         </div>
       )}
+      <Popup
+        modal
+        open={!!lastRemovingUsername}
+        closeOnEscape
+        closeOnDocumentClick
+        onClose={() => {
+          setLastRemovingUsername(null);
+        }}
+      >
+        <div className="ph3 pv3">
+          <h2 className="f4 mb3">
+            <FormattedMessage {...messages.memberRemoveConfirmationHeader} />
+          </h2>
+          <p className="dark-gray mb4">
+            {' '}
+            <FormattedMessage {...messages.memberRemoveConfirmationDescription} />
+          </p>
+          <div className="flex justify-end">
+            <Button
+              className="pv2 ph3 ba b--red white bg-black-40 mv1 mr2"
+              onClick={() => {
+                setLastRemovingUsername(null);
+              }}
+            >
+              <FormattedMessage {...messages.cancel} />
+            </Button>
+            <Button
+              className="pv2 ph3 ba b--red white bg-red mv1"
+              onClick={() => {
+                removeMembers(lastRemovingUsername);
+                setLastRemovingUsername(null);
+              }}
+            >
+              <FormattedMessage {...messages.remove} />
+            </Button>
+          </div>
+        </div>
+      </Popup>
     </>
   );
 }

--- a/frontend/src/components/teamsAndOrgs/messages.js
+++ b/frontend/src/components/teamsAndOrgs/messages.js
@@ -35,7 +35,7 @@ export default defineMessages({
     id: 'management.partners.menu',
     defaultMessage: 'Partners',
   },
-  resourcesButton:{
+  resourcesButton: {
     id: 'management.edit.resourcesButton',
     defaultMessage: 'Resources link',
   },
@@ -591,5 +591,13 @@ export default defineMessages({
   totalFeatures: {
     id: 'management.stats.features',
     defaultMessage: 'Total features',
+  },
+  memberRemoveConfirmationHeader: {
+    id: 'management.members.remove_confirmation_header',
+    defaultMessage: 'Are you sure you want to remove?',
+  },
+  memberRemoveConfirmationDescription: {
+    id: 'management.members.remove_confirmation_description',
+    defaultMessage: 'This team will have only managers and no members.',
   },
 });

--- a/frontend/src/views/teams.js
+++ b/frontend/src/views/teams.js
@@ -399,6 +399,7 @@ export function EditTeam(props) {
           type="members"
           memberJoinTeamError={memberJoinTeamError}
           setMemberJoinTeamError={setMemberJoinTeamError}
+          totalMembersOnTeam={[...members, ...managers].length}
         />
         <div className="h1"></div>
         <JoinRequests


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix

## Related Issue

Fixes:  #6909

## Describe this PR
This PR introduces a confirmation dialog when removing the last member from a team. It prevents accidental deletions and clarifies that the team will remain with only managers.

**Changes:**
- Enabled functionality to remove the last member from a team
- Added confirmation dialog UI on last team removal
- Added i18n messages for the dialog.

## Screenshots
Confirmation Dialog: 
<img width="1839" height="845" alt="image" src="https://github.com/user-attachments/assets/42697c65-aad5-4024-b4cc-9d2d0e2a936b" />


