### PR TITLE
Do not raise an exception if external stats endpoint fails, so login can work again. More verbosity for errors.

### DIFF
--- a/backend/services/users/user_service.py
+++ b/backend/services/users/user_service.py
@@ -187,10 +187,13 @@ class UserService:
             changeset_response = await client.get(osm_user_details_url)
 
         if oh_some_response.status_code != 200:
-            error_msg = "External-Error in Ohsome API: url=%s status_code=%s response=%s" % (
-                oh_some_url,
-                oh_some_response.status_code,
-                oh_some_response.text[:500]
+            error_msg = (
+                "External-Error in Ohsome API: url=%s status_code=%s response=%s"
+                % (
+                    oh_some_url,
+                    oh_some_response.status_code,
+                    oh_some_response.text[:500],
+                )
             )
             logger.exception(error_msg)
             return {}
@@ -198,10 +201,13 @@ class UserService:
         topic_data = oh_some_response.json()
 
         if changeset_response.status_code != 200:
-            error_msg = "External-Error in OSM API: url=%s status_code=%s response=%s" % (
-                osm_user_details_url,
-                changeset_response.status_code,
-                changeset_response.text[:500]
+            error_msg = (
+                "External-Error in OSM API: url=%s status_code=%s response=%s"
+                % (
+                    osm_user_details_url,
+                    changeset_response.status_code,
+                    changeset_response.text[:500],
+                )
             )
             logger.exception(error_msg)
             return {}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🐛 Hot Fix

## Describe this PR

Today people started to report problems with logging in. After some testing, I saw an error in the backend logs when the users stats are updated. In the production instance we can see this error:

```2026-03-07 20:37:04.238 | DEBUG    | loguru._logger:debug:2040 - External-Error in OSM API```

I've added more verbosity for the error logs in the function that update and save user stats and running TM locally I got HTTP error code `429` "Too many requests".

This PR adds more verbosity but also let the process continue when there's an error in an external stats API (OSM or OhSome), returning an empty object and not updating stats for the user.

## Review Guide

AFAIK, returning an empty object for stats should not affect anything. Stats will be outdated until the both external stats services are working, but please take a look into this to be sure.

You can block any external stats URL manually (ex: using /etc/hosts) and see how it works when a requests fail. The error log will include more details now.

Then you can test this code in development/staging/prod to check that everything is working ok. Even if the OSM server keeps returning "Too many requests", login and other features should work, the affected features will be user stats reporting and badges + updating mapper level.

