### PR TITLE
fix(labeler): update config to v6 format

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,20 +1,34 @@
 "scope: frontend":
-  - frontend/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - frontend/**/*
+
 "scope: backend":
-  - backend/**/*
-  - tests/**/*
-  - migrations/**/*
-  - ./manage.py
-  - ./pyproject.toml
+- changed-files:
+  - any-glob-to-any-file:
+    - backend/**/*
+    - tests/**/*
+    - migrations/**/*
+    - manage.py
+    - pyproject.toml
+
 "scope: infrastructure":
-  - .circleci/*
-  - .github/**/*
-  - scripts/aws/**/*
-  - scripts/docker/**/*
-  - scripts/install/**/*
-  - docker-*.yml
+- changed-files:
+  - any-glob-to-any-file:
+    - .circleci/*
+    - .github/**/*
+    - scripts/aws/**/*
+    - scripts/docker/**/*
+    - scripts/install/**/*
+    - docker-*.yml
+
 "dependencies":
-  - frontend/yarn.lock
-  - ./pyproject.toml
+- changed-files:
+  - any-glob-to-any-file:
+    - frontend/yarn.lock
+    - pyproject.toml
+
 "scope: translations":
-  - frontend/src/locales/*
+- changed-files:
+  - any-glob-to-any-file:
+    - frontend/src/locales/*


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🤖 Build or CI

## Describe this PR

- Fixes the labeler workflow error caused by outdated `.github/labeler.yml` format.
- Updates the config to match `actions/labeler v6` by replacing glob arrays with `changed-files` rules.

## How to test
- Open or update a PR
- Verify labels are applied based on changed files
- Confirm no labeler config error in Actions