### PR TITLE
project id in reset task action while setting action history

### DIFF
--- a/backend/models/postgis/task.py
+++ b/backend/models/postgis/task.py
@@ -1095,7 +1095,7 @@ class Task(Base):
         # Log the state change in the task history
         await Task.set_task_history(
             task_id=task_id,
-            project_id=None,  # Assuming project_id is not needed here or is passed earlier
+            project_id=project_id,
             user_id=user_id,
             action=TaskAction.STATE_CHANGE,
             db=db,

--- a/tests/api/unit/services/test_project_admin_service.py
+++ b/tests/api/unit/services/test_project_admin_service.py
@@ -159,7 +159,8 @@ class TestProjectAdminService:
             )
             assert task.task_status == TaskStatus.READY.value
             if task_history:
-                assert task_history[0].action_text == "Task reset"
+                assert task_history[0].action_text == TaskStatus.READY.name
+                assert task_history[1].action_text == "Task reset"
         query = """
             SELECT id, tasks_mapped, tasks_validated
             FROM projects


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #7009 

## Describe this PR

When a project's all tasks were reset, the project id was not populated in the task history causing it to revert to the last action before it was reset resulting in ambiguous actions. 

