### PR TITLE
infra: update ecs scale down bounds

### DIFF
--- a/scripts/aws/infra/develop/purgeable/ecs/terragrunt.hcl
+++ b/scripts/aws/infra/develop/purgeable/ecs/terragrunt.hcl
@@ -117,7 +117,7 @@ inputs = {
       { lower_bound = 10, upper_bound = null, adjustment = 2 }
     ]
     scale_down_steps = [
-      { lower_bound = null, upper_bound = 0, adjustment = -1 }
+      { lower_bound = null, upper_bound = -60, adjustment = -1 }
     ]
   }
 
@@ -133,7 +133,7 @@ inputs = {
       { lower_bound = 10, upper_bound = null, adjustment = 2 },
     ]
     scale_down_steps = [
-      { lower_bound = null, upper_bound = 0, adjustment = -1 }
+      { lower_bound = null, upper_bound = -40, adjustment = -1 }
     ]
   }
 

--- a/scripts/aws/infra/production/purgeable/ecs/terragrunt.hcl
+++ b/scripts/aws/infra/production/purgeable/ecs/terragrunt.hcl
@@ -125,8 +125,7 @@ inputs = {
       { lower_bound = 20, upper_bound = null, adjustment = 3 }
     ]
     scale_down_steps = [
-      { lower_bound = null, upper_bound = -10, adjustment = -2 },
-      { lower_bound = -10, upper_bound = 0, adjustment = -1 }
+      { lower_bound = null, upper_bound = -60, adjustment = -1 }
     ]
   }
 
@@ -143,8 +142,7 @@ inputs = {
       { lower_bound = 20, upper_bound = null, adjustment = 3 }
     ]
     scale_down_steps = [
-      { lower_bound = null, upper_bound = -10, adjustment = -2 },
-      { lower_bound = -10, upper_bound = 0, adjustment = -1 }
+      { lower_bound = null, upper_bound = -40, adjustment = -1 },
     ]
   }
 

--- a/scripts/aws/infra/staging/purgeable/ecs/terragrunt.hcl
+++ b/scripts/aws/infra/staging/purgeable/ecs/terragrunt.hcl
@@ -115,7 +115,7 @@ inputs = {
       { lower_bound = 10, upper_bound = null, adjustment = 2 }
     ]
     scale_down_steps = [
-      { lower_bound = null, upper_bound = 0, adjustment = -1 }
+      { lower_bound = null, upper_bound = -60, adjustment = -1 }
     ]
   }
 
@@ -131,7 +131,7 @@ inputs = {
       { lower_bound = 10, upper_bound = null, adjustment = 2 },
     ]
     scale_down_steps = [
-      { lower_bound = null, upper_bound = 0, adjustment = -1 }
+      { lower_bound = null, upper_bound = -40, adjustment = -1 }
     ]
   }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🐛 Bug Fix
- [X] 🤖Infra

## Related Issue
- In ECS TM container was scaling because memory & CPU metrics were always below 50%

## Action
- Disables downscaling policy with increased bounds for CPU & Memory.