### PR TITLE
Fixed Translation Bug On Task Completeness Question

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/static/favicon.ico" />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -48,6 +48,10 @@ const App = () => {
     store.dispatch(getUserDetails(store.getState()));
   }, []);
 
+  useEffect(() => {
+    document.documentElement.lang = locale;
+  }, [locale]);
+
   return (
     <ErrorBoundary fallback={<FallbackComponent />}>
       {isLoading ? (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "tasking-manager",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION

## What type of PR is this?

Bug Fix

## Related Issue

Fixes #7108 

## Describe this PR

This PR fixes a reported "bizarre" translation issue where Czech users saw incorrect terms like "JOB STATUS" (instead of TASK STATUS), "Again" (instead of Yes), and "Yes" (instead of No).

Root Cause: The application was missing the lang attribute on the <html> element. This caused browsers (specifically Chrome) to attempt auto-detection of the page language. In some cases, the browser incorrectly guessed the language or attempted to auto-translate short strings (like "Ano"/"Ne") into English using incorrect mappings, leading to hallucinations like "Again" and "Yes".

Solution:

index.html: Added a default lang="en" to the <html> tag.
App.js: Added a useEffect hook to dynamically update document.documentElement.lang whenever the application locale changes. This informs the browser exactly what language is being displayed, preventing inappropriate auto-translation triggers.


## Review Guide

Open the application and change the language to Czech (or any other language).
Inspect the page source/DOM using Developer Tools.
Verify that the <html> tag has the correct lang attribute (e.g., <html lang="cs">).
Switch back to English and verify it updates to <html lang="en">.