### PR TITLE
clear next level and votes on badge and level update

### DIFF
--- a/backend/models/postgis/mapping_level.py
+++ b/backend/models/postgis/mapping_level.py
@@ -104,6 +104,11 @@ class MappingLevel(Base):
                 """
                 await db.execute(update_query, values={**updated_values, "id": data.id})
 
+            # requirements have potentially changed, so nominations and
+            # votes are cleared
+            await db.execute("DELETE FROM user_next_level")
+            await db.execute("DELETE FROM user_level_vote")
+
             clear_query = "DELETE FROM mapping_level_badges WHERE level_id = :level_id"
             await db.execute(clear_query, values={"level_id": data.id})
 

--- a/tests/api/unit/services/users/test_user_service.py
+++ b/tests/api/unit/services/users/test_user_service.py
@@ -10,7 +10,10 @@ from backend.services.users.user_service import (
     UserService,
     UserServiceError,
 )
-from tests.api.helpers.test_helpers import create_canned_user
+from tests.api.helpers.test_helpers import (
+    create_canned_user,
+    return_canned_user,
+)
 from backend.models.postgis.user import (
     User,
     UserNextLevel,
@@ -324,24 +327,9 @@ class TestUserService:
         )
         await UserNextLevel.nominate(self.test_user.id, level.id, self.db)
 
-        other_user = User()
-        other_user.id = 24934
-        other_user.role = 0
-        other_user.mapping_level = 1
-        other_user.tasks_mapped = 0
-        other_user.tasks_validated = 0
-        other_user.tasks_invalidated = 0
-        other_user.is_email_verified = False
-        other_user.is_expert = False
-        other_user.default_editor = "ID"
-        other_user.mentions_notifications = True
-        other_user.projects_comments_notifications = False
-        other_user.projects_notifications = True
-        other_user.tasks_notifications = True
-        other_user.tasks_comments_notifications = False
-        other_user.teams_announcement_notifications = True
-
-        other_user = await create_canned_user(self.db, other_user)
+        other_user = await create_canned_user(
+            self.db, await return_canned_user(self.db, id=24934, username="foo")
+        )
 
         # Act
         await UserService.approve_level(self.test_user.id, other_user.id, self.db)
@@ -374,24 +362,9 @@ class TestUserService:
         )
         await UserNextLevel.nominate(self.test_user.id, level.id, self.db)
 
-        other_user = User()
-        other_user.id = 24934
-        other_user.role = 0
-        other_user.mapping_level = 1
-        other_user.tasks_mapped = 0
-        other_user.tasks_validated = 0
-        other_user.tasks_invalidated = 0
-        other_user.is_email_verified = False
-        other_user.is_expert = False
-        other_user.default_editor = "ID"
-        other_user.mentions_notifications = True
-        other_user.projects_comments_notifications = False
-        other_user.projects_notifications = True
-        other_user.tasks_notifications = True
-        other_user.tasks_comments_notifications = False
-        other_user.teams_announcement_notifications = True
-
-        other_user = await create_canned_user(self.db, other_user)
+        other_user = await create_canned_user(
+            self.db, await return_canned_user(self.db, id=24934, username="foo")
+        )
 
         # Act
         await UserService.approve_level(self.test_user.id, other_user.id, self.db)


### PR DESCRIPTION
This prevents inconsistent behavior when a level or a badge is updated