### PR TITLE
Fix: exclude split tasks from contribution counts

### DIFF
--- a/backend/services/users/user_service.py
+++ b/backend/services/users/user_service.py
@@ -91,6 +91,7 @@ class UserService:
             FROM task_history
             WHERE user_id = :user_id
             AND action = 'STATE_CHANGE'
+            AND action_text IN ('MAPPED', 'VALIDATED', 'INVALIDATED')
             AND DATE(action_date) > CURRENT_DATE - INTERVAL '1 year'
             GROUP BY day
             ORDER BY day DESC;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Fixes #5601

## Describe this PR

When a task is split, the system creates STATE_CHANGE entries with action_text values of 'SPLIT' and 'READY' for each new task. These were incorrectly being counted as user contributions in the contributions-by-day query.

This PR adds a filter to only count MAPPED, VALIDATED, and INVALIDATED actions as contributions, matching the expected behavior described in the issue.