### PR TITLE
Add sandbox indicator for Sandbox Project

### DIFF
--- a/frontend/src/components/header/index.js
+++ b/frontend/src/components/header/index.js
@@ -3,6 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import Popup from 'reactjs-popup';
 import { FormattedMessage } from 'react-intl';
+import { useProjectSummaryQuery } from '../../api/projects';
 
 import messages from './messages';
 import { ORG_URL, ORG_NAME, ORG_LOGO, SERVICE_DESK } from '../../config';
@@ -34,6 +35,13 @@ export const Header = () => {
   const userDetails = useSelector((state) => state.auth.userDetails);
   const organisations = useSelector((state) => state.auth.organisations);
   const showOrgBar = useSelector((state) => state.orgBarVisibility.isVisible);
+
+  // Matches URLs containing '/projects/' followed by digits (the project ID), like '/projects/130' or '/manage/projects/130'
+  const match = location.pathname.match(/\/projects\/(\d+)/);
+  const projectId = match ? match[1] : null;
+  const { data: project } = useProjectSummaryQuery(projectId, {
+    enabled: !!projectId,
+  });
 
   const linkCombo = 'link mh3 barlow-condensed blue-dark f4 ttu lh-solid nowrap pv2';
 
@@ -125,6 +133,11 @@ export const Header = () => {
           />
           <span className="barlow-condensed f3 fw6 ml2 blue-dark nowrap">Tasking Manager</span>
         </Link>
+        {project && project.sandbox && (
+          <div className="tc br1 f7 ttu ba b--red red pv1 ph2 ml3 v-mid dib nowrap">
+            <FormattedMessage {...messages.sandbox} />
+          </div>
+        )}
         <HorizontalScroll
           className={'dn dib-l ml5-l mr4-l pl6-xl'}
           style={{ flexGrow: 1 }}

--- a/frontend/src/components/header/messages.js
+++ b/frontend/src/components/header/messages.js
@@ -179,4 +179,8 @@ export default defineMessages({
     id: 'serviceWorker.dialog.remindMeLater',
     defaultMessage: 'Remind me later',
   },
+  sandbox: {
+    id: 'project.detail.sandbox',
+    defaultMessage: 'Sandbox Mode',
+  },
 });

--- a/frontend/src/components/header/tests/index.test.js
+++ b/frontend/src/components/header/tests/index.test.js
@@ -17,9 +17,11 @@ describe('Header', () => {
   const setup = () => {
     return {
       ...renderWithRouter(
-        <ReduxIntlProviders>
-          <Header />
-        </ReduxIntlProviders>,
+        <QueryClientProviders>
+          <ReduxIntlProviders>
+            <Header />
+          </ReduxIntlProviders>
+        </QueryClientProviders>,
       ),
     };
   };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [x] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #7226 

## Describe this PR
This PR introduces a Sandbox Mode indicator in the application header to provide clear visual feedback when a user
is interacting with a sandbox project.

Key Changes:
In `Header Component`: 
  - Implemented logic to extract the `projectId` from the current URL.
  - Integrated useProjectSummaryQuery to fetch project details.
  - Added a conditionally rendered "Sandbox Mode" badge next to the Tasking Manager logo for projects with
  sandbox: true.

- Testing: Updated the Header component tests to include `QueryClientProviders`, ensuring that the new API hook
doesn't break existing test suites.

## Screenshots
<img width="1427" height="961" alt="image" src="https://github.com/user-attachments/assets/490ede34-3372-4fa6-802f-07f3f8050637" />
