### PR TITLE
fix: Lock duration in extension task history action text and test cas…

### DIFF
--- a/backend/models/postgis/task.py
+++ b/backend/models/postgis/task.py
@@ -383,15 +383,22 @@ class TaskHistory(Base):
         try:
             # Fetch the last locked task history entry with raw SQL
             query = """
-                SELECT id, action_date
-                FROM task_history
-                WHERE task_id = :task_id
-                AND project_id = :project_id
-                AND action = :action
-                AND action_text IS NULL
-                AND user_id = :user_id
-                ORDER BY action_date DESC
-                LIMIT 1
+                WITH locked_rows AS (
+                    SELECT
+                        id,
+                        action_date,
+                        COUNT(*) OVER() AS total_rows
+                    FROM task_history
+                    WHERE task_id = :task_id
+                    AND project_id = :project_id
+                    AND action = :action
+                    AND action_text IS NULL
+                    AND user_id = :user_id
+                    ORDER BY action_date DESC, id DESC
+                    FETCH FIRST 1 ROW ONLY
+                )
+                SELECT id, action_date, total_rows
+                FROM locked_rows
             """
             values = {
                 "task_id": task_id,
@@ -409,6 +416,9 @@ class TaskHistory(Base):
                 # rather than showing the user an error that they can't fix.
                 # No record found, possibly a race condition or auto-unlock scenario.
                 return
+
+            if last_locked["total_rows"] > 1:
+                raise MultipleResultsFound()
 
             # Calculate the duration the task was locked for
             duration_task_locked = (
@@ -1183,6 +1193,14 @@ class Task(Base):
     ):
         """Unlock the task and change its state."""
         # Add task comment history if provided
+        if not undo:
+            last_history = await TaskHistory.get_last_action(project_id, task_id, db)
+            # To unlock a task the last action must have been either lock or extension
+            last_action = TaskAction[last_history.action]
+            await TaskHistory.update_task_locked_with_duration(
+                task_id, project_id, last_action, user_id, db
+            )
+
         if comment:
             await Task.set_task_history(
                 task_id,
@@ -1283,12 +1301,6 @@ class Task(Base):
                             "project_id": project_id,
                         },
                     )
-
-            # Update task locked duration in the history when `undo` is False
-            # Using a slightly evil side effect of Actions and Statuses having the same name here :)
-            await TaskHistory.update_task_locked_with_duration(
-                task_id, project_id, TaskStatus(current_status), user_id, db
-            )
         # Final query for updating task status
         final_update_query = """
             UPDATE tasks
@@ -1333,10 +1345,12 @@ class Task(Base):
                 db=db,
             )
         # Update task lock history with duration
+        last_history = await TaskHistory.get_last_action(project_id, task_id, db)
+        last_action = TaskAction[last_history.action]
         await TaskHistory.update_task_locked_with_duration(
             task_id=task_id,
             project_id=project_id,
-            lock_action=TaskStatus(task_status),
+            lock_action=last_action,
             user_id=user_id,
             db=db,
         )

--- a/backend/services/mapping_service.py
+++ b/backend/services/mapping_service.py
@@ -544,7 +544,6 @@ class MappingService:
             raise NotFound(
                 sub_code="TASK_NOT_FOUND", project_id=project_id, task_id=task_id
             )
-
         if TaskStatus(task.task_status) not in [
             TaskStatus.LOCKED_FOR_MAPPING,
             TaskStatus.LOCKED_FOR_VALIDATION,
@@ -574,14 +573,18 @@ class MappingService:
             task = await Task.get(task_id, extend_dto.project_id, db)
             action = (
                 TaskAction.EXTENDED_FOR_MAPPING
-                if task["task_status"] == TaskStatus.LOCKED_FOR_MAPPING
+                if TaskStatus(task.task_status) == TaskStatus.LOCKED_FOR_MAPPING
                 else TaskAction.EXTENDED_FOR_VALIDATION
             )
 
+            last_history = await TaskHistory.get_last_action(
+                extend_dto.project_id, task_id, db
+            )
+            last_action = TaskAction[last_history.action]
             await TaskHistory.update_task_locked_with_duration(
                 task_id,
                 extend_dto.project_id,
-                TaskStatus(task["task_status"]),
+                last_action,
                 extend_dto.user_id,
                 db,
             )

--- a/tests/api/integration/api/tasks/test_actions.py
+++ b/tests/api/integration/api/tasks/test_actions.py
@@ -655,6 +655,9 @@ class TestTasksActionsMappingUnlockAPI:
             task_status=TaskStatus.LOCKED_FOR_MAPPING.value,
             locked_by=self.test_user.id,
         )
+        await Task.lock_task_for_mapping(
+            1, self.test_project_id, self.test_user.id, self.db
+        )
         resp = await client.post(
             self.url,
             headers={"Authorization": f"Token {self.user_session_token}"},
@@ -673,10 +676,13 @@ class TestTasksActionsMappingUnlockAPI:
     async def test_mapping_unlock_returns_200_on_success_with_comment(
         self, client: AsyncClient
     ):
+
         await self._update_task(
             1,
-            task_status=TaskStatus.LOCKED_FOR_MAPPING.value,
-            locked_by=self.test_user.id,
+            task_status=TaskStatus.READY.value,
+        )
+        await Task.lock_task_for_mapping(
+            1, self.test_project_id, self.test_user.id, self.db
         )
         resp = await client.post(
             self.url,
@@ -778,8 +784,11 @@ class TestTasksActionsMappingStopAPI:
     async def test_mapping_stop_returns_200_on_success(self, client: AsyncClient):
         await self._update_task(
             1,
-            task_status=TaskStatus.LOCKED_FOR_MAPPING.value,
+            task_status=TaskStatus.READY.value,
             locked_by=self.test_user.id,
+        )
+        await Task.lock_task_for_mapping(
+            1, self.test_project_id, self.test_user.id, self.db
         )
         resp = await client.post(
             self.url,
@@ -797,8 +806,11 @@ class TestTasksActionsMappingStopAPI:
     ):
         await self._update_task(
             1,
-            task_status=TaskStatus.LOCKED_FOR_MAPPING.value,
+            task_status=TaskStatus.READY.value,
             locked_by=self.test_user.id,
+        )
+        await Task.lock_task_for_mapping(
+            1, self.test_project_id, self.test_user.id, self.db
         )
         resp = await client.post(
             self.url,
@@ -883,9 +895,7 @@ class TestTasksActionsValidationLockAPI:
         self, client: AsyncClient
     ):
         # set task 1 to READY (not allowed)
-        await self._update_task(
-            1, task_status=TaskStatus.READY.value, locked_by=self.test_user.id
-        )
+        await self._update_task(1, task_status=TaskStatus.READY.value)
         resp = await client.post(
             self.url,
             headers={"Authorization": f"Token {self.user_session_token}"},
@@ -1021,6 +1031,14 @@ class TestTasksActionsValidationUnlockAPI:
         self.user_session_token = _encode_token(raw)
         self.url = f"/api/v2/projects/{self.test_project_id}/tasks/actions/unlock-after-validation/"
 
+    async def _update_task(self, task_id, **fields):
+        set_clause = ", ".join(f"{k} = :{k}" for k in fields)
+        params = {**fields, "id": int(task_id), "proj": int(self.test_project_id)}
+        await self.db.execute(
+            f"UPDATE tasks SET {set_clause} WHERE id = :id AND project_id = :proj",
+            params,
+        )
+
     async def _lock_for_validation(self, task_id, user_id, mapped_by=None):
         params = {
             "task_status": TaskStatus.LOCKED_FOR_VALIDATION.value,
@@ -1148,14 +1166,21 @@ class TestTasksActionsValidationUnlockAPI:
     async def test_validation_unlock_returns_200_if_validated(
         self, client: AsyncClient
     ):
-        # lock two tasks for validation with mapped_by set (validator)
-        await self._lock_for_validation(
-            1, self.test_user.id, mapped_by=self.test_user.id
-        )
-        await self._lock_for_validation(
-            2, self.test_user.id, mapped_by=self.test_user.id
+        # set task 1 mapped_by test_user
+
+        await self._update_task(
+            1, task_status=TaskStatus.MAPPED.value, mapped_by=self.test_user.id
         )
 
+        await self._update_task(
+            2, task_status=TaskStatus.MAPPED.value, mapped_by=self.test_user.id
+        )
+        await Task.lock_task_for_validating(
+            1, self.test_project_id, self.test_user.id, self.db
+        )
+        await Task.lock_task_for_validating(
+            2, self.test_project_id, self.test_user.id, self.db
+        )
         resp = await client.post(
             self.url,
             headers={"Authorization": f"Token {self.user_session_token}"},
@@ -1182,8 +1207,12 @@ class TestTasksActionsValidationUnlockAPI:
     async def test_validation_unlock_returns_200_if_validated_with_comment(
         self, client: AsyncClient
     ):
-        await self._lock_for_validation(
-            1, self.test_user.id, mapped_by=self.test_user.id
+
+        await self._update_task(
+            1, task_status=TaskStatus.MAPPED.value, mapped_by=self.test_user.id
+        )
+        await Task.lock_task_for_validating(
+            1, self.test_project_id, self.test_user.id, self.db
         )
         resp = await client.post(
             self.url,
@@ -1218,6 +1247,14 @@ class TestTasksActionsValidationStopAPI:
         self.user_session_token = _encode_token(raw)
         self.url = (
             f"/api/v2/projects/{self.test_project_id}/tasks/actions/stop-validation/"
+        )
+
+    async def _update_task(self, task_id, **fields):
+        set_clause = ", ".join(f"{k} = :{k}" for k in fields)
+        params = {**fields, "id": int(task_id), "proj": int(self.test_project_id)}
+        await self.db.execute(
+            f"UPDATE tasks SET {set_clause} WHERE id = :id AND project_id = :proj",
+            params,
         )
 
     async def _lock_for_validation(self, task_id, user_id, mapped_by=None):
@@ -1323,13 +1360,11 @@ class TestTasksActionsValidationStopAPI:
     async def test_validation_stop_returns_200_if_task_locked_by_user(
         self, client: AsyncClient
     ):
-        # unlock task to MAPPED before locking for validation
-        await self.db.execute(
-            "UPDATE tasks SET task_status = :s WHERE id = :id AND project_id = :proj",
-            {"s": TaskStatus.MAPPED.value, "id": 1, "proj": int(self.test_project_id)},
+        await self._update_task(
+            1, task_status=TaskStatus.MAPPED.value, mapped_by=self.test_user.id
         )
-        await self._lock_for_validation(
-            1, self.test_user.id, mapped_by=self.test_user.id
+        await Task.lock_task_for_validating(
+            1, self.test_project_id, self.test_user.id, self.db
         )
         # Now call stop
         resp = await client.post(
@@ -1348,13 +1383,13 @@ class TestTasksActionsValidationStopAPI:
     async def test_validation_stop_returns_200_if_task_locked_by_user_with_comment(
         self, client: AsyncClient
     ):
-        await self.db.execute(
-            "UPDATE tasks SET task_status = :s WHERE id = :id AND project_id = :proj",
-            {"s": TaskStatus.MAPPED.value, "id": 1, "proj": int(self.test_project_id)},
+        await self._update_task(
+            1, task_status=TaskStatus.MAPPED.value, mapped_by=self.test_user.id
         )
-        await self._lock_for_validation(
-            1, self.test_user.id, mapped_by=self.test_user.id
+        await Task.lock_task_for_validating(
+            1, self.test_project_id, self.test_user.id, self.db
         )
+
         resp = await client.post(
             self.url,
             headers={"Authorization": f"Token {self.user_session_token}"},

--- a/tests/api/integration/services/test_mapping_service.py
+++ b/tests/api/integration/services/test_mapping_service.py
@@ -2,11 +2,12 @@ import datetime
 import xml.etree.ElementTree as ET
 from unittest.mock import patch
 
+from backend.models.dtos.mapping_dto import ExtendLockTimeDTO
 from backend.services.project_service import ProjectService
 import pytest
 
 from backend.services.mapping_service import MappingService, Task
-from backend.models.postgis.task import TaskStatus
+from backend.models.postgis.task import TaskAction, TaskHistory, TaskStatus
 from tests.api.helpers.test_helpers import create_canned_project
 
 ORG_NAME = "HOT Tasking Manager"
@@ -181,3 +182,107 @@ class TestMappingService:
         for task in self.test_project.tasks:
             task = await Task.get(task.id, self.test_project_id, self.db)
             assert task.task_status != TaskStatus.BADIMAGERY.value
+
+    async def test_task_extend_duration_is_recorded(self):
+        if self.skip_tests:
+            pytest.skip("skipping mapping heavy tests")
+
+        # Arrange
+        task = await Task.get(2, self.test_project_id, self.db)
+        await Task.lock_task_for_mapping(
+            2, self.test_project_id, self.test_user.id, self.db
+        )
+
+        extend_lock_dto = ExtendLockTimeDTO(
+            task_ids=[task.id],
+            project_id=self.test_project_id,
+            user_id=self.test_user.id,
+        )
+
+        # Act
+        await MappingService.extend_task_lock_time(extend_lock_dto, self.db)
+        await Task.reset_lock(
+            task_id=2,
+            project_id=self.test_project_id,
+            task_status=TaskStatus.MAPPED,
+            user_id=self.test_user.id,
+            comment=None,
+            db=self.db,
+        )
+
+        # Assert
+        extended_task_history = await self.db.fetch_all(
+            """
+            SELECT action, action_text
+            FROM task_history
+            WHERE task_id = :task_id
+            AND project_id = :project_id
+            AND action = :action
+            ORDER BY action_date DESC
+            """,
+            values={
+                "task_id": task.id,
+                "project_id": self.test_project_id,
+                "action": TaskAction.EXTENDED_FOR_MAPPING.name,
+            },
+        )
+
+        assert len(extended_task_history) == 1
+        assert (
+            extended_task_history[0]["action"] == TaskAction.EXTENDED_FOR_MAPPING.name
+        )
+        assert extended_task_history[0]["action_text"] is not None
+
+    async def test_update_task_locked_with_duration_removes_duplicate_rows(self):
+        if self.skip_tests:
+            pytest.skip("skipping mapping heavy tests")
+
+        # Arrange
+        task = await Task.get(2, self.test_project_id, self.db)
+        await Task.lock_task_for_mapping(
+            2, self.test_project_id, self.test_user.id, self.db
+        )
+
+        extend_lock_dto = ExtendLockTimeDTO(
+            task_ids=[task.id],
+            project_id=self.test_project_id,
+            user_id=self.test_user.id,
+        )
+
+        # Create the duplicate-history state through the real service path
+        await MappingService.extend_task_lock_time(extend_lock_dto, self.db)
+        # Relocking
+        await Task.lock_task_for_mapping(
+            2, self.test_project_id, self.test_user.id, self.db
+        )
+        await MappingService.extend_task_lock_time(extend_lock_dto, self.db)
+
+        # Act
+        await TaskHistory.update_task_locked_with_duration(
+            task.id,
+            self.test_project_id,
+            TaskAction.EXTENDED_FOR_MAPPING,
+            self.test_user.id,
+            self.db,
+        )
+
+        # Assert
+        remaining_rows = await self.db.fetch_all(
+            """
+            SELECT id, action, action_text
+            FROM task_history
+            WHERE task_id = :task_id
+            AND project_id = :project_id
+            AND action = :action
+            ORDER BY action_date DESC
+            """,
+            values={
+                "task_id": task.id,
+                "project_id": self.test_project_id,
+                "action": TaskAction.EXTENDED_FOR_MAPPING.name,
+            },
+        )
+
+        assert len(remaining_rows) == 1
+        assert remaining_rows[0]["action"] == TaskAction.EXTENDED_FOR_MAPPING.name
+        assert remaining_rows[0]["action_text"] is not None


### PR DESCRIPTION
…es refactor/fix

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #6014

## Describe this PR

Refactor of #7044

The action text was missing in EXTEND_FOR_MAPPING and EXTEND_FOR_VALIDATION actions which were later introduced.

Previously, all the Task actions and status were same so the based on the current task status the actions were being patched in the action text accordingly. However, in case of extending mapping or validation, the equivalent status weren't there due to which no tasks were being fetched and hence the timestamps was not being patched.

The task is always relocked when the session is expired for mapping or validation. This causes redundant entries for extension in the history table. These redundant entries are recursively deleted and only one entry is patched with the total extended time.
This recursive deletion function is legacy code which was introduced due to race condition creating multiple entries. This handles the multiple redundant entries for extension currently though this relock mechanism needs to be handled.

Ideal scenario for multiple extension of task duration would be, everytime the task is relocked, the extended session is patched and then again the task is locked and extended for the next phase of extension.

The test cases are refactored too as previously, the test cases didn't check the last entry of the task history but instead just checked the task status. Now when it tried to fetch the last entry, the tests that directly updated the status with sql, now didn't find the history entry and hence were refactored accordingly.
