### PR TITLE
Fix contribution page road stats and align the Ohsome topic across API docs, config defaults, UI labels, mappings, and tests

### DIFF
--- a/backend/api/users/statistics.py
+++ b/backend/api/users/statistics.py
@@ -176,7 +176,7 @@ async def get_ohsome_stats(
     db: Database = Depends(get_db),
     userId: int = Query(..., description="OSM user ID"),
     topics: str = Query(
-        ..., description="Comma-separated list of OSM topics, e.g. building,highway"
+        ..., description="Comma-separated list of OSM topics, e.g. building,road"
     ),
     startdate: Optional[str] = Query(
         None, description="YYYY-MM-DD, start of time range"

--- a/example.env
+++ b/example.env
@@ -90,7 +90,7 @@ OSM_USER_AGENT=${OSM_USER_AGENT:-HOT-TaskingManager}
 #
 OHSOME_STATS_BASE_URL=${OHSOME_STATS_BASE_URL:-https://stats.now.ohsome.org}
 OHSOME_STATS_API_URL=${OHSOME_STATS_API_URL:-https://stats.now.ohsome.org/api}
-OHSOME_STATS_TOPICS=${OHSOME_STATS_TOPICS:-highway,waterway,building,poi}
+OHSOME_STATS_TOPICS=${OHSOME_STATS_TOPICS:-road,waterway,building,poi}
 OHSOME_STATS_TOKEN=${OHSOME_STATS_TOKEN:-testSuperSecretTestToken}
 
 # Secret (required)

--- a/frontend/src/components/badges/messages.js
+++ b/frontend/src/components/badges/messages.js
@@ -11,6 +11,7 @@ export default defineMessages({
   description: { id: 'management.fields.description', defaultMessage: 'Description' },
   hidden: { id: 'management.badges.hidden', defaultMessage: 'Hide this badge from users' },
   highway: { id: 'management.badges.highway', defaultMessage: 'km of highways added' },
+  road: { id: 'management.badges.road', defaultMessage: 'km of roads added' },
   image: { id: 'management.fields.organisation.image', defaultMessage: 'Image' },
   imageError: { id: 'management.badges.imageError', defaultMessage: 'Error uploading image' },
   manage: { id: 'management.link.manage', defaultMessage: 'Manage {entity}' },

--- a/frontend/src/components/user/messages.js
+++ b/frontend/src/components/user/messages.js
@@ -409,6 +409,7 @@ export default defineMessages({
   tableUpgrade: { id: 'user.table.upgrade', defaultMessage: 'Level upgrade' },
   tableUsername: { id: 'user.table.username', defaultMessage: 'Username' },
   tableCol_highway: { id: 'user.table.highway', defaultMessage: 'Highways' },
+  tableCol_road: { id: 'user.table.road', defaultMessage: 'Roads' },
   tableCol_waterway: { id: 'user.table.waterway', defaultMessage: 'Waterways' },
   tableCol_building: { id: 'user.table.building', defaultMessage: 'Buildings' },
   tableCol_changeset: { id: 'user.table.changeset', defaultMessage: 'Changesets' },
@@ -423,6 +424,7 @@ export default defineMessages({
   progress_changeset: { id: 'user.progress.changeset', defaultMessage: 'changesets' },
   progress_waterway: { id: 'user.progress.waterway', defaultMessage: 'km of waterways' },
   progress_highway: { id: 'user.progress.highway', defaultMessage: 'km of highways' },
+  progress_road: { id: 'user.progress.road', defaultMessage: 'km of roads' },
   progress_poi: { id: 'user.progress.poi', defaultMessage: 'points of interest' },
   progress_building: { id: 'user.progress.building', defaultMessage: 'buildings' },
 });

--- a/frontend/src/components/userDetail/elementsMapped.js
+++ b/frontend/src/components/userDetail/elementsMapped.js
@@ -147,12 +147,12 @@ export const ElementsMapped = ({ userStats, osmStats }) => {
           icon={<RoadIcon className={iconClass} style={iconStyle} />}
           description={<FormattedMessage {...messages.roadMapped} />}
           subDescription="Created + Modified - Deleted"
-          mapped={osmStats?.topics?.highway?.value}
-          created={osmStats?.topics?.highway?.added}
-          modified={osmStats?.topics?.highway?.modified?.count_modified}
-          deleted={osmStats?.topics?.highway?.deleted}
-          unitMore={osmStats?.topics?.highway?.modified?.unit_more}
-          unitLess={osmStats?.topics?.highway?.modified?.unit_less}
+          mapped={osmStats?.topics?.road?.value}
+          created={osmStats?.topics?.road?.added}
+          modified={osmStats?.topics?.road?.modified?.count_modified}
+          deleted={osmStats?.topics?.road?.deleted}
+          unitMore={osmStats?.topics?.road?.modified?.unit_more}
+          unitLess={osmStats?.topics?.road?.modified?.unit_less}
         />
         <DetailedStatsCard
           icon={<MarkerIcon className={iconClass} style={iconStyle} />}

--- a/frontend/src/components/userDetail/tests/elementsMapped.test.js
+++ b/frontend/src/components/userDetail/tests/elementsMapped.test.js
@@ -19,7 +19,7 @@ describe('ElementsMapped & TaskStats components', () => {
           deleted: 0,
           value: 4,
         },
-        highway: {
+        road: {
           added: 6,
           modified: {
             count_modified: 21,

--- a/frontend/src/config/index.js
+++ b/frontend/src/config/index.js
@@ -8,7 +8,7 @@ export const OHSOME_STATS_BASE_URL =
 export const OHSOME_STATS_API_URL =
   process.env.REACT_APP_OHSOME_STATS_API_URL || 'https://stats.now.ohsome.org/api';
 export const OHSOME_STATS_TOPICS =
-  process.env.REACT_APP_OHSOME_STATS_TOPICS || 'highway,waterway,building,poi';
+  process.env.REACT_APP_OHSOME_STATS_TOPICS || 'road,waterway,building,poi';
 // APPLICATION SETTINGS
 export const DEFAULT_LOCALE = process.env.REACT_APP_DEFAULT_LOCALE || 'en';
 export const ENVIRONMENT = process.env.REACT_APP_ENVIRONMENT || '';


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

This PR fixes contribution page road statistics by aligning our Ohsome topic usage from highway to road across the stack. Since highway is deprecated in Ohsome, the old topic name could cause road contribution data and labels to be inconsistent or missing. This update changes the backend query example, env and frontend config defaults, user-facing labels, contribution mappings, and related tests so road stats are fetched and displayed correctly everywhere.