### PR TITLE
fix(node-version): update frontend workflows to Node.js 22.12.0

### DIFF
--- a/.github/workflows/frontend-build-deploy.yml
+++ b/.github/workflows/frontend-build-deploy.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v6
 
-      - name: Use Node.js 22.11.0
+      - name: Use Node.js 22.12.0
         uses: actions/setup-node@v6
         with:
-          node-version: 22.11.0
+          node-version: 22.12.0
 
       - name: Cache node_modules
         uses: actions/cache@v5

--- a/.github/workflows/pr_test_frontend.yml
+++ b/.github/workflows/pr_test_frontend.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v6
 
-      - name: Use Node.js 22.11.0
+      - name: Use Node.js 22.12.0
         uses: actions/setup-node@v6
         with:
-          node-version: 22.11.0
+          node-version: 22.12.0
 
       - name: Cache node_modules
         uses: actions/cache@v5


### PR DESCRIPTION
## What's Here ?
This PR updates the Node.js version used in GitHub Actions workflows to resolve a build failure introduced by the iD Editor upgrade.

The upstream iD Editor update introduces a dependency tree pulling Vite 8, which requires Node.js >= 22.12.0. The current CI environment was using Node.js 22.11.0, causing the build to fail.

## Fix
- Update Node.js version in CI workflows to 22.12.0 to match the new requirement.

## Changes
- Update Node.js version in:
  - .github/workflows/frontend-build-deploy.yml
  - .github/workflows/pr_test_frontend.yml

## Notes
- This is a CI-only change
- No application or dependency changes included
- Required for compatibility with iD Editor v2.38.0 upgrade already introduced in PR #7229