### PR TITLE
Add #mappers hashtag Support

### DIFF
--- a/frontend/src/components/comments/commentInput.js
+++ b/frontend/src/components/comments/commentInput.js
@@ -32,6 +32,7 @@ function CommentInputField({
   isShowUserPicture = false,
   placeholderMsg = messages.leaveAComment,
   markdownTextareaProps = {},
+  enableMappersHashtag = false,
 }: Object) {
   const token = useSelector((state) => state.auth.token);
   const textareaRef = useRef();
@@ -289,6 +290,12 @@ function CommentInputField({
             <>
               <span>, </span>
               <HashtagPaste text={comment} setFn={setComment} hashtag="#contributors" />
+            </>
+          )}
+          {enableMappersHashtag && (
+            <>
+              <span>, </span>
+              <HashtagPaste text={comment} setFn={setComment} hashtag="#mappers" />
             </>
           )}
         </span>

--- a/frontend/src/components/comments/messages.js
+++ b/frontend/src/components/comments/messages.js
@@ -36,6 +36,10 @@ export default defineMessages({
     id: 'comment.hashtags.help.contributors',
     defaultMessage: 'Add "{hashtag}" to notify the task contributors about your comment.',
   },
+  mappersHashtagTip: {
+    id: 'comment.hashtags.help.mappers',
+    defaultMessage: 'Add "{hashtag}" to notify the task mappers about your comment.',
+  },
   nothingToPreview: {
     id: 'comment.preview.nothingToPreview',
     defaultMessage: 'Nothing to preview',

--- a/frontend/src/components/projectDetail/questionsAndComments.js
+++ b/frontend/src/components/projectDetail/questionsAndComments.js
@@ -56,6 +56,7 @@ export const PostProjectComment = ({ projectId, refetchComments, contributors })
             contributors={
               Array.isArray(contributors) ? contributors.map((user) => user.username) : undefined
             }
+            enableMappersHashtag
           />
         </Suspense>
       </div>

--- a/frontend/src/components/taskSelection/actionSidebars.js
+++ b/frontend/src/components/taskSelection/actionSidebars.js
@@ -277,6 +277,7 @@ export function CompletionTabForMapping({
             enableHashtagPaste={true}
             enableContributorsHashtag
             isShowTabNavs
+            enableMappersHashtag
           />
         </Suspense>
       </div>
@@ -662,6 +663,7 @@ const TaskValidationSelector = ({
                 enableHashtagPaste
                 enableContributorsHashtag
                 isShowTabNavs
+                enableMappersHashtag
               />
             </Suspense>
           </div>

--- a/frontend/src/components/taskSelection/taskActivity.js
+++ b/frontend/src/components/taskSelection/taskActivity.js
@@ -65,6 +65,7 @@ const PostComment = ({ projectId, taskId, contributors, setCommentPayload }) => 
           enableContributorsHashtag
           isShowUserPicture
           isShowTabNavs
+          enableMappersHashtag
         />
       </Suspense>
       <div className="ml-auto mb5 flex flex-column gap-1 items-end">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #7215

## Describe this PR

This PR introduces support for the `#mappers` hashtag in the `CommentInputField` component. 

Key changes include:
- Added `enableMappersHashtag` prop to `CommentInputField` to conditionally display the #mappers hashtag paste button.
- Updated` messages.js` with a new `tooltip` message for the #mappers hashtag.
- Enabled the #mappers hashtag in several key areas of the application:
   - Project Questions and Comments section.
   - Task Selection sidebars for both mapping and validation.
   - Task Activity comment section.

This enhancement allows users to easily notify mappers on a project or task by including the #mappers hashtag in their comments.

## Screenshots
<img width="1911" height="961" alt="image" src="https://github.com/user-attachments/assets/8f9006a8-6474-42f0-8c11-a414b69ebde3" />


<img width="1911" height="961" alt="image" src="https://github.com/user-attachments/assets/613f0d32-56bb-4f2f-aea2-c5818310d06f" />
