### PR TITLE
fix(frontend): dedupe management.button.cancel locale id (#7284)

### DIFF
--- a/frontend/src/components/badges/index.js
+++ b/frontend/src/components/badges/index.js
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 
 import messages from './messages';
+import sharedMessages from '../teamsAndOrgs/messages';
 import { Button } from '../button';
 import { Management } from '../teamsAndOrgs/management';
 import { nCardPlaceholders } from './nCardPlaceholders';
@@ -302,7 +303,7 @@ export const BadgeUpdateForm = ({ badge, updateBadge }) => {
               <div className="cf pt0 h3">
                 <div className="w-70-l w-50 fl tr dib bg-grey-light">
                   <Button className="blue-dark bg-grey-light h3" onClick={() => form.restart()}>
-                    <FormattedMessage {...messages.cancel} />
+                    <FormattedMessage {...sharedMessages.cancel} />
                   </Button>
                 </div>
                 <div className="w-30-l w-50 h-100 fr dib">

--- a/frontend/src/components/badges/messages.js
+++ b/frontend/src/components/badges/messages.js
@@ -5,7 +5,6 @@ export default defineMessages({
   badgeInfo: { id: 'management.titles.badge_information', defaultMessage: 'Badge information' },
   badges: { id: 'management.badges', defaultMessage: 'Badges' },
   building: { id: 'management.badges.building', defaultMessage: 'buildings added' },
-  cancel: { id: 'management.button.cancel', defaultMessage: 'Cancel' },
   changeset: { id: 'management.badges.changeset', defaultMessage: 'Number of changesets' },
   changesets: { id: 'management.badges.changesets', defaultMessage: 'Changesets' },
   description: { id: 'management.fields.description', defaultMessage: 'Description' },

--- a/frontend/src/components/levels/index.js
+++ b/frontend/src/components/levels/index.js
@@ -6,6 +6,7 @@ import Select from 'react-select';
 import { useState } from 'react';
 
 import messages from './messages';
+import sharedMessages from '../teamsAndOrgs/messages';
 import { Button } from '../button';
 import { Management } from '../teamsAndOrgs/management';
 import { nCardPlaceholders } from './nCardPlaceholder';
@@ -230,7 +231,7 @@ export const LevelForm = ({ level, badges, updateLevel }) => {
               <div className="cf pt0 h3">
                 <div className="w-70-l w-50 fl tr dib bg-grey-light">
                   <Button className="blue-dark bg-grey-light h3" onClick={() => form.restart()}>
-                    <FormattedMessage {...messages.cancel} />
+                    <FormattedMessage {...sharedMessages.cancel} />
                   </Button>
                 </div>
                 <div className="w-30-l w-50 h-100 fr dib">

--- a/frontend/src/components/levels/messages.js
+++ b/frontend/src/components/levels/messages.js
@@ -3,7 +3,6 @@ import { defineMessages } from 'react-intl';
 export default defineMessages({
   add: { id: 'management.levels.add', defaultMessage: 'Add' },
   approvals_required: { id: 'management.levels.approvals_required', defaultMessage: 'Approvals required' },
-  cancel: { id: 'management.button.cancel', defaultMessage: 'Cancel' },
   color: { id: 'management.levels.color', defaultMessage: 'Color' },
   levelInfoTitle: { id: 'management.titles.level_information', defaultMessage: 'Level information' },
   levels: { id: 'management.levels', defaultMessage: 'Levels' },


### PR DESCRIPTION
## Summary
- Removes duplicate `management.button.cancel` react-intl id from `levels/messages.js` and `badges/messages.js`
- Reuses the definition in `teamsAndOrgs/messages.js`

Fixes `yarn build-locales` failure: `Duplicate message id: management.button.cancel`

## Test plan
- [ ] `cd frontend && yarn build-locales` completes without duplicate-id error
- [ ] Levels/badges cancel buttons still render "Cancel"


Made with [Cursor](https://cursor.com)