### PR TITLE
In case of sandbox project set the default editor as a `ID editor` and ignore the user's default editor.

### DIFF
--- a/frontend/src/components/taskSelection/footer.js
+++ b/frontend/src/components/taskSelection/footer.js
@@ -28,7 +28,7 @@ const TaskSelectionFooter = ({
   const { pathname } = useLocation();
   const token = useSelector((state) => state.auth.token);
   const locale = useSelector((state) => state.preferences.locale);
-  const [editor, setEditor] = useState(defaultUserEditor);
+  const [editor, setEditor] = useState(project?.sandbox ? 'ID' : defaultUserEditor);
   const [editorOptions, setEditorOptions] = useState([]);
   const [isPending, setIsPending] = useState(false);
   const [lockError, setLockError] = useState(null);
@@ -181,7 +181,7 @@ const TaskSelectionFooter = ({
     project?.database,
   ]);
 
-  const updateEditor = (arr) => setEditor(arr[0].value);
+  const updateEditor = (arr) => setEditor(arr?.[0].value);
   const titleClasses = 'db ttu f7 blue-grey mb2 fw5';
 
   return (


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Fixes #7177

## Describe this PR
For sandbox projects, ignore the user's default editor and set it to an `ID editor`, since we don't have other editor options for sandbox projects. 