### PR TITLE
chore: adopt Renovate for dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "baseBranches": ["develop"],
+  "timezone": "Etc/UTC",
+  "schedule": ["before 9am on monday"],
+  "enabledManagers": ["pep621", "npm", "dockerfile", "docker-compose"],
+  "rangeStrategy": "update-lockfile",
+  "lockFileMaintenance": {
+    "enabled": false
+  },
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 4,
+  "ignoreDeps": [
+    "postgis/postgis",
+    "python",
+    "docker.io/python",
+    "node",
+    "ghcr.io/hotosm/tasking-manager/backend",
+    "ghcr.io/hotosm/tasking-manager/frontend"
+  ],
+  "packageRules": [
+    {
+      "description": "Scope labels per ecosystem",
+      "matchManagers": ["pep621"],
+      "addLabels": ["scope: backend"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "addLabels": ["scope: frontend"]
+    },
+    {
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "addLabels": ["scope: infrastructure"]
+    },
+    {
+      "description": "Keep major updates as individual PRs for careful review",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Group remaining Python minor/patch updates",
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "python-non-major"
+    },
+    {
+      "description": "Group remaining npm minor/patch updates",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm-non-major"
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["fastapi*", "uvicorn*", "pydantic*", "starlette*"],
+      "groupName": "fastapi-stack"
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["SQLAlchemy*", "alembic*", "databases*", "asyncpg*", "GeoAlchemy2*"],
+      "groupName": "database-stack"
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["shapely*", "geojson*", "pyproj*"],
+      "groupName": "geo-stack"
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["sentry-sdk*"],
+      "groupName": "sentry-python"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["react", "react-dom", "react-router-dom", "react-scripts", "@types/react", "@types/react-dom"],
+      "groupName": "react-core"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["@tanstack/*"],
+      "groupName": "tanstack"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["@turf/*"],
+      "groupName": "turf"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["maplibre-gl", "@maplibre/*", "@watergis/*", "terra-draw"],
+      "groupName": "maplibre"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["@sentry/*"],
+      "groupName": "sentry-js"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["@testing-library/*", "msw", "jest*", "react-test-renderer"],
+      "groupName": "testing"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["workbox-*"],
+      "groupName": "workbox"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackageNames": ["redux", "react-redux", "redux-*"],
+      "groupName": "redux-state"
+    }
+  ]
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #7183

## Describe this PR

Adds `renovate.json` to automate dependency updates with Renovate, per
[docs 0012](https://docs.hotosm.org/decisions/0012-dependency-refresh/)
(reduce GitHub vendor lock-in). Supersedes the Dependabot config in #7274.

- Four ecosystems only: `pep621`, `npm`, `dockerfile`, `docker-compose`
  (GitHub Actions intentionally excluded)
- Weekly batch (Mon, UTC), minor/patch **grouped** into consolidated PRs
- Direct deps only; legacy `requirements.txt` skipped
- **No auto-merge**; **major** updates held behind Dependency Dashboard approval
- `ignoreDeps` for critical pins: `postgis/postgis`, `python`, `node`, and
  TM's own `ghcr.io/hotosm/tasking-manager/*` images

`renovate.json` validates against the Renovate schema. It does nothing until
the Renovate app has access to this repo.

I think Renovate is already installed on the org (it's active on
field-tm), so this probably just needs `tasking-manager` added to the app's
repo access rather than a fresh install.

## Alternative Approaches Considered

Dependabot (#7274) — dropped in favour of Renovate per ADR 0012; this ports
that config's intent.
