### PR TITLE
Add featured projects to default sort on Explore Projects page

### DIFF
--- a/backend/services/project_search_service.py
+++ b/backend/services/project_search_service.py
@@ -120,7 +120,8 @@ class ProjectSearchService:
                 u.name AS author_name,
                 u.username AS author_username,
                 o.name AS organisation_name,
-                o.logo AS organisation_logo
+                o.logo AS organisation_logo,
+                p.featured
             FROM projects p
             LEFT JOIN organisations o ON o.id = p.organisation_id
             LEFT JOIN users u ON u.id = p.author_id
@@ -715,7 +716,17 @@ class ProjectSearchService:
                 filters.append("p.id = ANY(:managed_projects)")
                 params["managed_projects"] = project_ids
 
-        order_by_clause = ""
+        order_by_clause = """
+            ORDER BY
+                CASE
+                    WHEN p.priority = 0 THEN 0
+                    WHEN p.featured = TRUE THEN 1
+                    WHEN p.priority = 1 THEN 2
+                    WHEN p.priority = 2 THEN 3
+                    ELSE 4
+                END,
+                p.id DESC
+        """
 
         if search_dto.order_by:
             order_by = search_dto.order_by

--- a/tests/api/unit/services/test_project_search_service.py
+++ b/tests/api/unit/services/test_project_search_service.py
@@ -91,3 +91,49 @@ class TestProjectService:
         assert project_search_dto is not None
         assert len(project_search_dto.results) > 0
         assert any(p.project_id == self.project_id for p in project_search_dto.results)
+
+    async def test_default_sort_order_places_featured_between_urgent_and_high(self):
+        """
+        Issue #6704: When no order_by is specified, projects should be sorted as:
+        Urgent (priority=0) > Featured > High (priority=1) > Medium (priority=2) > Low.
+        """
+        # Arrange: create 3 more canned projects so we have 4 total covering each tier
+        _, _, urgent_id = await create_canned_project(self.db, name="urgent_proj")
+        _, _, featured_id = await create_canned_project(self.db, name="featured_proj")
+        _, _, high_id = await create_canned_project(self.db, name="high_proj")
+        # The original self.project_id will be our MEDIUM tier project
+
+        # Set priority/featured/status for each project to define the test scenario
+        configs = [
+            (urgent_id, 0, False),  # URGENT (priority=0)
+            (featured_id, 1, True),  # FEATURED (high priority, but featured=TRUE)
+            (high_id, 1, False),  # HIGH (priority=1)
+            (self.project_id, 2, False),  # MEDIUM (priority=2)
+        ]
+        for pid, priority, featured in configs:
+            await self.db.execute(
+                """
+                UPDATE projects
+                SET priority = :priority, featured = :featured, status = :status
+                WHERE id = :id
+                """,
+                {
+                    "priority": priority,
+                    "featured": featured,
+                    "status": ProjectStatus.PUBLISHED.value,
+                    "id": pid,
+                },
+            )
+
+        # Act: search with no explicit order_by (default sort path)
+        search_dto = ProjectSearchDTO(project_statuses=["PUBLISHED"], page=1)
+        result = await ProjectSearchService.search_projects(search_dto, None, self.db)
+
+        # Assert: extract the order of just our 4 seeded projects
+        seeded = {urgent_id, featured_id, high_id, self.project_id}
+        observed = [p.project_id for p in result.results if p.project_id in seeded]
+        expected = [urgent_id, featured_id, high_id, self.project_id]
+        assert observed == expected, (
+            f"Expected default sort Urgent>Featured>High>Medium "
+            f"({expected}), but got {observed}"
+        )


### PR DESCRIPTION
## What

Implements issue #6704 by adding "featured" projects to the default sort order on the Explore Projects page. When no explicit `order_by` parameter is supplied, projects are now sorted in the following order: 
**Urgent → Featured → High → Medium → Low**

## Why

As described in #6704, the Explore Projects page currently defaults to sorting by priority, with older projects appearing first within each priority group. This means the front page is often dominated by outdated projects and beginner-friendly projects are hard to find. The "featured" flag had no effect on the default sort. This PR makes featured projects discoverable in the default view by placing them in their own prioritized tier.

## How

Two small changes in `backend/services/project_search_service.py`:

1. **SELECT**: Added `p.featured` to the project search query to be available for ordering.
2. **ORDER BY**: Replaced the previously empty default `order_by_clause` with a `CASE` expression that orders the five tiers. The existing logic that overrides `order_by_clause` when `search_dto.order_by` is provided is preserved.

## Testing

Added `test_default_sort_order_places_featured_between_urgent_and_high` in `tests/api/unit/services/test_project_search_service.py`. The test initializes 4 projects covering each tier (urgent, featured-high, plain-high, medium) and asserts that search service returns them in the expected order when no `order_by` is supplied.

To run:
'uv run python -m pytest tests/api/unit/services/test_project_search_service.py -v'

All 4 tests in that file pass locally.