### PR TITLE
Add option to immediately exit cron_jobs script

### DIFF
--- a/backend/cron_jobs.py
+++ b/backend/cron_jobs.py
@@ -157,7 +157,17 @@ async def main():
         await db_connection.database.connect()
         logger.info("Database connection established.")
 
-        await setup_cron_jobs()
+        if args.immediate_exit:
+            # Run each job once, and that's it
+            await auto_unlock_tasks()
+            await update_all_project_stats()
+            await update_recent_updated_project_stats()
+        else:
+            # Set up a scheduler and run it indefinitely
+            await setup_cron_jobs()
+            # Keeping the process alive.
+            while True:
+                await asyncio.sleep(3600)
 
     except (KeyboardInterrupt, SystemExit):
         logger.info("Shutting down...")
@@ -168,11 +178,6 @@ async def main():
         logger.info("Disconnecting from the database...")
         await db_connection.database.disconnect()
         logger.info("Database connection closed.")
-
-    if not args.immediate_exit:
-        # Keeping the process alive.
-        while True:
-            await asyncio.sleep(3600)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

Adds a `--immediate-exit` option to the `backend/cron_job.py` script, which exits immediately upon completing the jobs. I additionally pulled the sleep statement out of the try block, so that the database connection wouldn't stay open for 10 minutes.

## Alternative Approaches Considered

I would prefer for the script to exit immediately by default, but didn't want to break anything upstream.

## Review Guide

My intention was for this to be entirely backwards compatible. I hope that the `backend/cron_jobs.py` script runs the same as before, unless the user opts-in to the immediate exit. I'm not entirely sure how Tasking Manager runs in AWS, so I want to be sure I don't break that functionality.

## Checklist before requesting a review

- 📖 Read the Tasking Manager Contributing Guide: <https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExa3d6eW15NGdycm9ja2J4cHNwMzhna214Z3FhZjlpeGc3MWNoZ3F3YyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tIeCLkB8geYtW/giphy.gif)
