### PR TITLE
fix: Resolve project stats fetch based on hastag from ohsome on project statistics

### DIFF
--- a/frontend/src/api/stats.js
+++ b/frontend/src/api/stats.js
@@ -61,18 +61,20 @@ export const useOsmStatsQuery = ({ topics = [] }) => {
 };
 
 export const useOsmHashtagStatsQuery = (defaultComment) => {
+  const hashtag = defaultComment?.[0]?.replace(/^#/, '').trim().toLowerCase();
+
   const fetchOsmStats = ({ signal }) => {
-    return api().get(`${OHSOME_STATS_API_URL}/stats/${defaultComment[0].replace('#', '')}`, {
+    return api().get(`${OHSOME_STATS_API_URL}/stats/hashtags/${encodeURIComponent(hashtag)}`, {
       signal,
     });
   };
 
   return useQuery({
-    queryKey: ['osm-hashtag-stats'],
+    queryKey: ['osm-hashtag-stats', hashtag],
     queryFn: fetchOsmStats,
     useErrorBoundary: true,
-    enabled: Boolean(defaultComment?.[0]),
-    select: (data) => data.data.result,
+    enabled: Boolean(hashtag),
+    select: (data) => data.data.result?.[hashtag] || {},
   });
 };
 

--- a/frontend/src/network/tests/mockData/userStats.js
+++ b/frontend/src/network/tests/mockData/userStats.js
@@ -1,4 +1,5 @@
 import { formatISO } from 'date-fns';
+import { TM_DEFAULT_CHANGESET_COMMENT } from '../../../config';
 
 export const newUsersStats = {
   total: 1044,
@@ -79,9 +80,11 @@ export const ohsomeNowUserStats = {
   },
 };
 
+const projectHashtag = `${TM_DEFAULT_CHANGESET_COMMENT.replace(/^#/, '')}-1`;
+
 export const osmStatsProject = {
   result: {
-    'hotosm-project-1': {
+    [projectHashtag]: {
       changesets: 987654321,
       users: 112,
       roads: 5658.62006919192,

--- a/frontend/src/network/tests/mockData/userStats.js
+++ b/frontend/src/network/tests/mockData/userStats.js
@@ -81,12 +81,14 @@ export const ohsomeNowUserStats = {
 
 export const osmStatsProject = {
   result: {
-    changesets: 987654321,
-    users: 112,
-    roads: 5658.62006919192,
-    buildings: 12923,
-    edits: 123456789,
-    latest: '2020-10-05T23:21:22.000Z',
+    'hotosm-project-1': {
+      changesets: 987654321,
+      users: 112,
+      roads: 5658.62006919192,
+      buildings: 12923,
+      edits: 123456789,
+      latest: '2020-10-05T23:21:22.000Z',
+    },
   },
 };
 

--- a/frontend/src/network/tests/server-handlers.js
+++ b/frontend/src/network/tests/server-handlers.js
@@ -368,7 +368,7 @@ const handlers = [
   rest.get(`${OHSOME_STATS_API_URL}/hot-tm-user`, (req, res, ctx) => {
     return res(ctx.json(ohsomeNowUserStats));
   }),
-  rest.get(`${OHSOME_STATS_API_URL}/stats/:projectId`, (req, res, ctx) => {
+  rest.get(`${OHSOME_STATS_API_URL}/stats/hashtags/:projectId`, (req, res, ctx) => {
     return res(ctx.json(osmStatsProject));
   }),
   rest.get(`${OHSOME_STATS_API_URL}/metadata`, (req, res, ctx) => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #7245

## Describe this PR

- Replace deprecated ohsome stats project endpoint with `/stats/hashtags/{hashtag}`
- Normalize the default changeset hashtag before requesting stats
- Adapt the new keyed response shape back to the existing project edits stats UI contract
- Update frontend test mocks for the new ohsome response format

