### PR TITLE
Fix task splitting when drawing area

### DIFF
--- a/frontend/src/components/projectCreate/setTaskSizes.js
+++ b/frontend/src/components/projectCreate/setTaskSizes.js
@@ -81,7 +81,7 @@ export default function SetTaskSizes({ metadata, mapObj, updateMetadata }) {
       }
 
       if (newFeature.length > 0) {
-        const geom = transformScale(newFeature[0].geometry, 0.5);
+        const geom = newFeature[0].geometry;
         const taskGrid = mapObj.map.getSource('grid')._data;
         if (metadata.tempTaskGrid === null) {
           updateMetadata({ ...metadata, tempTaskGrid: taskGrid });
@@ -179,16 +179,18 @@ export default function SetTaskSizes({ metadata, mapObj, updateMetadata }) {
           </p>
           <div role="group">
             <CustomButton
-              className={`bg-white ph3 pv2 mr2 ba ${splitMode === 'click' ? 'red b--red' : 'blue-dark b--grey-light'
-                }`}
+              className={`bg-white ph3 pv2 mr2 ba ${
+                splitMode === 'click' ? 'red b--red' : 'blue-dark b--grey-light'
+              }`}
               onClick={() => setSplitMode(splitMode === 'click' ? null : 'click')}
               icon={<CircleIcon className="v-mid" style={{ width: '0.5rem' }} />}
             >
               <FormattedMessage {...messages.splitByClicking} />
             </CustomButton>
             <CustomButton
-              className={`bg-white ph3 pv2 mr2 ba ${splitMode === 'draw' ? 'red b--red' : 'blue-dark b--grey-light'
-                }`}
+              className={`bg-white ph3 pv2 mr2 ba ${
+                splitMode === 'draw' ? 'red b--red' : 'blue-dark b--grey-light'
+              }`}
               onClick={splitDrawing}
               icon={<MappedIcon className="h1 w1 v-mid" />}
             >


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #7135 

## Describe this PR
This PR fixes the issue where the "split by drawing" tool only split some of the selected tasks instead of all tasks that touched the drawn area.

Changes:
The scaling factor (0.5) has been removed from the splitDrawing logic. Now uses the 100% full geometry as drawn by the user, ensuring every task touched by the polygon is correctly identified and split.

