### PR TITLE
Show specific error messages on team unlinking failure (follow-up to #6953)

### DIFF
--- a/frontend/src/components/teamsAndOrgs/TeamLinkedProjects.js
+++ b/frontend/src/components/teamsAndOrgs/TeamLinkedProjects.js
@@ -38,6 +38,39 @@ export function TeamLinkedProjects({ viewAllEndpoint, border = true, canUserEdit
     id,
   );
 
+  const setResponseAsPerSubCode = (e, isMultiple, projectId) => {
+    if (e.message === 'TeamMappingPermissionError') {
+      setResponse({
+        type: 'error',
+        message: `${
+          isMultiple ? 'Certain projects have ' : 'Project has '
+        }mapping permission to only team and this team is the only team assigned with mapping permission. Please contact the project author before unlinking.`,
+        projectId: projectId,
+      });
+      return;
+    }
+    if (e.message === 'TeamValidationPermissionError') {
+      setResponse({
+        type: 'error',
+        message: `${
+          isMultiple ? 'Certain projects have ' : 'Project has '
+        }validation permission to only team and this team is the only team assigned with validation permission. Please contact the project author before unlinking.`,
+        projectId: projectId,
+      });
+      return;
+    }
+    if (e.message === 'ProjectManagementPermissionError') {
+      setResponse({
+        type: 'error',
+        message: `${
+          isMultiple ? 'Certain Projects have ' : 'Project has '
+        }project management permission assigned to this team and no other team is assigned. Please contact the project author before unlinking.`,
+        projectId: projectId,
+      });
+      return;
+    }
+  };
+
   // bulk action
   const unlinkAllProjectsFromTeam = () => {
     fetchLocalJSONAPI(`teams/projects/teams/${id}/unlink`, token, 'DELETE')
@@ -46,13 +79,7 @@ export function TeamLinkedProjects({ viewAllEndpoint, border = true, canUserEdit
         refetch();
       })
       .catch((e) => {
-        if (e.message === 'ProjectPermissionError') {
-          setResponse({
-            type: 'error',
-            message:
-              'Certain projects have mapping/validation permissions restricted to teams, but no other team is assigned. Please contact the project author before unlinking.',
-          });
-        }
+        setResponseAsPerSubCode(e, true);
         console.log(e.message);
       })
       .finally(() => {
@@ -71,15 +98,11 @@ export function TeamLinkedProjects({ viewAllEndpoint, border = true, canUserEdit
         refetch();
       })
       .catch((e) => {
-        if (e.message === 'ProjectPermissionError') {
-          setResponse({
-            type: 'error',
-            message: `${
-              projectIds.length === 1 ? 'Project has ' : 'Certain projects have '
-            } mapping/validation permissions restricted to teams, but no other team is assigned. Please contact the project author before unlinking.`,
-            projectId: projectIds.length === 1 ? projectIds[0] : 0,
-          });
-        }
+        setResponseAsPerSubCode(
+          e,
+          projectIds.length > 1,
+          projectIds.length === 1 ? projectIds[0] : 0,
+        );
         console.log(e.message);
       })
       .finally(() => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor 
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR
This PR enhances the existing team unlinking feature by displaying contextual error messages based on the failure reason (e.g. team assigned as validation/mapping/manager permission).

The initial unlinking functionality was introduced in #6953. This follow-up improves user feedback by interpreting the backend Subcode in unlink failure responses and showing relevant messages.

**Changes**
- Display specific error messages depending on the Subcode returned in unlinking failure responses.
- Improved error handling flow in the unlinking logic for better clarity.
- Minor code clean-ups for readability.

## Checklist before requesting a review

- 📖 Read the Tasking Manager Contributing Guide: <https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.
