### PR TITLE
Resolve pie chart rendering for users by level in stat page

### DIFF
--- a/frontend/src/components/projectStats/contributorsStats.js
+++ b/frontend/src/components/projectStats/contributorsStats.js
@@ -34,11 +34,17 @@ export default function ContributorsStats({ contributors }) {
     })();
   }, []);
 
-  let userLevelsReference = levels.map((level) => {
+  const fallbackColors = ['#50C1CB', '#FAA71E', '#53688B', '#F34D47', '#9B59B6', '#2ECC71'];
+
+  let userLevelsReference = levels.map((level, index) => {
     return {
       label: level.name,
-      field: (stats) => stats.usersByLevel[level.name],
-      backgroundColor: level.color,
+      field: (stats) => stats.usersByLevel[level.name.split(' ')[0].toUpperCase()],
+      backgroundColor: level.color
+        ? level.color.startsWith('#')
+          ? level.color
+          : `#${level.color}`
+        : fallbackColors[index % fallbackColors.length],
       borderColor: CHART_COLOURS.white,
     };
   });


### PR DESCRIPTION
## What type of PR is this? (check multiple if applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI

Fixes: 
#7266

## Describe this PR (brief summary)
This PR fixes the `Users by Level` doughnut chart on the project statistics page being completely blank in production despite the API returning valid data.

Root causes:
- Level name key mismatch: `useContributorStats` stores contributor counts using the first word of mappingLevel uppercased (e.g. "Beginner mapper" → "BEGINNER"), but the chart was looking up by the full `level.name` from the /levels/ API ("Beginner mapper"). These never matched, so all counts were 0, making the chart render nothing. This was not caught in` dev/staging` because level names there were single words (BEGINNER, ADVANCED) where the lookup accidentally worked.

- Invalid color values:  When level.color is null or missing the # prefix (e.g. "F34D47"), `Chart.js` fails to parse it as a valid color and crashes with Cannot read properties of null (reading 'a') when computing hover colors.

**Changes**:
- Fixed level name lookup to normalize using `split(' ')[0].toUpperCase() ` to match how `useContributorStats` stores keys
- Added color normalization: prepends # if missing, falls back to a palette of distinct colors per level index if null

