### PR TITLE
Fix incorrect user task total on contributions page

### DIFF
--- a/backend/services/stats_service.py
+++ b/backend/services/stats_service.py
@@ -382,7 +382,7 @@ class StatsService:
                 COALESCE(m.count, 0) AS mapped,
                 COALESCE(v.count, 0) AS validated,
                 COALESCE(b.count, 0) AS bad_imagery,
-                COALESCE(m.count, 0) + COALESCE(v.count, 0) + COALESCE(b.count, 0) AS total,
+                COALESCE(m.count, 0) + COALESCE(v.count, 0) AS total,
                 COALESCE(m.task_ids, '{}') AS mapped_tasks,
                 COALESCE(v.task_ids, '{}') AS validated_tasks,
                 COALESCE(b.task_ids, '{}') AS bad_imagery_tasks


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #7115

## Describe this PR

The total task count on the contributions page incorrectly includes `bad_imagery` tasks, but the frontend only displays `mapped` and `validated` counts. This causes the total to not match the sum of the displayed values (e.g., 39 mapped + 0 validated = 40 total).

This fix removes `bad_imagery` from the total calculation so it correctly reflects `mapped + validated`.

## Screenshots

N/A - calculation fix only

## Review Guide

1. Go to any project contributions page
2. Verify that total = mapped + validated for each user