### PR TITLE
allow listing projects to map or validate as anonymous user

### DIFF
--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -790,13 +790,17 @@ class ProjectSearchService:
             SELECT p.id FROM projects p
             LEFT JOIN mapping_levels l ON l.id = p.mapping_permission_level_id
             WHERE (p.tasks_mapped + p.tasks_validated) < (p.total_tasks - p.tasks_bad_imagery)
-            AND p.status = :published_status AND l.ordering <= :user_level_ordering
+            AND p.status = :published_status
         """
-        user_level = await MappingLevel.get_by_id(user.mapping_level, db)
+
         params = {
             "published_status": ProjectStatus.PUBLISHED.value,
-            "user_level_ordering": user_level.ordering,
         }
+
+        if user:
+            user_level = await MappingLevel.get_by_id(user.mapping_level, db)
+            base_query += " AND l.ordering <= :user_level_ordering"
+            params["user_level_ordering"] = user_level.ordering
 
         if user and user.role != UserRole.ADMIN.value:
             (
@@ -820,13 +824,17 @@ class ProjectSearchService:
             SELECT p.id FROM projects p
             LEFT JOIN mapping_levels l ON l.id = p.validation_permission_level_id
             WHERE p.tasks_validated < (p.total_tasks - p.tasks_bad_imagery)
-            AND p.status = :published_status AND l.ordering <= :user_level_ordering
+            AND p.status = :published_status
         """
-        user_level = await MappingLevel.get_by_id(user.mapping_level, db)
+
         params = {
             "published_status": ProjectStatus.PUBLISHED.value,
-            "user_level_ordering": user_level.ordering,
         }
+
+        if user:
+            user_level = await MappingLevel.get_by_id(user.mapping_level, db)
+            base_query += " AND l.ordering <= :user_level_ordering"
+            params["user_level_ordering"] = user_level.ordering
 
         if user and user.role != UserRole.ADMIN.value:
             (

--- a/tests/api/unit/services/test_project_search_service.py
+++ b/tests/api/unit/services/test_project_search_service.py
@@ -50,3 +50,45 @@ class TestProjectService:
         assert project_search_dto is not None
         assert len(project_search_dto.results) > 0
         assert any(p.project_id == self.project_id for p in project_search_dto.results)
+
+    async def test_projects_can_be_searched_without_account_map(self):
+        # Arrange
+        search_dto = ProjectSearchDTO(
+            difficulty="EASY",
+            project_statuses=["PUBLISHED"],
+            order_by="priority",
+            order_by_type="DESC",
+            action="validate",
+            page=1,
+        )
+
+        # Act
+        project_search_dto = await ProjectSearchService.search_projects(
+            search_dto, None, self.db
+        )
+
+        # Assert
+        assert project_search_dto is not None
+        assert len(project_search_dto.results) > 0
+        assert any(p.project_id == self.project_id for p in project_search_dto.results)
+
+    async def test_projects_can_be_searched_without_account_validate(self):
+        # Arrange
+        search_dto = ProjectSearchDTO(
+            difficulty="EASY",
+            project_statuses=["PUBLISHED"],
+            order_by="priority",
+            order_by_type="DESC",
+            action="validate",
+            page=1,
+        )
+
+        # Act
+        project_search_dto = await ProjectSearchService.search_projects(
+            search_dto, None, self.db
+        )
+
+        # Assert
+        assert project_search_dto is not None
+        assert len(project_search_dto.results) > 0
+        assert any(p.project_id == self.project_id for p in project_search_dto.results)


### PR DESCRIPTION
A bug prevented the projects to be filtered by "map" or "validate" action. Filtering projects by "any" had no problem. This PR fixes it.