### PR TITLE
Fix task list page jumping to wrong page on selection with sort

### DIFF
--- a/frontend/src/components/taskSelection/taskList.js
+++ b/frontend/src/components/taskSelection/taskList.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
 import Popup from 'reactjs-popup';
 import { useQueryParam, NumberParam, StringParam } from 'use-query-params';
@@ -405,16 +405,23 @@ function PaginatedList({
     }
   }, [items, page, lastPage, setPage]);
 
+  // Keep a ref to items that's always current (updated synchronously on render)
+  // This allows the selection effect to use fresh items without re-running on items changes
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+
   useEffect(() => {
     // switch the taskList page to always show the selected task.
     // Only do it if there is only one task selected
     if (selected.length === 1) {
-      const taskIndex = items.findIndex((task) => task.properties.taskId === selected[0]);
+      const taskIndex = itemsRef.current.findIndex(
+        (task) => task.properties.taskId === selected[0],
+      );
       if (taskIndex >= 0) {
         setPage(Math.ceil((taskIndex + 1) / pageSize));
       }
     }
-  }, [selected, items, setPage, pageSize]);
+  }, [selected, setPage, pageSize]);
 
   return (
     <>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #6850

## Describe this PR

When selecting a task while sorting by "least recently updated", the task list would jump to the wrong page, making the selected task not visible in the list.

The issue was caused by a stale ref pattern in the `PaginatedList` component. The page calculation used `latestItems.current` which could be out of sync with the actual sorted items array due to React's effect ordering.

The fix uses `items` directly in the useEffect and adds it to the dependency array, ensuring the page calculation always uses the current sorted list.

## Review Guide

1. Go to any project with tasks
2. Click on Tasks tab
3. Filter for "Available for mapping" and sort by "Least recently updated"
4. Select a task from the map or list
5. Verify the task list page navigates to show the selected task