### PR TITLE
Save comment draft in session to prevent data loss on reload/navigation

### DIFF
--- a/frontend/src/components/comments/commentInput.js
+++ b/frontend/src/components/comments/commentInput.js
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import MDEditor from '@uiw/react-md-editor';
 import Tribute from 'tributejs';
@@ -21,6 +21,7 @@ import { CurrentUserAvatar } from '../user/avatar';
 const maxFileSize = 1 * 1024 * 1024; // 1MB
 
 function CommentInputField({
+  sessionkey,
   comment,
   setComment,
   contributors,
@@ -130,6 +131,23 @@ function CommentInputField({
     });
   };
 
+  useEffect(() => {
+    if (!sessionkey) return;
+    const commenEvent = sessionStorage.getItem(sessionkey);
+    if (commenEvent) {
+      setComment(commenEvent);
+    }
+  }, [sessionkey, setComment]);
+
+  const onCommentChange = useCallback(
+    (e) => {
+      setComment(e);
+      if (!sessionkey) return;
+      sessionStorage.setItem(sessionkey, e);
+    },
+    [sessionkey, setComment],
+  );
+
   return (
     <div {...getRootProps()}>
       {isShowTabNavs && (
@@ -165,7 +183,7 @@ function CommentInputField({
           extraCommands={[]}
           height={200}
           value={comment}
-          onChange={setComment}
+          onChange={onCommentChange}
           textareaProps={{
             ...getInputProps(),
             spellCheck: 'true',

--- a/frontend/src/components/projectDetail/questionsAndComments.js
+++ b/frontend/src/components/projectDetail/questionsAndComments.js
@@ -26,12 +26,14 @@ export const PostProjectComment = ({ projectId, refetchComments, contributors })
   const token = useSelector((state) => state.auth.token);
   const locale = useSelector((state) => state.preferences['locale']);
   const [comment, setComment] = useState('');
+  const SESSION_KEY = 'project-comment';
 
   const mutation = useMutation({
     mutationFn: () => postProjectComment(projectId, comment, token, locale),
     onSuccess: () => {
       refetchComments();
       setComment('');
+      sessionStorage.clear(SESSION_KEY);
     },
   });
 
@@ -44,6 +46,7 @@ export const PostProjectComment = ({ projectId, refetchComments, contributors })
       <div className={`w-100 h-100`} style={{ position: 'relative', display: 'block' }}>
         <Suspense fallback={<ReactPlaceholder showLoadingAnimation={true} rows={13} delay={300} />}>
           <CommentInputField
+            sessionkey={SESSION_KEY}
             comment={comment}
             setComment={setComment}
             enableHashtagPaste


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- #6684 

## Describe this PR
This PR adds functionality to `save the comment text in session storage` so that the user’s input persists when they reload the page or navigate away and come back.

**Changes**
- Store comment text in sessionStorage whenever the user types.
- Retrieve and restore the comment text when the component mounts.
- Clear the stored comment after successful submission.

## Alternative Approaches Considered
Considered showing a warning when the user tries to reload or navigate away, but saving the comment text in sessionStorage provides a smoother experience without interruptions.
Did you attempt any other approaches that are not documented in code?


## Checklist before requesting a review

- 📖 Read the Tasking Manager Contributing Guide: <https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.
