### PR TITLE
Tasks invalidated count for a particular project for choropleth map

### DIFF
--- a/backend/api/projects/statistics.py
+++ b/backend/api/projects/statistics.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from databases import Database
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
@@ -104,7 +106,7 @@ async def get_project_user_stats(
 
 @router.get("/{project_id}/tasks/invalidated/")
 async def get_project_invalidated_counts(
-    project_id: int, db: Database = Depends(get_db)
+    project_id: int, db: Annotated[Database, Depends(get_db)]
 ):
     """
     Return all tasks in a project with the number of times each task was invalidated.

--- a/frontend/src/api/projects.js
+++ b/frontend/src/api/projects.js
@@ -138,6 +138,22 @@ export const useTasksQuery = (projectId, otherOptions = {}) => {
   });
 };
 
+export const useInvalidatedTasksQuery = (projectId, otherOptions = {}) => {
+  const token = useSelector((state) => state.auth.token);
+  const fetchInvalidatedTasks = ({ signal }) => {
+    return api(token).get(`projects/${projectId}/tasks/invalidated/`, {
+      signal,
+    });
+  };
+
+  return useQuery({
+    queryKey: ['project-invalidated-tasks', projectId],
+    queryFn: fetchInvalidatedTasks,
+    select: (data) => data.data.tasks,
+    ...otherOptions,
+  });
+};
+
 export const usePriorityAreasQuery = (projectId) => {
   const fetchProjectPriorityArea = (signal) => {
     return api().get(`projects/${projectId}/queries/priority-areas/`, {

--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -30,6 +30,7 @@ import {
   useActivitiesQuery,
   useProjectContributionsQuery,
   useTasksQuery,
+  useInvalidatedTasksQuery,
 } from '../../api/projects';
 import { useTeamsQuery } from '../../api/teams';
 
@@ -70,6 +71,7 @@ export function TaskSelection({ project }: Object) {
   const [activeStatus, setActiveStatus] = useState(null);
   const [activeUser, setActiveUser] = useState(null);
   const [textSearch, setTextSearch] = useQueryParam('search', StringParam);
+  const [showChoropleth, setShowChoropleth] = useState(false);
   const isFirstRender = useRef(true); // to check if component is rendered first time
 
   const { data: userTeams, isLoading: isUserTeamsLoading } = useTeamsQuery(
@@ -101,6 +103,14 @@ export function TaskSelection({ project }: Object) {
     isLoading: isPriorityAreasLoading,
     isLoadingError: isPriorityAreasLoadingError,
   } = usePriorityAreasQuery(projectId);
+
+  const { data: invalidatedTasksData } = useInvalidatedTasksQuery(projectId, {
+    enabled: showChoropleth,
+    // No staleTime — data is immediately stale so React Query refetches on
+    // every window focus or remount. This ensures if a user invalidates a task
+    // and comes back to this page, the count is always up to date.
+    refetchOnWindowFocus: true,
+  });
 
   const tasks = useMemo(
     () => (tasksData && activities ? updateTasksStatus(tasksData, activities) : undefined),
@@ -377,8 +387,11 @@ export function TaskSelection({ project }: Object) {
                 taskBordersOnly={false}
                 priorityAreas={priorityAreas}
                 animateZoom={false}
+                showChoropleth={showChoropleth}
+                invalidatedTasksData={invalidatedTasksData}
+                onToggleChoropleth={() => setShowChoropleth((v) => !v)}
               />
-              <TasksMapLegend />
+              <TasksMapLegend showChoropleth={showChoropleth} />
             </ReactPlaceholder>
           )}
         </div>

--- a/frontend/src/components/taskSelection/legend.js
+++ b/frontend/src/components/taskSelection/legend.js
@@ -5,44 +5,96 @@ import messages from './messages';
 import { TaskStatus } from './taskList';
 import { LockIcon, ChevronDownIcon, ChevronUpIcon } from '../svgIcons';
 
-export function TasksMapLegend() {
+// Colour stops that exactly match the MapLibre interpolate expression in map.js
+const RAMP = [
+  { value: 0, color: '#f9fafb', label: '0' },
+  { value: 1, color: '#fde68a', label: '1' },
+  { value: 3, color: '#f97316', label: '3' },
+  { value: 6, color: '#b91c1c', label: '6+' },
+];
+
+function ChoroplethGradientLegend() {
+  const gradient = RAMP.map((s) => s.color).join(', ');
+  return (
+    <div className="mt2">
+      {/* Continuous gradient bar — mirrors the interpolate ramp on the map */}
+      <div
+        style={{
+          height: 14,
+          borderRadius: 3,
+          background: `linear-gradient(to right, ${gradient})`,
+          border: '1px solid #d1d5db',
+        }}
+      />
+      {/* Tick labels at each colour stop */}
+      <div className="flex justify-between mt1">
+        {RAMP.map(({ value, label }) => (
+          <span key={value} className="f7 blue-dark" style={{ lineHeight: 1 }}>
+            {label}
+          </span>
+        ))}
+      </div>
+      {/* <p className="f7 blue-dark mv1 i">
+        <FormattedMessage {...messages.invalidationChoroplethRampHint} />
+      </p> */}
+    </div>
+  );
+}
+
+export function TasksMapLegend({ showChoropleth = false }) {
   const lineClasses = 'mv2 blue-dark f5';
   const [expand, setExpand] = useState(true);
+
   return (
-    <div className="cf left-1 bottom-2 absolute bg-white pa2 br1">
-      <h4
-        className="fw6 pointer f4 ttu barlow-condensed mt0 mb2"
-        onClick={() => setExpand(!expand)}
-      >
-        <FormattedMessage {...messages.legend} />
-        {expand ? <ChevronDownIcon className="pl2" /> : <ChevronUpIcon className="pl2" />}
-      </h4>
+    <div className="cf left-1 bottom-2 absolute bg-white pa2 br1" style={{ minWidth: 180 }}>
+      {/* ── Header row: title + collapse chevron ── */}
+      <div className="flex items-center justify-between">
+        <h4
+          className="fw6 pointer f4 ttu barlow-condensed mt0 mb0 flex-auto"
+          onClick={() => setExpand(!expand)}
+        >
+          {showChoropleth ? (
+            <FormattedMessage {...messages.invalidationChoropleth} />
+          ) : (
+            <FormattedMessage {...messages.legend} />
+          )}
+          {expand ? <ChevronDownIcon className="pl2" /> : <ChevronUpIcon className="pl2" />}
+        </h4>
+      </div>
+
+      {/* ── Legend items ── */}
       {expand && (
-        <div>
-          <p className={lineClasses}>
-            <TaskStatus status="READY" />
-          </p>
-          <p className={lineClasses}>
-            <TaskStatus status="MAPPED" />
-          </p>
-          <p className={lineClasses}>
-            <TaskStatus status="INVALIDATED" />
-          </p>
-          <p className={lineClasses}>
-            <TaskStatus status="VALIDATED" />
-          </p>
-          <p className={lineClasses}>
-            <TaskStatus status="BADIMAGERY" />
-          </p>
-          <p className={lineClasses}>
-            <TaskStatus status="PRIORITY_AREAS" />
-          </p>
-          <p className={lineClasses}>
-            <LockIcon style={{ paddingTop: '1px' }} className="v-mid h1 w1" />
-            <span className="pl2 v-mid">
-              <FormattedMessage {...messages[`taskStatus_LOCKED`]} />
-            </span>
-          </p>
+        <div className="mt1">
+          {showChoropleth ? (
+            <ChoroplethGradientLegend />
+          ) : (
+            <>
+              <p className={lineClasses}>
+                <TaskStatus status="READY" />
+              </p>
+              <p className={lineClasses}>
+                <TaskStatus status="MAPPED" />
+              </p>
+              <p className={lineClasses}>
+                <TaskStatus status="INVALIDATED" />
+              </p>
+              <p className={lineClasses}>
+                <TaskStatus status="VALIDATED" />
+              </p>
+              <p className={lineClasses}>
+                <TaskStatus status="BADIMAGERY" />
+              </p>
+              <p className={lineClasses}>
+                <TaskStatus status="PRIORITY_AREAS" />
+              </p>
+              <p className={lineClasses}>
+                <LockIcon style={{ paddingTop: '1px' }} className="v-mid h1 w1" />
+                <span className="pl2 v-mid">
+                  <FormattedMessage {...messages[`taskStatus_LOCKED`]} />
+                </span>
+              </p>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/taskSelection/map.js
+++ b/frontend/src/components/taskSelection/map.js
@@ -5,6 +5,8 @@ import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { FormattedMessage, useIntl } from 'react-intl';
 
+import { NineCellsGridIcon } from '../svgIcons';
+
 import WebglUnsupported from '../webglUnsupported';
 import isWebglSupported from '../../utils/isWebglSupported';
 import useSetRTLTextPlugin from '../../utils/useSetRTLTextPlugin';
@@ -33,6 +35,9 @@ export const TasksMap = ({
   animateZoom = true,
   showTaskIds = false,
   selected: selectedOnMap,
+  invalidatedTasksData,
+  showChoropleth = false,
+  onToggleChoropleth,
 }) => {
   const intl = useIntl();
   const mapRef = createRef();
@@ -500,6 +505,120 @@ export const TasksMap = ({
     intl,
   ]);
 
+  /* ------------------------------------------------------------------
+   * Choropleth effect: add / update / remove the invalidation-count layer
+   * ------------------------------------------------------------------ */
+  useLayoutEffect(() => {
+    if (!map) return;
+
+    const CHOROPLETH_SOURCE = 'tasks-invalidation-choropleth';
+    const CHOROPLETH_LAYER = 'tasks-invalidation-fill';
+
+    const buildChoroplethGeoJSON = () => {
+      if (!mapResults || !invalidatedTasksData) return null;
+      const countMap = {};
+      invalidatedTasksData.forEach(({ taskId, invalidatedCount }) => {
+        countMap[taskId] = invalidatedCount;
+      });
+      return {
+        type: 'FeatureCollection',
+        features: mapResults.features.map((f) => ({
+          ...f,
+          properties: {
+            ...f.properties,
+            invalidatedCount: countMap[f.properties.taskId] || 0,
+          },
+        })),
+      };
+    };
+
+    if (!showChoropleth) {
+      // Restore the normal task-status fill opacity
+      if (map.getLayer('tasks-fill')) {
+        map.setPaintProperty('tasks-fill', 'fill-opacity', 0.8);
+      }
+      // Hide the choropleth overlay
+      if (map.getLayer(CHOROPLETH_LAYER)) {
+        map.setLayoutProperty(CHOROPLETH_LAYER, 'visibility', 'none');
+      }
+      return;
+    }
+
+    if (!invalidatedTasksData || !mapResults?.features?.length) return;
+
+    const geojson = buildChoroplethGeoJSON();
+    if (!geojson) return;
+
+    const addOrUpdateLayer = () => {
+      try {
+        // Make tasks-fill invisible (opacity=0) but keep it in the layer stack
+        // so MapLibre click hit-testing still works on it.
+        if (map.getLayer('tasks-fill')) {
+          map.setPaintProperty('tasks-fill', 'fill-opacity', 0);
+        }
+
+        if (map.getSource(CHOROPLETH_SOURCE)) {
+          map.getSource(CHOROPLETH_SOURCE).setData(geojson);
+          if (map.getLayer(CHOROPLETH_LAYER)) {
+            map.setLayoutProperty(CHOROPLETH_LAYER, 'visibility', 'visible');
+          }
+          return;
+        }
+
+        map.addSource(CHOROPLETH_SOURCE, { type: 'geojson', data: geojson });
+
+        const layerDef = {
+          id: CHOROPLETH_LAYER,
+          type: 'fill',
+          source: CHOROPLETH_SOURCE,
+          paint: {
+            'fill-color': [
+              'interpolate', ['linear'], ['get', 'invalidatedCount'],
+              0, '#f9fafb',   // never invalidated: near-white
+              1, '#fde68a',   // once: light amber
+              3, '#f97316',   // moderate: orange
+              6, '#b91c1c',   // high: deep red
+            ],
+            'fill-opacity': 1,
+          },
+          layout: { visibility: 'visible' },
+        };
+
+        // Insert BEFORE the border layers so grid lines always render on top.
+        // Fall back to appending only if no border layers exist yet.
+        const beforeLayer = map.getLayer('unselected-tasks-border')
+          ? 'unselected-tasks-border'
+          : map.getLayer('selected-tasks-border')
+          ? 'selected-tasks-border'
+          : undefined;
+
+        if (beforeLayer) {
+          map.addLayer(layerDef, beforeLayer);
+        } else {
+          map.addLayer(layerDef);
+        }
+      } catch (err) {
+        console.error('[Choropleth] Failed to add/update invalidation layer:', err);
+      }
+    };
+
+    // Attempt to add the layer immediately if the map is fully ready.
+    // If not (e.g. style still loading or tasks source not yet registered),
+    // defer to the next 'idle' event, which fires once all sources/tiles settle.
+    if (map.isStyleLoaded() && map.getSource('tasks') !== undefined) {
+      addOrUpdateLayer();
+    } else {
+      // 'load' only fires once and may already have fired; use 'idle' as
+      // a reliable one-shot that fires after all pending operations settle.
+      const onIdle = () => {
+        addOrUpdateLayer();
+        map.off('idle', onIdle);
+      };
+      map.on('idle', onIdle);
+      return () => map.off('idle', onIdle);
+    }
+  }, [map, showChoropleth, invalidatedTasksData, mapResults]);
+
   if (!isWebglSupported()) {
     return <WebglUnsupported className={`w-100 h-100 fr ${className || ''}`} />;
   } else {
@@ -510,6 +629,44 @@ export const TasksMap = ({
             <FormattedMessage {...messages.taskId} values={{ id: hoveredTaskId }} />
           </div>
         )}
+
+        {/* Choropleth toggle — icon-only square, grouped below zoom controls */}
+        {onToggleChoropleth && (
+          <button
+            id="invalidation-choropleth-toggle"
+            onClick={onToggleChoropleth}
+            title={showChoropleth ? 'Hide invalidation heatmap' : 'Show invalidation heatmap'}
+            style={{
+              position: 'absolute',
+              top: 103,   // 10px margin + 58px zoom cluster + 29px compass + 6px gap
+              right: 10,
+              zIndex: 5,
+              width: 29,
+              height: 29,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: 0,
+              border: 'none',
+              borderRadius: 4,
+              background: showChoropleth ? '#fff0f0' : '#ffffff',
+              cursor: 'pointer',
+              // Matches MapLibre's .maplibregl-ctrl-group box-shadow exactly
+              boxShadow: '0 0 0 2px rgba(0,0,0,.1)',
+              transition: 'background 0.15s',
+            }}
+          >
+            <NineCellsGridIcon
+              style={{
+                width: 15,
+                height: 15,
+                fill: showChoropleth ? '#d73f3f' : '#404040',
+                transition: 'fill 0.15s',
+              }}
+            />
+          </button>
+        )}
+
         <div id="map" className={className} ref={mapRef}></div>
       </>
     );

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -926,4 +926,36 @@ export default defineMessages({
     id: 'project.tasks.osm_data_controls.show.title',
     defaultMessage: 'Show OSM features',
   },
+  invalidationChoropleth: {
+    id: 'project.tasks.map.invalidationChoropleth',
+    defaultMessage: 'Legend',
+  },
+  invalidationChoroplethToggle: {
+    id: 'project.tasks.map.invalidationChoropleth.toggle',
+    defaultMessage: 'Show invalidation heatmap',
+  },
+  invalidationChoroplethLegendTitle: {
+    id: 'project.tasks.map.invalidationChoropleth.legend.title',
+    defaultMessage: 'Invalidation count',
+  },
+  invalidationChoroplethNone: {
+    id: 'project.tasks.map.invalidationChoropleth.legend.none',
+    defaultMessage: 'Never invalidated',
+  },
+  invalidationChoroplethLow: {
+    id: 'project.tasks.map.invalidationChoropleth.legend.low',
+    defaultMessage: '1–2 times',
+  },
+  invalidationChoroplethMedium: {
+    id: 'project.tasks.map.invalidationChoropleth.legend.medium',
+    defaultMessage: '3–5 times',
+  },
+  invalidationChoroplethHigh: {
+    id: 'project.tasks.map.invalidationChoropleth.legend.high',
+    defaultMessage: '6+ times',
+  },
+  invalidationChoroplethRampHint: {
+    id: 'project.tasks.map.invalidationChoropleth.legend.rampHint',
+    defaultMessage: 'Colour blends continuously between stops',
+  },
 });

--- a/frontend/src/components/taskSelection/tests/legend.test.js
+++ b/frontend/src/components/taskSelection/tests/legend.test.js
@@ -13,7 +13,8 @@ test('Legend collapse / expand when clicking', async () => {
     </ReduxIntlProviders>,
   );
 
-  expect(screen.getByText('Legend').className).toBe('fw6 pointer f4 ttu barlow-condensed mt0 mb2');
+  // Legend title is present and all items are visible initially
+  expect(screen.getByText('Legend')).toBeInTheDocument();
   expect(screen.getByText('Available for mapping')).toBeInTheDocument();
   expect(screen.getByText('Ready for validation')).toBeInTheDocument();
   expect(screen.getByText('Unavailable')).toBeInTheDocument();
@@ -21,8 +22,12 @@ test('Legend collapse / expand when clicking', async () => {
   expect(screen.getByText('More mapping needed')).toBeInTheDocument();
   expect(screen.getByText('Finished')).toBeInTheDocument();
   expect(screen.getByText('Locked')).toBeInTheDocument();
+
+  // Clicking the legend title collapses the items
   await user.click(screen.getByText('Legend'));
   expect(screen.queryByText('Available for mapping')).not.toBeInTheDocument();
+
+  // Clicking again expands the items
   await user.click(screen.getByText('Legend'));
   expect(screen.getByText('Available for mapping')).toBeInTheDocument();
 });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [x] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #7111 

## Describe this PR

A chloropleth map on each project's tasks page based on number of times the tasks on the project has been invalidated.

## Frontend Changes
- Adds an invalidation choropleth overlay to the project tasks map. A toggle button (grouped with the zoom controls) lets users visualise how many times each task has been invalidated using a continuous colour ramp from white (never invalidated) through amber and orange to deep red (6+ times). The legend updates in-place to show the gradient scale when active, and reverts to the normal task-status legend when toggled off. Task borders and click-to-select behaviour are preserved while the overlay is on.

## Screenshots
<img width="1915" height="959" alt="image" src="https://github.com/user-attachments/assets/d2b1daa0-a8f1-4ec0-aeb1-38b723c32a0a" />
