### PR TITLE
Fix/html to markdown editor conversion

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,6 +71,7 @@
     "terra-draw": "^1.18.1",
     "tributejs": "^5.1.3",
     "turndown": "^7.2.4",
+    "turndown-plugin-gfm": "^1.0.2",
     "use-query-params": "^2.2.1",
     "webfontloader": "^1.6.28",
     "workbox-core": "^7.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,6 +70,7 @@
     "tachyons": "^4.12.0",
     "terra-draw": "^1.18.1",
     "tributejs": "^5.1.3",
+    "turndown": "^7.2.4",
     "use-query-params": "^2.2.1",
     "webfontloader": "^1.6.28",
     "workbox-core": "^7.0.0",

--- a/frontend/src/components/comments/commentInput.js
+++ b/frontend/src/components/comments/commentInput.js
@@ -13,7 +13,7 @@ import HashtagPaste from './hashtagPaste';
 import FileRejections from './fileRejections';
 import DropzoneUploadStatus from './uploadStatus';
 import { DROPZONE_SETTINGS } from '../../config';
-import { formatUserNamesToLink } from '../../utils/htmlFromMarkdown';
+import { formatUserNamesToLink, markdownFromHtml } from '../../utils/htmlFromMarkdown';
 import { iconConfig } from './editorIconConfig';
 import messages from './messages';
 import { CurrentUserAvatar } from '../user/avatar';
@@ -37,6 +37,7 @@ function CommentInputField({
   const textareaRef = useRef();
   const fileInputRef = useRef(null);
   const isBundle = useRef(false);
+  const lastConvertedRef = useRef(null);
   const [isShowPreview, setIsShowPreview] = useState(false);
 
   const appendImgToComment = (url) => setComment(`${comment}\n![image](${url})\n`);
@@ -149,7 +150,21 @@ function CommentInputField({
     sessionStorage.setItem(sessionkey, comment);
   }, [comment, sessionkey]);
 
-  console.log(comment, 'comment');
+  useEffect(() => {
+    if (
+      comment &&
+      comment !== lastConvertedRef.current &&
+      /<\/?(?:p|div|h[1-6]|ul|ol|li|br|strong|em|a|table|thead|tbody|tr|th|td|blockquote|pre|code|span)[\s>]/i.test(comment) &&
+      document.activeElement !== textareaRef.current?.textarea
+    ) {
+      const converted = markdownFromHtml(comment);
+      if (converted !== comment) {
+        lastConvertedRef.current = converted;
+        setComment(converted);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [comment]);
 
   return (
     <div {...getRootProps()}>

--- a/frontend/src/utils/htmlFromMarkdown.js
+++ b/frontend/src/utils/htmlFromMarkdown.js
@@ -1,6 +1,7 @@
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import TurndownService from 'turndown';
+import { gfm } from 'turndown-plugin-gfm';
 
 const VIDEO_TAG_REGEXP = new RegExp(/^::youtube\[(.*)\]$/);
 
@@ -104,7 +105,37 @@ export const formatUserNamesToLink = (text) => {
   return text;
 };
 
-const turndownService = new TurndownService();
+const turndownService = new TurndownService({
+  headingStyle: 'atx',
+  codeBlockStyle: 'fenced',
+  hr: '---',
+  bullet: '-',
+});
+turndownService.use(gfm);
+
+// Rule to convert YouTube iframes back to ::youtube[id] syntax
+turndownService.addRule('youtube', {
+  filter: (node) => {
+    return (
+      node.nodeName === 'IFRAME' &&
+      node.getAttribute('src')?.startsWith('https://www.youtube.com/embed/')
+    );
+  },
+  replacement: (content, node) => {
+    const src = node.getAttribute('src');
+    const id = src.split('/').pop();
+    return `\n\n::youtube[${id}]\n\n`;
+  },
+});
+
+// Rule to use double tildes for strikethrough
+turndownService.addRule('strikethrough', {
+  filter: ['del', 's', 'strike'],
+  replacement: (content) => `~~${content}~~`,
+});
+
+// Rule to keep other iframes
+turndownService.keep(['iframe']);
 
 export const markdownFromHtml = (html) => {
   return turndownService.turndown(html);

--- a/frontend/src/utils/htmlFromMarkdown.js
+++ b/frontend/src/utils/htmlFromMarkdown.js
@@ -132,10 +132,8 @@ turndownService.use(gfm);
 turndownService.addRule('listItem', {
   filter: 'li',
   replacement: function (content, node, options) {
-    content = content
-      .replace(/^\n+/, '') // remove leading newlines
-      .replace(/\n+$/, '\n') // replace trailing newlines with just one
-      .replace(/\n/gm, '\n    '); // indent content
+    content = content.trimStart().trimEnd();
+    content = content.replace(/\n/gm, '\n    '); // indent content
     let prefix = options.bullet + ' ';
     const parent = node.parentNode;
     if (parent.nodeName === 'OL') {
@@ -143,7 +141,7 @@ turndownService.addRule('listItem', {
       const index = Array.prototype.indexOf.call(parent.children, node);
       prefix = (start ? Number(start) + index : index + 1) + '. ';
     }
-    return prefix + content + (node.nextSibling && !/\n$/.test(content) ? '\n' : '');
+    return prefix + content + (node.nextSibling ? '\n' : '');
   },
 });
 
@@ -164,8 +162,23 @@ turndownService.keep(['iframe']);
 
 export const markdownFromHtml = (html) => {
   const markdown = turndownService.turndown(html);
-  return markdown
-    .replace(/(#+ .+\n)\n+(?=#+ .+)/g, '$1') // Remove blank lines between consecutive headers
-    .replace(/\n{3,}/g, '\n\n') // Max two newlines
-    .trim();
+
+  // Split into lines to avoid complex regex that can lead to ReDoS (security hotspots)
+  const lines = markdown.split('\n');
+  const filteredLines = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const nextLine = lines[i + 1];
+
+    filteredLines.push(line);
+
+    // If current line is a header and next line is empty,
+    // and the line after that is also a header, skip the empty line.
+    if (line.startsWith('#') && nextLine === '' && lines[i + 2]?.startsWith('#')) {
+      i++; // Skip the next empty line
+    }
+  }
+
+  return filteredLines.join('\n').replace(/\n{3,}/g, '\n\n').trim();
 };

--- a/frontend/src/utils/htmlFromMarkdown.js
+++ b/frontend/src/utils/htmlFromMarkdown.js
@@ -1,5 +1,6 @@
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
+import TurndownService from 'turndown';
 
 const VIDEO_TAG_REGEXP = new RegExp(/^::youtube\[(.*)\]$/);
 
@@ -101,4 +102,10 @@ export const formatUserNamesToLink = (text) => {
     }
   }
   return text;
+};
+
+const turndownService = new TurndownService();
+
+export const markdownFromHtml = (html) => {
+  return turndownService.turndown(html);
 };

--- a/frontend/src/utils/htmlFromMarkdown.js
+++ b/frontend/src/utils/htmlFromMarkdown.js
@@ -110,21 +110,40 @@ const turndownService = new TurndownService({
   codeBlockStyle: 'fenced',
   hr: '---',
   bullet: '-',
+  emDelimiter: '*',
 });
+
+// Custom escape function to avoid escaping brackets [ ] and other common characters
+// which fixes the task list issue \[x\] and makes the output cleaner.
+turndownService.escape = (string) => {
+  return string
+    .replace(/\\/g, '\\\\')
+    .replace(/\*/g, '\\*')
+    .replace(/_/g, '\\_')
+    .replace(/`/g, '\\`')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)')
+    .replace(/#/g, '\\#');
+};
+
 turndownService.use(gfm);
 
-// Rule to convert YouTube iframes back to ::youtube[id] syntax
-turndownService.addRule('youtube', {
-  filter: (node) => {
-    return (
-      node.nodeName === 'IFRAME' &&
-      node.getAttribute('src')?.startsWith('https://www.youtube.com/embed/')
-    );
-  },
-  replacement: (content, node) => {
-    const src = node.getAttribute('src');
-    const id = src.split('/').pop();
-    return `\n\n::youtube[${id}]\n\n`;
+// Rule to force '-' bullets for unordered lists
+turndownService.addRule('listItem', {
+  filter: 'li',
+  replacement: function (content, node, options) {
+    content = content
+      .replace(/^\n+/, '') // remove leading newlines
+      .replace(/\n+$/, '\n') // replace trailing newlines with just one
+      .replace(/\n/gm, '\n    '); // indent content
+    let prefix = options.bullet + ' ';
+    const parent = node.parentNode;
+    if (parent.nodeName === 'OL') {
+      const start = parent.getAttribute('start');
+      const index = Array.prototype.indexOf.call(parent.children, node);
+      prefix = (start ? Number(start) + index : index + 1) + '. ';
+    }
+    return prefix + content + (node.nextSibling && !/\n$/.test(content) ? '\n' : '');
   },
 });
 
@@ -134,9 +153,19 @@ turndownService.addRule('strikethrough', {
   replacement: (content) => `~~${content}~~`,
 });
 
+// Rule to keep HTML comments
+turndownService.addRule('keepComments', {
+  filter: (node) => node.nodeType === 8,
+  replacement: (content, node) => `\n<!--${node.data}-->\n`,
+});
+
 // Rule to keep other iframes
 turndownService.keep(['iframe']);
 
 export const markdownFromHtml = (html) => {
-  return turndownService.turndown(html);
+  const markdown = turndownService.turndown(html);
+  return markdown
+    .replace(/(#+ .+\n)\n+(?=#+ .+)/g, '$1') // Remove blank lines between consecutive headers
+    .replace(/\n{3,}/g, '\n\n') // Max two newlines
+    .trim();
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2139,6 +2139,11 @@
     rw "^1.3.3"
     tinyqueue "^3.0.0"
 
+"@mixmark-io/domino@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@mixmark-io/domino/-/domino-2.2.0.tgz#4e8ec69bf1afeb7a14f0628b7e2c0f35bdb336c3"
+  integrity sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==
+
 "@mswjs/cookies@^0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-0.2.2.tgz#b4e207bf6989e5d5427539c2443380a33ebb922b"
@@ -14101,6 +14106,13 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+turndown@^7.2.4:
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.2.4.tgz#42d98202aefa8c188c997b586bc6da78bdf27ea2"
+  integrity sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==
+  dependencies:
+    "@mixmark-io/domino" "^2.2.0"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -14107,6 +14107,11 @@ tsutils@^3.21.0:
   dependencies:
     tslib "^1.8.1"
 
+turndown-plugin-gfm@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz#6f8678a361f35220b2bdf5619e6049add75bf1c7"
+  integrity sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==
+
 turndown@^7.2.4:
   version "7.2.4"
   resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.2.4.tgz#42d98202aefa8c188c997b586bc6da78bdf27ea2"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
Fixes #7224

## Describe this PR
This PR implements automatic conversion of HTML content to Markdown within the CommentInputField component using the turndown library. 

Key improvements include:
- Automatic Conversion: Added a useEffect hook in CommentInputField that detects HTML tags in the comment state and converts them to Markdown.
- New Utility: Introduced markdownFromHtml in src/utils/htmlFromMarkdown.js which leverage turndown Service.
- Dependency Management: Added turndown (v7.2.4) to the frontend dependencies.

## Screenshots

**Before Conversion**
<img width="946" height="392" alt="image" src="https://github.com/user-attachments/assets/8aa7a292-c8ab-4f31-a3cf-3d56db7ef393" />

**After Conversion**
<img width="672" height="365" alt="image" src="https://github.com/user-attachments/assets/931eb559-8fef-4b01-b1f1-3dc6186fb20b" />

