### PR TITLE
Remove undefined listed as a hashtag

### DIFF
--- a/frontend/src/components/partners/partnersActivity.js
+++ b/frontend/src/components/partners/partnersActivity.js
@@ -6,7 +6,7 @@ import PartnersProgresBar from './partnersProgresBar';
 import messages from './messages';
 import { OHSOME_STATS_API_URL } from '../../config';
 
-export const Activity = ({ partner }) => {
+export const Activity = ({ partner }: Object) => {
   const [data, setData] = useState(null);
 
   const fetchData = async () => {
@@ -17,10 +17,12 @@ export const Activity = ({ partner }) => {
       }
       primaryHashtag = primaryHashtag.toLowerCase();
 
-      const secondaryHashtags = partner.secondary_hashtag
-        ?.split(',')
-        ?.map((tag) => tag.trim().replace('#', '').toLowerCase())
-        ?.join(',');
+      const secondaryHashtags =
+        partner.secondary_hashtag
+          ?.split(',')
+          ?.map((tag) => tag.trim().replace('#', '').toLowerCase())
+          ?.join(',') || '';
+
       const response = await fetch(
         OHSOME_STATS_API_URL + `/stats/hashtags/${primaryHashtag},${secondaryHashtags}`,
       );


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- #7082

## Describe this PR
This change refactors how secondary hashtags are processed by ensuring the value defaults to an empty string ('') if it's null or undefined. This prevents unnecessary API calls and avoids treating undefined as an extra hashtag.

## Screenshots

<img width="628" height="229" alt="image" src="https://github.com/user-attachments/assets/c5d90e84-27a7-4cb5-b7f9-12e3f9777ad4" />
