### PR TITLE
Remove fixed width causing login button overlap.

### DIFF
--- a/frontend/src/components/header/styles.scss
+++ b/frontend/src/components/header/styles.scss
@@ -7,7 +7,7 @@
   scrollbar-width: none;
 }
 
-@media screen and (max-width: 45em) {
+@media screen and (max-width: 46em) {
   .dn-sm {
     display: none;
   }

--- a/frontend/src/components/localeSelect.js
+++ b/frontend/src/components/localeSelect.js
@@ -38,7 +38,7 @@ function LocaleSelect({
   if (!supportedLanguages.length) return <></>;
 
   return (
-    <div className={`settings-width ml-auto ${className || ''}`}>
+    <div className={`ml-auto ${className || ''}`}>
       <Select
         classNamePrefix="react-select"
         styles={{


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

 Fixes: #6508 

## Describe this PR

This PR removes the `.settings-width` class from the localization dropdown. The fixed width was causing layout issues—specifically, the login button would overlap when the localization text was long. Removing the class allows the dropdown to size naturally and prevents content overlap.

