### PR TITLE
 Reposition sandbox mode badge from main header

### DIFF
--- a/frontend/src/components/header/index.js
+++ b/frontend/src/components/header/index.js
@@ -3,8 +3,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import Popup from 'reactjs-popup';
 import { FormattedMessage } from 'react-intl';
-import { useProjectSummaryQuery } from '../../api/projects';
-
 import messages from './messages';
 import { ORG_URL, ORG_NAME, ORG_LOGO, SERVICE_DESK } from '../../config';
 import logo from '../../assets/img/main-logo.svg';
@@ -35,13 +33,6 @@ export const Header = () => {
   const userDetails = useSelector((state) => state.auth.userDetails);
   const organisations = useSelector((state) => state.auth.organisations);
   const showOrgBar = useSelector((state) => state.orgBarVisibility.isVisible);
-
-  // Matches URLs containing '/projects/' followed by digits (the project ID), like '/projects/130' or '/manage/projects/130'
-  const match = location.pathname.match(/\/projects\/(\d+)/);
-  const projectId = match ? match[1] : null;
-  const { data: project } = useProjectSummaryQuery(projectId, {
-    enabled: !!projectId,
-  });
 
   const linkCombo = 'link mh3 barlow-condensed blue-dark f4 ttu lh-solid nowrap pv2';
 
@@ -133,11 +124,6 @@ export const Header = () => {
           />
           <span className="barlow-condensed f3 fw6 ml2 blue-dark nowrap">Tasking Manager</span>
         </Link>
-        {project && project.sandbox && (
-          <div className="tc br1 f7 ttu ba b--red red pv1 ph2 ml3 v-mid dib nowrap">
-            <FormattedMessage {...messages.sandbox} />
-          </div>
-        )}
         <HorizontalScroll
           className={'dn dib-l ml5-l mr4-l pl6-xl'}
           style={{ flexGrow: 1 }}

--- a/frontend/src/components/projectDetail/header.js
+++ b/frontend/src/components/projectDetail/header.js
@@ -70,6 +70,14 @@ export const ProjectHeader = ({ project, showEditLink }: Object) => {
         {['DRAFT', 'ARCHIVED'].includes(project.status) && (
           <ProjectStatusBox status={project.status} className="pv2 ph3 mb3 v-mid dib mr3" />
         )}
+        {project.sandbox && (
+          <div
+            className="tc br1 f8 fw6 ttu pv2 ph3 mb3 v-mid dib mr3"
+            style={{ backgroundColor: '#a8e6cf', color: '#116530' }}
+          >
+            <FormattedMessage {...messages.sandbox} />
+          </div>
+        )}
       </div>
       <TagLine
         campaigns={project.campaigns}

--- a/frontend/src/components/projectDetail/messages.js
+++ b/frontend/src/components/projectDetail/messages.js
@@ -356,4 +356,8 @@ export default defineMessages({
     id: 'project.permissions.levelOrAbove',
     defaultMessage: 'level or above',
   },
+  sandbox: {
+    id: 'project.detail.sandbox',
+    defaultMessage: 'Sandbox Mode',
+  },
 });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #7226

## Describe this PR
- The `Sandbox Mode` badge was previously rendered in the global navigation header, requiring a background API call on every project page to fetch project data solely for this badge.
- Moves the badge to ProjectHeader (project detail header), alongside the existing visibility and status indicators (Draft, Archived, Private), where it contextually belongs.
- Styles the badge to match the InfoBox component (mint green fill) instead of the previous red border outline.
- Removes the now-unnecessary `useProjectSummaryQuery` call and URL regex match from the global header, eliminating an extra network request on project pages.


## Screenshots
<img width="1844" height="925" alt="image" src="https://github.com/user-attachments/assets/872967c7-ad27-43d4-9b80-9dbf2ce214d9" />
