### PR TITLE
fix(frontend): show specific lock-task error reasons (#7281)

### DIFF
--- a/frontend/src/components/taskSelection/footer.js
+++ b/frontend/src/components/taskSelection/footer.js
@@ -50,13 +50,17 @@ const TaskSelectionFooter = ({
     navigate(`/projects/${project.projectId}/${endpoint}/${urlParams}`);
   };
 
-  const lockFailed = (windowObjectReference, message) => {
+  const lockFailed = (windowObjectReference, error) => {
     // JOSM and iD don't open a new window
     if (!['JOSM', 'ID', 'RAPID'].includes(editor)) {
       windowObjectReference.close();
     }
     fetchLockedTasks();
-    setLockError(message);
+    setLockError(
+      typeof error === 'object' && error !== null
+        ? error
+        : { subCode: error, detail: null },
+    );
     setIsPending(false);
   };
 
@@ -107,7 +111,9 @@ const TaskSelectionFooter = ({
           .then((res) => {
             lockSuccess('LOCKED_FOR_VALIDATION', 'validate', windowObjectReference);
           })
-          .catch((e) => lockFailed(windowObjectReference, e.message));
+          .catch((e) =>
+            lockFailed(windowObjectReference, { subCode: e.subCode || e.message, detail: e.apiError }),
+          );
       }
     }
     if (['mapSelectedTask', 'mapAnotherTask', 'mapATask'].includes(taskAction)) {
@@ -120,7 +126,9 @@ const TaskSelectionFooter = ({
         .then((res) => {
           lockSuccess('LOCKED_FOR_MAPPING', 'map', windowObjectReference);
         })
-        .catch((e) => lockFailed(windowObjectReference, e.message));
+        .catch((e) =>
+          lockFailed(windowObjectReference, { subCode: e.subCode || e.message, detail: e.apiError }),
+        );
     }
     if (['resumeMapping', 'resumeValidation'].includes(taskAction)) {
       const urlParams = openEditor(

--- a/frontend/src/components/taskSelection/lockedTasks.js
+++ b/frontend/src/components/taskSelection/lockedTasks.js
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
 
 import messages from './messages';
+import { resolveLockErrorMessages, normalizeLockError } from '../../utils/lockErrorMessages';
 import { Button } from '../button';
 import { useGetLockedTasks } from '../../hooks/UseLockedTasks';
 
@@ -119,23 +120,17 @@ export const LicenseError = ({ id, close, lockTasks }) => {
 };
 
 export function LockError({ error, close, tasks, selectedTasks, setSelectedTasks, lockTasks }) {
-  const shouldShowDeselectButton = error === 'CannotValidateMappedTask' && selectedTasks.length > 1;
+  const { subCode } = normalizeLockError(error);
+  const shouldShowDeselectButton = subCode === 'CannotValidateMappedTask' && selectedTasks.length > 1;
+  const { title, description } = resolveLockErrorMessages(error, messages);
 
   return (
     <>
       <h3 className="barlow-condensed f3 fw6 mv0">
-        {messages[`${error}Error`] ? (
-          <FormattedMessage {...messages[`${error}Error`]} />
-        ) : (
-          <FormattedMessage {...messages.lockError} />
-        )}
+        <FormattedMessage {...title} />
       </h3>
       <div className="mv4 lh-title">
-        {messages[`${error}ErrorDescription`] ? (
-          <FormattedMessage {...messages[`${error}ErrorDescription`]} />
-        ) : (
-          <FormattedMessage {...messages.lockErrorDescription} />
-        )}
+        <FormattedMessage {...description} />
       </div>
       <LockErrorButtons
         close={close}
@@ -210,14 +205,15 @@ export function LockedTaskModalContent({
 }: Object) {
   const lockedTasks = useGetLockedTasks();
   const action = lockedTasks.status === 'LOCKED_FOR_VALIDATION' ? 'validate' : 'map';
-  const licenseError = error === 'UserLicenseError' && !lockedTasks.project;
+  const { subCode } = normalizeLockError(error);
+  const licenseError = subCode === 'UserLicenseError' && !lockedTasks.project;
 
   return (
     <div className="blue-dark bg-white pv2 pv4-ns ph2 ph4-ns">
       {licenseError && <LicenseError id={project.licenseId} close={close} lockTasks={lockTasks} />}
       {/* Other error happened */}
-      {error === 'JOSM' && <LockError error={error} close={close} />}
-      {!lockedTasks.project && !licenseError && error !== 'JOSM' && (
+      {subCode === 'JOSM' && <LockError error={error} close={close} />}
+      {!lockedTasks.project && !licenseError && subCode !== 'JOSM' && (
         <LockError
           error={error}
           close={close}
@@ -228,7 +224,7 @@ export function LockedTaskModalContent({
         />
       )}
       {/* User has tasks locked on another project */}
-      {lockedTasks.project && lockedTasks.project !== project.projectId && error !== 'JOSM' && (
+      {lockedTasks.project && lockedTasks.project !== project.projectId && subCode !== 'JOSM' && (
         <AnotherProjectLock
           projectId={lockedTasks.project}
           action={action}
@@ -236,7 +232,7 @@ export function LockedTaskModalContent({
         />
       )}
       {/* User has tasks locked on the current project */}
-      {lockedTasks.project === project.projectId && error !== 'JOSM' && (
+      {lockedTasks.project === project.projectId && subCode !== 'JOSM' && (
         <SameProjectLock action={action} lockedTasks={lockedTasks} />
       )}
     </div>

--- a/frontend/src/utils/lockErrorMessages.js
+++ b/frontend/src/utils/lockErrorMessages.js
@@ -1,0 +1,87 @@
+/**
+ * Maps API lock SubCodes to taskSelection message keys.
+ * Legacy SubCodes (e.g. UserNotAllowed) use the `${code}Error` pattern in messages.js.
+ */
+export const LOCK_SUBCODE_MESSAGES = {
+  'MappingNotAllowed.USER_NOT_CORRECT_MAPPING_LEVEL': {
+    title: 'permissionErrorTitle',
+    description: 'permissionError_userLevelToMap',
+  },
+  'MappingNotAllowed.USER_NOT_TEAM_MEMBER': {
+    title: 'permissionErrorTitle',
+    description: 'permissionError_userIsNotMappingTeamMember',
+  },
+  'MappingNotAllowed.USER_NOT_ON_ALLOWED_LIST': {
+    title: 'UserNotAllowedError',
+    description: 'UserNotAllowedErrorDescription',
+  },
+  'MappingNotAllowed.PROJECT_NOT_PUBLISHED': {
+    title: 'ProjectNotPublishedError',
+    description: 'ProjectNotPublishedErrorDescription',
+  },
+  'MappingNotAllowed.USER_ALREADY_HAS_TASK_LOCKED': {
+    title: 'lockError',
+    description: 'lockErrorDescription',
+  },
+  'MappingNotAllowed.USER_NOT_ACCEPTED_LICENSE': {
+    title: 'lockErrorLicense',
+    description: 'lockErrorLicenseDescription',
+  },
+  'ValidatingNotAllowed.USER_NOT_CORRECT_MAPPING_LEVEL': {
+    title: 'permissionErrorTitle',
+    description: 'permissionError_userLevelToValidate',
+  },
+  'ValidatingNotAllowed.USER_NOT_TEAM_MEMBER': {
+    title: 'permissionErrorTitle',
+    description: 'permissionError_userIsNotValidationTeamMember',
+  },
+  'ValidatingNotAllowed.USER_NOT_ON_ALLOWED_LIST': {
+    title: 'UserNotAllowedError',
+    description: 'UserNotAllowedErrorDescription',
+  },
+  'ValidatingNotAllowed.PROJECT_NOT_PUBLISHED': {
+    title: 'ProjectNotPublishedError',
+    description: 'ProjectNotPublishedErrorDescription',
+  },
+};
+
+export function normalizeLockError(error) {
+  if (error && typeof error === 'object' && error.subCode) {
+    return error;
+  }
+
+  return { subCode: error, detail: null };
+}
+
+export function resolveLockErrorMessages(error, messages) {
+  const { subCode, detail } = normalizeLockError(error);
+
+  const mapped = LOCK_SUBCODE_MESSAGES[subCode];
+  if (mapped) {
+    return {
+      title: messages[mapped.title],
+      description: messages[mapped.description],
+    };
+  }
+
+  const legacyTitle = messages[`${subCode}Error`];
+  const legacyDescription = messages[`${subCode}ErrorDescription`];
+  if (legacyTitle) {
+    return {
+      title: legacyTitle,
+      description: legacyDescription,
+    };
+  }
+
+  if (detail) {
+    return {
+      title: messages.lockError,
+      description: { id: 'project.tasks.lock_error.api_detail', defaultMessage: detail },
+    };
+  }
+
+  return {
+    title: messages.lockError,
+    description: messages.lockErrorDescription,
+  };
+}

--- a/frontend/src/utils/lockErrorMessages.js
+++ b/frontend/src/utils/lockErrorMessages.js
@@ -2,48 +2,35 @@
  * Maps API lock SubCodes to taskSelection message keys.
  * Legacy SubCodes (e.g. UserNotAllowed) use the `${code}Error` pattern in messages.js.
  */
-export const LOCK_SUBCODE_MESSAGES = {
-  'MappingNotAllowed.USER_NOT_CORRECT_MAPPING_LEVEL': {
-    title: 'permissionErrorTitle',
-    description: 'permissionError_userLevelToMap',
-  },
-  'MappingNotAllowed.USER_NOT_TEAM_MEMBER': {
-    title: 'permissionErrorTitle',
-    description: 'permissionError_userIsNotMappingTeamMember',
-  },
-  'MappingNotAllowed.USER_NOT_ON_ALLOWED_LIST': {
-    title: 'UserNotAllowedError',
-    description: 'UserNotAllowedErrorDescription',
-  },
-  'MappingNotAllowed.PROJECT_NOT_PUBLISHED': {
-    title: 'ProjectNotPublishedError',
-    description: 'ProjectNotPublishedErrorDescription',
-  },
-  'MappingNotAllowed.USER_ALREADY_HAS_TASK_LOCKED': {
-    title: 'lockError',
-    description: 'lockErrorDescription',
-  },
-  'MappingNotAllowed.USER_NOT_ACCEPTED_LICENSE': {
-    title: 'lockErrorLicense',
-    description: 'lockErrorLicenseDescription',
-  },
-  'ValidatingNotAllowed.USER_NOT_CORRECT_MAPPING_LEVEL': {
-    title: 'permissionErrorTitle',
-    description: 'permissionError_userLevelToValidate',
-  },
-  'ValidatingNotAllowed.USER_NOT_TEAM_MEMBER': {
-    title: 'permissionErrorTitle',
-    description: 'permissionError_userIsNotValidationTeamMember',
-  },
-  'ValidatingNotAllowed.USER_NOT_ON_ALLOWED_LIST': {
-    title: 'UserNotAllowedError',
-    description: 'UserNotAllowedErrorDescription',
-  },
-  'ValidatingNotAllowed.PROJECT_NOT_PUBLISHED': {
-    title: 'ProjectNotPublishedError',
-    description: 'ProjectNotPublishedErrorDescription',
-  },
-};
+
+function lockMessages(entries) {
+  return entries.reduce((acc, [suffix, title, mapDescription, validateDescription = mapDescription]) => {
+    acc[`MappingNotAllowed.${suffix}`] = { title, description: mapDescription };
+    if (validateDescription !== null) {
+      acc[`ValidatingNotAllowed.${suffix}`] = { title, description: validateDescription };
+    }
+    return acc;
+  }, {});
+}
+
+export const LOCK_SUBCODE_MESSAGES = lockMessages([
+  [
+    'USER_NOT_CORRECT_MAPPING_LEVEL',
+    'permissionErrorTitle',
+    'permissionError_userLevelToMap',
+    'permissionError_userLevelToValidate',
+  ],
+  [
+    'USER_NOT_TEAM_MEMBER',
+    'permissionErrorTitle',
+    'permissionError_userIsNotMappingTeamMember',
+    'permissionError_userIsNotValidationTeamMember',
+  ],
+  ['USER_NOT_ON_ALLOWED_LIST', 'UserNotAllowedError', 'UserNotAllowedErrorDescription'],
+  ['PROJECT_NOT_PUBLISHED', 'ProjectNotPublishedError', 'ProjectNotPublishedErrorDescription'],
+  ['USER_ALREADY_HAS_TASK_LOCKED', 'lockError', 'lockErrorDescription', null],
+  ['USER_NOT_ACCEPTED_LICENSE', 'lockErrorLicense', 'lockErrorLicenseDescription', null],
+]);
 
 export function normalizeLockError(error) {
   if (error && typeof error === 'object' && error.subCode) {

--- a/frontend/src/utils/promise.js
+++ b/frontend/src/utils/promise.js
@@ -20,17 +20,20 @@ export async function handleErrors(response, defaultMessage = 'Something went wr
   }
 
   let text;
+  let apiError;
   await response
     .clone()
     .json()
     .then((res) => {
       text = res.SubCode || res.error?.sub_code || response.statusText;
-    });
+      apiError = res.Error;
+    })
+    .catch(() => {});
 
-    console.log(text, 'text******');
-
-
-  throw Error(text || defaultMessage);
+  const err = new Error(text || defaultMessage);
+  err.subCode = text;
+  err.apiError = apiError;
+  throw err;
 }
 
 export function cancelableFetchJSON(url: string) {


### PR DESCRIPTION
## Summary
- Maps API `SubCode` values (e.g. `MappingNotAllowed.USER_NOT_CORRECT_MAPPING_LEVEL`) to existing permission error messages
- Falls back to API `Error` text when no mapping exists
- Removes stray `console.log` from `handleErrors`

## Test plan
- [ ] User below project mapping level sees level-specific message, not generic dialog
- [ ] Legacy SubCodes (`UserNotAllowed`, etc.) still work
- [ ] JOSM / license / locked-task flows unchanged


Made with [Cursor](https://cursor.com)