### PR TITLE
Refactor: Improve task validation wording and layout structure

### DIFF
--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -473,23 +473,23 @@ export function CompletionTabForValidation({
         <h4 className="ttu blue-grey f5">
           <FormattedMessage {...messages.editStatus} />
         </h4>
-        <p className="b mb2">
+        {/* <p className="b mb2">
           <FormattedMessage {...messages.validatedQuestion} values={{ number: tasksIds.length }} />
-        </p>
+        </p> */}
         {tasksIds.length > 3 && (
           <div className="cf w-100 db pt1 pv2 blue-dark mb2 bb b--light-gray">
             <div className="cf w-100">
-              <div className="fw8 f5 w-10 dib">
+              <div className="fw8 f5 w-10 dib v-top pt2">
                 <FormattedMessage {...messages.filterAll} />
               </div>
-              <div className="w-auto dib">
+              <div className="w-80 dib">
                 {['VALIDATED', 'INVALIDATED'].map((value, index) => (
-                  <div className="dib" key={index}>
+                  <div className="flex items-start mb2" key={index}>
                     <input
                       type="radio"
                       id={value}
                       value={value}
-                      className="radio-input input-reset pointer v-mid dib h2 w2 mr2 ml3 br-100 ba b--blue-light"
+                      className="radio-input input-reset pointer flex-shrink-0 h2 w2 mr2 br-100 ba b--blue-light"
                       checked={
                         Object.values(validationStatus).every((status) => status === value) &&
                         Object.values(validationStatus).length === tasksIds.length
@@ -500,11 +500,11 @@ export function CompletionTabForValidation({
                         setValidationStatus(tempObj);
                       }}
                     />
-                    <label htmlFor={value}>
+                    <label htmlFor={value} className="pointer lh-copy">
                       {index ? (
-                        <FormattedMessage {...messages.incomplete} />
+                        <FormattedMessage {...messages.invalidMapping} />
                       ) : (
-                        <FormattedMessage {...messages.complete} />
+                        <FormattedMessage {...messages.validMapping} />
                       )}
                     </label>
                   </div>
@@ -604,34 +604,38 @@ const TaskValidationSelector = ({
   return (
     <div className="cf w-100 db pt1 pv2 blue-dark">
       <div className="cf w-100">
-        <div className="fw8 f5 w-10 dib">#{id}</div>
-        <div className="w-auto dib">
-          <input
-            type="radio"
-            value="VALIDATED"
-            id={`#${id}-VALIDATED`}
-            className="radio-input input-reset pointer v-mid dib h2 w2 mr2 ml3 br-100 ba b--blue-light"
-            checked={currentStatus === 'VALIDATED'}
-            onChange={() => updateStatus(id, 'VALIDATED')}
-          />
-          <label htmlFor={`#${id}-VALIDATED`}>
-            <FormattedMessage {...messages.complete} />
-          </label>
-          <input
-            type="radio"
-            value="INVALIDATED"
-            id={`#${id}-INVALIDATED`}
-            className="radio-input input-reset pointer v-mid dib h2 w2 mr2 ml3 br-100 ba b--blue-light"
-            checked={currentStatus === 'INVALIDATED'}
-            onChange={() => updateStatus(id, 'INVALIDATED')}
-          />
-          <label htmlFor={`#${id}-INVALIDATED`}>
-            <FormattedMessage {...messages.incomplete} />
-          </label>
+        <div className="fw8 f5 w-10 dib v-top pt2">#{id}</div>
+        <div className="w-80 dib">
+          <div className="flex items-start mb2">
+            <input
+              type="radio"
+              value="VALIDATED"
+              id={`#${id}-VALIDATED`}
+              className="radio-input input-reset pointer flex-shrink-0 h2 w2 mr2 br-100 ba b--blue-light"
+              checked={currentStatus === 'VALIDATED'}
+              onChange={() => updateStatus(id, 'VALIDATED')}
+            />
+            <label htmlFor={`#${id}-VALIDATED`} className="pointer lh-copy">
+              <FormattedMessage {...messages.validMapping} />
+            </label>
+          </div>
+          <div className="flex items-start mb2">
+            <input
+              type="radio"
+              value="INVALIDATED"
+              id={`#${id}-INVALIDATED`}
+              className="radio-input input-reset pointer flex-shrink-0 h2 w2 mr2 br-100 ba b--blue-light"
+              checked={currentStatus === 'INVALIDATED'}
+              onChange={() => updateStatus(id, 'INVALIDATED')}
+            />
+            <label htmlFor={`#${id}-INVALIDATED`} className="pointer lh-copy">
+              <FormattedMessage {...messages.invalidMapping} />
+            </label>
+          </div>
           <CustomButton
             className={`${
               showCommentInput ? 'b--red red' : 'b--grey-light blue-dark'
-            } bg-white ba br1 ml3 pv2 ph3`}
+            } bg-white ba br1 mt1 pv2 ph3`}
             onClick={() => setShowCommentInput(!showCommentInput)}
             icon={
               comment ? (

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -584,9 +584,18 @@ export default defineMessages({
     id: 'project.tasks.action.options.complete',
     defaultMessage: 'Yes',
   },
+  validMapping: {
+    id: 'project.tasks.action.options.valid_mapping',
+    defaultMessage: 'Task well mapped, thanks for mapping',
+  },
   incomplete: {
     id: 'project.tasks.action.options.incomplete',
     defaultMessage: 'No',
+  },
+  invalidMapping: {
+    id: 'project.tasks.action.options.invalid_mapping',
+    defaultMessage:
+      'More work is required to complete this task. Please carefully read the comment section for further information.',
   },
   badImagery: {
     id: 'project.tasks.action.options.bad_imagery',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #7182 

## Describe this PR

This PR updates the validation status labels in the task selection sidebar to provide clearer feedback for users. The previous "Yes/No" labels for task validation have been replaced with more descriptive messages:
   - Valid Mapping: "Task well mapped, thanks for mapping"
   - Invalid Mapping: "More work is required to complete this task. Please carefully read the comment section for further information."

The UI has also been reorganized to use a vertical list for these options, improving readability and alignment. The validatedQuestion paragraph was removed to streamline the interface. These changes address issue #7182.

## Screenshots
<img width="561" height="865" alt="image" src="https://github.com/user-attachments/assets/7518258b-3a57-4f75-a19f-55364e4b432e" />
