### PR TITLE
fix problem when deleting level with votes

### DIFF
--- a/backend/api/projects/activities.py
+++ b/backend/api/projects/activities.py
@@ -71,7 +71,6 @@ async def get_activities(
             db,
         )
         if not project_dto:
-
             return JSONResponse(
                 content={
                     "Error": "User not permitted: Private Project",
@@ -133,7 +132,6 @@ async def get_latest_activities(
             db,
         )
         if not project_dto:
-
             return JSONResponse(
                 content={
                     "Error": "User not permitted: Private Project",

--- a/backend/api/projects/contributions.py
+++ b/backend/api/projects/contributions.py
@@ -66,7 +66,6 @@ async def get_project_contributions(
             db,
         )
         if not project_dto:
-
             return JSONResponse(
                 content={
                     "Error": "User not permitted: Private Project",

--- a/backend/api/projects/resources.py
+++ b/backend/api/projects/resources.py
@@ -1160,7 +1160,6 @@ async def get_project_summary(
             db,
         )
         if not project_dto:
-
             return JSONResponse(
                 content={
                     "Error": "User not permitted: Private Project",

--- a/backend/api/tasks/resources.py
+++ b/backend/api/tasks/resources.py
@@ -115,7 +115,6 @@ async def get_project_tasks(
             description: Internal Server Error
     """
     try:
-
         is_private, status = await ProjectService.get_project_privacy_and_status(
             project_id, db
         )
@@ -137,7 +136,6 @@ async def get_project_tasks(
                 db,
             )
             if not project_dto:
-
                 return JSONResponse(
                     content={
                         "Error": "User not permitted: Private Project",

--- a/backend/models/postgis/user.py
+++ b/backend/models/postgis/user.py
@@ -589,8 +589,14 @@ class UserMappingBadge(Base):
 class UserNextLevel(Base):
     __tablename__ = "user_next_level"
 
-    user_id = Column(BigInteger, nullable=False, primary_key=True)
-    level_id = Column(Integer, nullable=False, primary_key=True)
+    user_id = Column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, primary_key=True
+    )
+    level_id = Column(
+        ForeignKey("mapping_levels.id", ondelete="CASCADE"),
+        nullable=False,
+        primary_key=True,
+    )
     nomination_date = Column(DateTime, nullable=False, default=timestamp)
 
     @staticmethod
@@ -642,9 +648,17 @@ class UserNextLevel(Base):
 class UserLevelVote(Base):
     __tablename__ = "user_level_vote"
 
-    user_id = Column(BigInteger, nullable=False, primary_key=True)
-    level_id = Column(Integer, nullable=False, primary_key=True)
-    voter_id = Column(BigInteger, nullable=False, primary_key=True)
+    user_id = Column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, primary_key=True
+    )
+    level_id = Column(
+        ForeignKey("mapping_levels.id", ondelete="CASCADE"),
+        nullable=False,
+        primary_key=True,
+    )
+    voter_id = Column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, primary_key=True
+    )
     vote_date = Column(
         DateTime,
         nullable=False,

--- a/migrations/versions/4489b9e235f8_.py
+++ b/migrations/versions/4489b9e235f8_.py
@@ -1,0 +1,95 @@
+"""Allow deleting a level with no users but with votes
+Revision ID: 4489b9e235f8
+Revises: d289a8a785b9
+Create Date: 2025-08-22 13:43
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4489b9e235f8"
+down_revision = "d289a8a785b9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # user_next_level
+    # level_id
+    op.execute(
+        "alter table user_next_level drop constraint user_next_level_level_id_fkey"
+    )
+    op.execute(
+        "alter table user_next_level add constraint user_next_level_level_id_fkey foreign key (level_id) references mapping_levels (id) on delete cascade"
+    )
+    # user_id
+    op.execute(
+        "alter table user_next_level drop constraint user_next_level_user_id_fkey"
+    )
+    op.execute(
+        "alter table user_next_level add constraint user_next_level_user_id_fkey foreign key (user_id) references users (id) on delete cascade"
+    )
+    # user_level_vote
+    # level_id
+    op.execute(
+        "alter table user_level_vote drop constraint user_level_vote_level_id_fkey"
+    )
+    op.execute(
+        "alter table user_level_vote add constraint user_level_vote_level_id_fkey foreign key (level_id) references mapping_levels (id) on delete cascade"
+    )
+    # user_id
+    op.execute(
+        "alter table user_level_vote drop constraint user_level_vote_user_id_fkey"
+    )
+    op.execute(
+        "alter table user_level_vote add constraint user_level_vote_user_id_fkey foreign key (user_id) references users (id) on delete cascade"
+    )
+    # voter_id
+    op.execute(
+        "alter table user_level_vote drop constraint user_level_vote_voter_id_fkey"
+    )
+    op.execute(
+        "alter table user_level_vote add constraint user_level_vote_voter_id_fkey foreign key (voter_id) references users (id) on delete cascade"
+    )
+
+
+def downgrade():
+    # user_next_level
+    # level_id
+    op.execute(
+        "alter table user_next_level drop constraint user_next_level_level_id_fkey"
+    )
+    op.execute(
+        "alter table user_next_level add constraint user_next_level_level_id_fkey foreign key (level_id) references mapping_levels (id) on delete restrict"
+    )
+    # user_id
+    op.execute(
+        "alter table user_next_level drop constraint user_next_level_user_id_fkey"
+    )
+    op.execute(
+        "alter table user_next_level add constraint user_next_level_user_id_fkey foreign key (user_id) references users (id) on delete restrict"
+    )
+    # user_level_vote
+    # level_id
+    op.execute(
+        "alter table user_level_vote drop constraint user_level_vote_level_id_fkey"
+    )
+    op.execute(
+        "alter table user_level_vote add constraint user_level_vote_level_id_fkey foreign key (level_id) references mapping_levels (id) on delete restrict"
+    )
+    # user_id
+    op.execute(
+        "alter table user_level_vote drop constraint user_level_vote_user_id_fkey"
+    )
+    op.execute(
+        "alter table user_level_vote add constraint user_level_vote_user_id_fkey foreign key (user_id) references users (id) on delete restrict"
+    )
+    # voter_id
+    op.execute(
+        "alter table user_level_vote drop constraint user_level_vote_voter_id_fkey"
+    )
+    op.execute(
+        "alter table user_level_vote add constraint user_level_vote_voter_id_fkey foreign key (voter_id) references users (id) on delete restrict"
+    )

--- a/tests/api/unit/services/users/test_user_service.py
+++ b/tests/api/unit/services/users/test_user_service.py
@@ -324,8 +324,27 @@ class TestUserService:
         )
         await UserNextLevel.nominate(self.test_user.id, level.id, self.db)
 
+        other_user = User()
+        other_user.id = 24934
+        other_user.role = 0
+        other_user.mapping_level = 1
+        other_user.tasks_mapped = 0
+        other_user.tasks_validated = 0
+        other_user.tasks_invalidated = 0
+        other_user.is_email_verified = False
+        other_user.is_expert = False
+        other_user.default_editor = "ID"
+        other_user.mentions_notifications = True
+        other_user.projects_comments_notifications = False
+        other_user.projects_notifications = True
+        other_user.tasks_notifications = True
+        other_user.tasks_comments_notifications = False
+        other_user.teams_announcement_notifications = True
+
+        other_user = await create_canned_user(self.db, other_user)
+
         # Act
-        await UserService.approve_level(self.test_user.id, 234, self.db)
+        await UserService.approve_level(self.test_user.id, other_user.id, self.db)
 
         # Assert
         user = await UserService.get_user_by_id(self.test_user.id, self.db)
@@ -355,8 +374,27 @@ class TestUserService:
         )
         await UserNextLevel.nominate(self.test_user.id, level.id, self.db)
 
+        other_user = User()
+        other_user.id = 24934
+        other_user.role = 0
+        other_user.mapping_level = 1
+        other_user.tasks_mapped = 0
+        other_user.tasks_validated = 0
+        other_user.tasks_invalidated = 0
+        other_user.is_email_verified = False
+        other_user.is_expert = False
+        other_user.default_editor = "ID"
+        other_user.mentions_notifications = True
+        other_user.projects_comments_notifications = False
+        other_user.projects_notifications = True
+        other_user.tasks_notifications = True
+        other_user.tasks_comments_notifications = False
+        other_user.teams_announcement_notifications = True
+
+        other_user = await create_canned_user(self.db, other_user)
+
         # Act
-        await UserService.approve_level(self.test_user.id, 234, self.db)
+        await UserService.approve_level(self.test_user.id, other_user.id, self.db)
 
         # Assert
         user = await UserService.get_user_by_id(self.test_user.id, self.db)


### PR DESCRIPTION
Uses CASCADE for relationships that come from voting related tables so that they don't interfere when deleting a level with no users.