### PR TITLE
fix: remove  Kontur OpenAerialMap Mosaic background layer from iD editor

### DIFF
--- a/frontend/src/components/editor.js
+++ b/frontend/src/components/editor.js
@@ -7,7 +7,11 @@ import '@openstreetmap/id/dist/iD.css';
 
 import { OSM_CLIENT_ID, OSM_REDIRECT_URI, OSM_SERVER_URL } from '../config';
 import messages from './messages';
-import { captureIdEditorPackage, resolveIdEditorContext } from '../utils/idEditorContext';
+import {
+  captureIdEditorPackage,
+  removeUnavailableImagerySources,
+  resolveIdEditorContext,
+} from '../utils/idEditorContext';
 
 const officialID = captureIdEditorPackage();
 
@@ -107,6 +111,7 @@ export default function Editor({ setDisable, comment, presets, imagery, gpxUrl, 
       } else {
         iDContext.init();
       }
+      removeUnavailableImagerySources(iDContext.background());
       if (gpxUrl) {
         fetch(gpxUrl)
           .then((response) => response.text())

--- a/frontend/src/components/sandboxEditor.js
+++ b/frontend/src/components/sandboxEditor.js
@@ -15,7 +15,11 @@ import {
 import { useSandboxOAuthCallback } from '../hooks/UseSandboxOAuthCallback';
 import { getValidTokenOrInitiateAuth, fetchSandboxLicense } from '../utils/sandboxUtils';
 import { useOsmFeaturesQuery } from '../api/projects';
-import { captureIdEditorPackage, resolveIdEditorContext } from '../utils/idEditorContext';
+import {
+  captureIdEditorPackage,
+  removeUnavailableImagerySources,
+  resolveIdEditorContext,
+} from '../utils/idEditorContext';
 
 const sandboxID = captureIdEditorPackage();
 
@@ -155,6 +159,8 @@ export default function SandboxEditor({
         } else {
           iDContext.init();
         }
+
+        removeUnavailableImagerySources(iDContext.background());
 
         iDContext.connection().switch({
           url: tokenData.sandbox_api_url,

--- a/frontend/src/utils/idEditorContext.js
+++ b/frontend/src/utils/idEditorContext.js
@@ -1,3 +1,24 @@
+const backgroundsWithFilteredImagery = new WeakSet();
+const unavailableImagerySourceIds = new Set(['OpenAerialMapMosaic']);
+
+// Both iD editors still include the retired Kontur OAM imagery source.
+// Wrap each background instance once so the unavailable source is hidden,
+// while preserving every argument expected by iD's source lookup.
+export function removeUnavailableImagerySources(background) {
+  if (
+    !background ||
+    typeof background.sources !== 'function' ||
+    backgroundsWithFilteredImagery.has(background)
+  ) {
+    return;
+  }
+
+  const originalSources = background.sources.bind(background);
+  background.sources = (...args) =>
+    originalSources(...args).filter((source) => !unavailableImagerySourceIds.has(source.id));
+  backgroundsWithFilteredImagery.add(background);
+}
+
 // Both @openstreetmap/id and @osm-sandbox/sandbox-id have no real ESM/CJS
 // exports — each only assigns itself to window.iD as a side effect on
 // import, and whichever loaded last wins that global for the rest of the

--- a/frontend/src/utils/tests/idEditorContext.test.js
+++ b/frontend/src/utils/tests/idEditorContext.test.js
@@ -1,0 +1,59 @@
+import { removeUnavailableImagerySources } from '../idEditorContext';
+
+describe('removeUnavailableImagerySources', () => {
+  it('removes the unavailable Kontur imagery source', () => {
+    const background = {
+      sources: jest.fn(() => [
+        { id: 'Bing' },
+        { id: 'OpenAerialMapMosaic' },
+        { id: 'EsriWorldImagery' },
+      ]),
+    };
+
+    removeUnavailableImagerySources(background);
+
+    expect(background.sources()).toEqual([{ id: 'Bing' }, { id: 'EsriWorldImagery' }]);
+  });
+
+  it('wraps each background source lookup only once', () => {
+    const originalSources = jest.fn(() => [{ id: 'Bing' }]);
+    const background = { sources: originalSources };
+
+    removeUnavailableImagerySources(background);
+    const filteredSources = background.sources;
+    removeUnavailableImagerySources(background);
+
+    expect(background.sources).toBe(filteredSources);
+    expect(background.sources()).toEqual([{ id: 'Bing' }]);
+    expect(originalSources).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards all source lookup arguments', () => {
+    const originalSources = jest.fn(() => [{ id: 'Bing' }]);
+    const background = { sources: originalSources };
+    const extent = { min: [0, 0], max: [1, 1] };
+
+    removeUnavailableImagerySources(background);
+    background.sources(extent, 18, true);
+
+    expect(originalSources).toHaveBeenCalledWith(extent, 18, true);
+  });
+
+  it('filters separate official and Sandbox background instances', () => {
+    const createBackground = () => ({
+      sources: () => [{ id: 'OpenAerialMapMosaic' }, { id: 'Bing' }],
+    });
+    const officialBackground = createBackground();
+    const sandboxBackground = createBackground();
+
+    removeUnavailableImagerySources(officialBackground);
+    removeUnavailableImagerySources(sandboxBackground);
+
+    expect(officialBackground.sources()).toEqual([{ id: 'Bing' }]);
+    expect(sandboxBackground.sources()).toEqual([{ id: 'Bing' }]);
+  });
+
+  it('ignores a missing background', () => {
+    expect(() => removeUnavailableImagerySources()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
Fixes #7186 

## Describe this PR
The Kontur OpenAerialMap Mosaic (`OpenAerialMapMosaic`) imagery source is no longer available, and its tile endpoint is defunct:

https://apps.kontur.io/raster-tiler/oam/mosaic/

This PR removes the unavailable source from the background-layer menu in both:

- The official iD editor
- The Sandbox iD editor

The source filtering is applied once per editor background instance while preserving the arguments expected by iD's source lookup.

## Screenshots
<img width="1351" height="960" alt="image" src="https://github.com/user-attachments/assets/38445dc8-d2fa-4376-a4a6-3b3d5215a3a4" />

