### PR TITLE
Remove composite fk on project teams and add id pk

### DIFF
--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -29,6 +29,7 @@ from sqlalchemy import (
     orm,
     select,
     update,
+    UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -96,9 +97,15 @@ project_allowed_users = Table(
 
 class ProjectTeams(Base):
     __tablename__ = "project_teams"
-    team_id = Column(Integer, ForeignKey("teams.id"), primary_key=True)
-    project_id = Column(Integer, ForeignKey("projects.id"), primary_key=True)
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    team_id = Column(Integer, ForeignKey("teams.id"), nullable=False)
+    project_id = Column(Integer, ForeignKey("projects.id"), nullable=False)
     role = Column(Integer, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("team_id", "project_id", "role", name="uq_project_team_role"),
+    )
 
     project = relationship(
         "Project", backref=backref("teams", cascade="all, delete-orphan")

--- a/migrations/versions/763165f937cf_.py
+++ b/migrations/versions/763165f937cf_.py
@@ -1,0 +1,54 @@
+"""
+
+Revision ID: 763165f937cf
+Revises: 4489b9e235f8
+Create Date: 2025-11-20 12:09:24.690604
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "763165f937cf"
+down_revision = "4489b9e235f8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("CREATE SEQUENCE IF NOT EXISTS project_teams_id_seq;")
+    op.add_column(
+        "project_teams",
+        sa.Column(
+            "id",
+            sa.BigInteger(),
+            nullable=True,
+            server_default=sa.text("nextval('project_teams_id_seq'::regclass)"),
+        ),
+    )
+    op.execute(
+        "UPDATE project_teams SET id = nextval('project_teams_id_seq') WHERE id IS NULL;"
+    )
+    op.alter_column("project_teams", "id", nullable=False)
+    op.execute("ALTER SEQUENCE project_teams_id_seq OWNED BY project_teams.id;")
+    op.create_unique_constraint(
+        "uq_project_team_role", "project_teams", ["team_id", "project_id", "role"]
+    )
+    op.drop_constraint("project_teams_pkey", "project_teams", type_="primary")
+    op.create_primary_key("project_teams_pkey", "project_teams", ["id"])
+    op.create_index("ix_project_teams_project_id", "project_teams", ["project_id"])
+    op.create_index("ix_project_teams_team_id", "project_teams", ["team_id"])
+
+
+def downgrade():
+    op.drop_constraint("project_teams_pkey", "project_teams", type_="primary")
+    op.drop_index("ix_project_teams_project_id", table_name="project_teams")
+    op.drop_index("ix_project_teams_team_id", table_name="project_teams")
+    op.create_primary_key(
+        "project_teams_pkey", "project_teams", ["team_id", "project_id"]
+    )
+    op.drop_constraint("uq_project_team_role", "project_teams", type_="unique")
+    op.drop_column("project_teams", "id")
+    op.execute("DROP SEQUENCE IF EXISTS project_teams_id_seq;")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #7084

## Describe this PR

The project teams had a composite foreign key with project id and team id which didn't allow the same team to be assigned to a project even though it was assigned with a different role.

Removed the composite foreign key and added id as primary key to project teams table.

Made project, team and role combination unique as one team can only have a particular role in a project and roles cannot be duplicated for a particular project.


## Alternative Approaches Considered

Could simply add the role attribute in the composite key too so that unique combination of project id, team id and role could be the fk. But if in future, the project teams is linked to other classes then referencing it could cause overheads and simply introducing a new attribute id as foreign key and making the combination unique seemed to be optimal.


