### PR TITLE
Hide OSMCha buttons and changeset resources for sandbox projects

### DIFF
--- a/frontend/src/components/projectDetail/index.js
+++ b/frontend/src/components/projectDetail/index.js
@@ -167,6 +167,7 @@ export const ProjectDetail = (props) => {
   const minimumValidationLevel = levels
     .find((level) => level.id === props.project.validationPermissionLevelId);
 
+  const isSandbox = props.project.sandbox;
   return (
     <div className={`${props.className || 'blue-dark'}`}>
       <div className="db flex-l tasks-map-height">
@@ -255,32 +256,32 @@ export const ProjectDetail = (props) => {
           alignItems: "baseline",
           gap: "1rem",
         }}>
-          <h4 className="mb2 mt0 fw6">
-            <FormattedMessage {...messages.whoCanMap} />
-          </h4>
-          <PermissionBox
-            permission={props.project.mappingPermission}
-            className="dib pv2 ph3 red"
-          />
-          <FormattedMessage {...messages.having} />
-          <div className={`tc br1 f6 ba dib pv2 ph3 red`}>
-            {minimumMappingLevel && minimumMappingLevel.name}
-          </div>
-          <FormattedMessage {...messages.levelOrAbove} />
+            <h4 className="mb2 mt0 fw6">
+              <FormattedMessage {...messages.whoCanMap} />
+            </h4>
+            <PermissionBox
+              permission={props.project.mappingPermission}
+              className="dib pv2 ph3 red"
+            />
+            <FormattedMessage {...messages.having} />
+            <div className={`tc br1 f6 ba dib pv2 ph3 red`}>
+              {minimumMappingLevel && minimumMappingLevel.name}
+            </div>
+            <FormattedMessage {...messages.levelOrAbove} />
 
-          <h4 className="mb2 mt0 fw6">
-            <FormattedMessage {...messages.whoCanValidate} />
-          </h4>
-          <PermissionBox
-            permission={props.project.validationPermission}
-            validation
-            className="dib pv2 ph3 red"
-          />
-          <FormattedMessage {...messages.having} />
-          <div className={`tc br1 f6 ba dib pv2 ph3 red`}>
-            {minimumValidationLevel && minimumValidationLevel.name}
-          </div>
-          <FormattedMessage {...messages.levelOrAbove} />
+            <h4 className="mb2 mt0 fw6">
+              <FormattedMessage {...messages.whoCanValidate} />
+            </h4>
+            <PermissionBox
+              permission={props.project.validationPermission}
+              validation
+              className="dib pv2 ph3 red"
+            />
+            <FormattedMessage {...messages.having} />
+            <div className={`tc br1 f6 ba dib pv2 ph3 red`}>
+              {minimumValidationLevel && minimumValidationLevel.name}
+            </div>
+            <FormattedMessage {...messages.levelOrAbove} />
         </div>}
 
         <div className="mt3">
@@ -375,10 +376,12 @@ export const ProjectDetail = (props) => {
               <FormattedMessage {...messages.moreStats} />
             </CustomButton>
           </Link>
-          <OSMChaButton
-            project={props.project}
-            className="bg-white blue-dark ba b--grey-light pa3"
-          />
+          {!isSandbox && (
+            <OSMChaButton
+              project={props.project}
+              className="bg-white blue-dark ba b--grey-light pa3"
+            />
+          )}
           <DownloadAOIButton
             projectId={props.project.projectId}
             className="bg-white blue-dark ba b--grey-light pa3"

--- a/frontend/src/components/projectDetail/index.js
+++ b/frontend/src/components/projectDetail/index.js
@@ -443,6 +443,7 @@ ProjectDetail.propTypes = {
     mappingPermission: PropTypes.string,
     validationPermission: PropTypes.string,
     teams: PropTypes.arrayOf(PropTypes.object),
+    sandbox: PropTypes.bool,
   }).isRequired,
   className: PropTypes.string,
 };

--- a/frontend/src/components/taskSelection/resourcesTab.js
+++ b/frontend/src/components/taskSelection/resourcesTab.js
@@ -23,43 +23,49 @@ export const ResourcesTab = ({ project, tasksIds, tasksGeojson }) => {
     [bbox, project.created, project.changesetComment],
   );
 
+  const isSandbox = project && project.sandbox;
+
   return (
     <>
-      <h4 className="ttu blue-grey f5">
-        <FormattedMessage {...messages.changesets} />
-      </h4>
-      <div className="ph2">
-        <p>
-          <OSMChaButton project={project}>
-            <CustomButton className="bg-white blue-dark ba b--grey-light pv2 ph3">
-              <FormattedMessage {...messages.entireProject} />
-              <ExternalLinkIcon className="pl2" />
-            </CustomButton>
-          </OSMChaButton>
-        </p>
-        <div className="w-100 cf flex flex-wrap">
-          {tasksIds.length > 1 && (
-            <Select
-              classNamePrefix="react-select"
-              className="z-4 flex-auto fl mr3 pb2"
-              isClearable={false}
-              getOptionLabel={(option) => option.label}
-              getOptionValue={(option) => option.value}
-              isMulti={false}
-              options={tasksIds.map((id) => ({ label: id, value: id }))}
-              placeholder={<FormattedMessage {...messages.selectTask} />}
-              isSearchable={true}
-              onChange={(selected) => setActiveTask(selected.value)}
-            />
-          )}
-          <a href={osmchaLink} target="_blank" rel="noopener noreferrer">
-            <CustomButton className={'bg-red b--red white ba pv2 ph3'} disabled={!activeTask}>
-              <FormattedMessage {...messages.seeTaskChangesets} />
-              <ExternalLinkIcon className="pl2" />
-            </CustomButton>
-          </a>
-        </div>
-      </div>
+      {!isSandbox && (
+        <>
+          <h4 className="ttu blue-grey f5">
+            <FormattedMessage {...messages.changesets} />
+          </h4>
+          <div className="ph2">
+            <p>
+              <OSMChaButton project={project}>
+                <CustomButton className="bg-white blue-dark ba b--grey-light pv2 ph3">
+                  <FormattedMessage {...messages.entireProject} />
+                  <ExternalLinkIcon className="pl2" />
+                </CustomButton>
+              </OSMChaButton>
+            </p>
+            <div className="w-100 cf flex flex-wrap">
+              {tasksIds.length > 1 && (
+                <Select
+                  classNamePrefix="react-select"
+                  className="z-4 flex-auto fl mr3 pb2"
+                  isClearable={false}
+                  getOptionLabel={(option) => option.label}
+                  getOptionValue={(option) => option.value}
+                  isMulti={false}
+                  options={tasksIds.map((id) => ({ label: id, value: id }))}
+                  placeholder={<FormattedMessage {...messages.selectTask} />}
+                  isSearchable={true}
+                  onChange={(selected) => setActiveTask(selected.value)}
+                />
+              )}
+              <a href={osmchaLink} target="_blank" rel="noopener noreferrer">
+                <CustomButton className={'bg-red b--red white ba pv2 ph3'} disabled={!activeTask}>
+                  <FormattedMessage {...messages.seeTaskChangesets} />
+                  <ExternalLinkIcon className="pl2" />
+                </CustomButton>
+              </a>
+            </div>
+          </div>
+        </>
+      )}
       <h4 className="ttu blue-grey f5">
         <FormattedMessage {...messages.projectData} />
       </h4>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
 Fixes #7175 

## Describe this PR

This PR hides the **OSMCha** buttons and the **Changesets** resources section for projects marked as **sandbox**. 

### Key Changes:
- **Project Detail Page:** Conditionally renders the 'OSMChaButton' only if the project is not a sandbox project.
- **Resources Tab:** Conditionally hides the entire 'Changesets' section (including the project-level OSMCha button and task-specific changeset links) for sandbox projects.

## Screenshots
 - Snapshot of `Project Detail` page  of the Sandbox Project in which `OSMChaButton` is  conditionally rendered.
 
<img width="1855" height="854" alt="image" src="https://github.com/user-attachments/assets/9932d436-4c66-41fd-8b1a-a1803faffdaf" />

- Snapshot of `Resource Tab` section
<img width="561" height="865" alt="image" src="https://github.com/user-attachments/assets/6b7dd71e-ad93-4bc1-9532-0ca90b31fb85" />



