### PR TITLE
bring back project statistics: users per level

### DIFF
--- a/frontend/src/components/projectStats/contributorsStats.js
+++ b/frontend/src/components/projectStats/contributorsStats.js
@@ -10,41 +10,39 @@ import {
   Tooltip,
 } from 'chart.js';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { useState, useEffect } from 'react';
 
 import messages from './messages';
-import userMessages from '../user/messages';
 import { CHART_COLOURS } from '../../config';
 import { formatChartData, formatTooltip } from '../../utils/formatChartJSData';
 import { useContributorStats } from '../../hooks/UseContributorStats';
 import { StatsCardContent } from '../statsCard';
+import { fetchLocalJSONAPI } from '../../network/genericJSONRequest';
 
 export default function ContributorsStats({ contributors }) {
   ChartJS.register(BarElement, CategoryScale, Legend, LinearScale, Title, Tooltip, ArcElement);
   const intl = useIntl();
   const stats = useContributorStats(contributors);
-  const getUserLevelLabel = (level) => intl.formatMessage(userMessages[`mapperLevel${level}`]);
   const getUserExpLabel = (id) => intl.formatMessage(messages[`${id}`]);
+  const [levels, setLevels] = useState([]);
 
-  let userLevelsReference = [
-    {
-      label: getUserLevelLabel('BEGINNER'),
-      field: 'beginnerUsers',
-      backgroundColor: CHART_COLOURS.green,
+  useEffect(() => {
+    (async () => {
+      const res = await fetchLocalJSONAPI(`levels/`);
+
+      setLevels(res.levels);
+    })();
+  }, []);
+
+  let userLevelsReference = levels.map((level) => {
+    return {
+      label: level.name,
+      field: (stats) => stats.usersByLevel[level.name],
+      backgroundColor: level.color,
       borderColor: CHART_COLOURS.white,
-    },
-    {
-      label: getUserLevelLabel('INTERMEDIATE'),
-      field: 'intermediateUsers',
-      backgroundColor: CHART_COLOURS.blue,
-      borderColor: CHART_COLOURS.white,
-    },
-    {
-      label: getUserLevelLabel('ADVANCED'),
-      field: 'advancedUsers',
-      backgroundColor: CHART_COLOURS.orange,
-      borderColor: CHART_COLOURS.white,
-    },
-  ];
+    };
+  });
+
   let userExperienceReference = [
     {
       label: getUserExpLabel('lessThan1MonthExp'),

--- a/frontend/src/hooks/UseContributorStats.js
+++ b/frontend/src/hooks/UseContributorStats.js
@@ -5,23 +5,28 @@ export function useContributorStats(contributions) {
   const [stats, setStats] = useState({
     validators: 0,
     mappers: 0,
-    beginnerUsers: 0,
-    intermediateUsers: 0,
-    advancedUsers: 0,
+    usersByLevel: {},
     lessThan1MonthExp: 0,
     lessThan3MonthExp: 0,
     lessThan6MonthExp: 0,
     lessThan12MonthExp: 0,
     moreThan1YearExp: 0,
   });
+
   useEffect(() => {
     if (contributions !== undefined) {
       const data = {
         validators: contributions.filter((i) => i.validated > 0).length,
         mappers: contributions.filter((i) => i.mapped > 0).length,
-        beginnerUsers: contributions.filter((i) => i.mappingLevel === 'BEGINNER').length,
-        intermediateUsers: contributions.filter((i) => i.mappingLevel === 'INTERMEDIATE').length,
-        advancedUsers: contributions.filter((i) => i.mappingLevel === 'ADVANCED').length,
+        usersByLevel: contributions.reduce((prev, curr) => {
+          if (!Object.hasOwnProperty.call(prev, curr.mappingLevel)) {
+            prev[curr.mappingLevel] = 0;
+          }
+
+          prev[curr.mappingLevel]++;
+
+          return prev;
+        }, {}),
       };
       const monthRanges = [
         [0, 1],
@@ -43,5 +48,6 @@ export function useContributorStats(contributions) {
       setStats(data);
     }
   }, [contributions]);
+
   return stats;
 }

--- a/frontend/src/utils/formatChartJSData.js
+++ b/frontend/src/utils/formatChartJSData.js
@@ -1,7 +1,13 @@
 export const formatChartData = (reference, stats) => {
   let data = { datasets: [{ data: [], backgroundColor: [] }], labels: [] };
 
-  data.datasets[0].data = reference.map((f) => stats[f.field]);
+  data.datasets[0].data = reference.map((f) => {
+    if (typeof f.field === "function") {
+      return f.field(stats) || 0;
+    }
+
+    return stats[f.field];
+  });
   const total = data.datasets[0].data.reduce((a, b) => a + b, 0);
   data.datasets[0].data = data.datasets[0].data.map((v) => Math.round((v / total) * 100));
   data.datasets[0].backgroundColor = reference.map((f) => f.backgroundColor);


### PR DESCRIPTION
This fixes the users-per-level donut to work with the new levels.