### PR TITLE
Accept numeric values only as a search input on project list of notification 

### DIFF
--- a/frontend/src/components/notifications/inboxNav.js
+++ b/frontend/src/components/notifications/inboxNav.js
@@ -120,7 +120,14 @@ export const InboxNav = (props) => {
             return (
               <ProjectSearchBox
                 className="dib fl mr2"
-                setQuery={setInboxQuery}
+                setQuery={(value) => {
+                  if (!value.project) {
+                    setInboxQuery({ ...inboxQuery, project: undefined });
+                    return;
+                  }
+                  if (value.project && isNaN(value.project)) return;
+                  setInboxQuery(value);
+                }}
                 fullProjectsQuery={inboxQuery}
                 placeholder={msg}
                 searchField={'project'}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issues 

- #7078

## Describe this PR
Ignores the alphabetical values as a search parameter so the user is restricted to search projects by project `id` only.
