### PR TITLE
Restore three requested functionality related to super mapper

### DIFF
--- a/backend/models/dtos/mapping_level_dto.py
+++ b/backend/models/dtos/mapping_level_dto.py
@@ -48,6 +48,9 @@ class MappingLevelUpdateDTO(BaseModel):
     @field_validator("required_badges")
     @classmethod
     def has_badges(cls, value: str, info: ValidationInfo):
+        if info.data["is_beginner"]:
+            return value
+
         return has_badges(value)
 
 

--- a/backend/models/postgis/user.py
+++ b/backend/models/postgis/user.py
@@ -1,3 +1,4 @@
+import re
 import json
 import geojson
 import sqlalchemy as sa
@@ -198,7 +199,7 @@ class User(Base):
         filters = []
         params = {}
 
-        if query.mapping_level:
+        if query.mapping_level and re.match("^\d+$", query.mapping_level):
             mapping_level_array = map(int, query.mapping_level.split(","))
             filters.append("mapping_level = ANY(:mapping_levels)")
             params["mapping_levels"] = tuple(mapping_level_array)

--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -794,7 +794,7 @@ class ProjectSearchService:
             WHERE (p.tasks_mapped + p.tasks_validated) < (p.total_tasks - p.tasks_bad_imagery)
             AND p.status = :published_status AND l.ordering <= :user_level_ordering
         """
-        user_level = await MappingLevel.get_by_id(user.mapping_level)
+        user_level = await MappingLevel.get_by_id(user.mapping_level, db)
         params = {
             "published_status": ProjectStatus.PUBLISHED.value,
             "user_level_ordering": user_level.ordering,
@@ -824,7 +824,7 @@ class ProjectSearchService:
             WHERE p.tasks_validated < (p.total_tasks - p.tasks_bad_imagery)
             AND p.status = :published_status AND l.ordering <= :user_level_ordering
         """
-        user_level = await MappingLevel.get_by_id(user.mapping_level)
+        user_level = await MappingLevel.get_by_id(user.mapping_level, db)
         params = {
             "published_status": ProjectStatus.PUBLISHED.value,
             "user_level_ordering": user_level.ordering,

--- a/frontend/src/components/levels/index.js
+++ b/frontend/src/components/levels/index.js
@@ -54,15 +54,9 @@ export const LevelsManagement = ({levels, isFetched}) => {
   );
 };
 
-export const LevelInformation = ({ badges }) => {
+export const LevelInformation = ({ level, badges }) => {
   const labelClasses = 'db pt3 pb2';
   const fieldClasses = 'blue-grey w-100 pv3 ph2 input-reset ba b--grey-light bg-transparent';
-
-  const validateBadges = (value) => {
-    if (value && value.length === 0) {
-      return <FormattedMessage {...messages.needsBadges} />;
-    }
-  }
 
   return <div className="cf">
     <label className={labelClasses}>
@@ -81,12 +75,14 @@ export const LevelInformation = ({ badges }) => {
       {({input}) => ColorField({ input })}
     </Field>
 
-    <label className={labelClasses}>
-      <FormattedMessage {...messages.required_badges} />
-    </label>
-    <Field name="requiredBadges" className={fieldClasses} required validate={validateBadges}>
-      {({input}) => RequiredBadgesField({input, badges})}
-    </Field>
+    {((level && !level.isBeginner) || !level) && <>
+      <label className={labelClasses}>
+        <FormattedMessage {...messages.required_badges} />
+      </label>
+      <Field name="requiredBadges" className={fieldClasses}>
+        {({input}) => RequiredBadgesField({input, badges})}
+      </Field>
+    </>}
   </div>;
 };
 
@@ -226,7 +222,7 @@ export const LevelForm = ({ level, badges, updateLevel }) => {
               </h3>
               <form id="level-form" onSubmit={handleSubmit}>
                 <fieldset className="bn pa0" disabled={submitting}>
-                  <LevelInformation badges={badges} />
+                  <LevelInformation level={level} badges={badges} />
                 </fieldset>
               </form>
             </div>

--- a/frontend/src/components/projectEdit/permissionsBlock.js
+++ b/frontend/src/components/projectEdit/permissionsBlock.js
@@ -117,6 +117,7 @@ export const PermissionsBlock = ({ permissions, levels, type }: Object) => {
         options={levelOptions}
         value={levelValue}
         onChange={handlePermissionLevelChange}
+        className="z-5"
       />
     </div>
   );

--- a/frontend/src/components/user/list.js
+++ b/frontend/src/components/user/list.js
@@ -102,6 +102,7 @@ const MapperLevelFilter = ({ filters, updateFilters, levels }) => {
   return (
     <div>
       <Select
+        isClearable={true}
         placeholder={intl.formatMessage(messages.mapperLevelALL)}
         options={options}
         onChange={(value) => updateFilters('level', value?.value)}


### PR DESCRIPTION
* [ ] allow updating the beginner level without setting required badges (and stop showing badges ui for that level)
* [ ] prevent an overlapping in the level select for project permissions
* [ ] allow clearing the level filter in the users table without clearing all of the filters
* [ ] fix projects table failing when listing projects to map or validate