### PR TITLE
Unlink team from a project for allowing team deletion

### DIFF
--- a/backend/services/team_service.py
+++ b/backend/services/team_service.py
@@ -817,3 +817,24 @@ class TeamService:
             logger.info("Messages sent successfully.")
         except Exception as e:
             logger.error(f"Error sending messages in background task: {str(e)}")
+
+    @staticmethod
+    async def unlink_team(project_id: int, team_id: int, db: Database) -> bool:
+        """
+        Delete the project_teams row matching project_id & team_id.
+        Returns True if a row was deleted, False otherwise.
+        """
+        query = """
+            DELETE FROM project_teams
+            WHERE project_id = :project_id
+              AND team_id    = :team_id
+            RETURNING team_id
+        """
+        row = await db.fetch_one(
+            query,
+            values={
+                "project_id": project_id,
+                "team_id": team_id,
+            },
+        )
+        return row is not None


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Related to #6773

## Describe this PR

If teams are linked to a project, the team cant be deleted and there is no way for team managers to unlink a team from a project without having edit permission to that particular project.

Provides a separate endpoint for team managers to unlink their team from a particular project.
