### PR TITLE
Access the team management page

### DIFF
--- a/frontend/src/views/management.js
+++ b/frontend/src/views/management.js
@@ -87,8 +87,12 @@ export const ManagementSection = (props) => {
       location.pathname === '/manage',
     [location.pathname],
   );
-  // access this page from here and restrictd on the page itslf if it has no edit access
-  const isProjectEditRoute = location.pathname.startsWith('/manage/projects') && id;
+
+  // access this page from here and restricted on the page itself if it has no edit access
+  const isProjectEditRoute =
+    (location.pathname.startsWith('/manage/projects') ||
+      location.pathname.startsWith('/manage/teams')) &&
+    id;
 
   return (
     <>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes: #7091 

## Describe this PR
Previously, the `/manage/teams` route was accessible only to users with the **admin** or **org admin** roles, as they were the only ones authorized to manage teams. However, there are cases where a user with team management permissions (but not admin or org admin roles) should also have access to this page.

To address this, the restriction is now enforced at the page level rather than the route level, allowing users with team management permissions to access the page while still restricting access for other roles.
