### PR TITLE
fix(frontend): render Users by level pie chart (#7266)

### DIFF
--- a/frontend/src/hooks/UseContributorStats.js
+++ b/frontend/src/hooks/UseContributorStats.js
@@ -19,6 +19,9 @@ export function useContributorStats(contributions) {
         validators: contributions.filter((i) => i.validated > 0).length,
         mappers: contributions.filter((i) => i.mapped > 0).length,
         usersByLevel: contributions.reduce((prev, curr) => {
+          if (!curr.mappingLevel) {
+            return prev;
+          }
           const level = curr.mappingLevel.split(' ')[0].toUpperCase();
           if (!Object.hasOwnProperty.call(prev, level)) {
             prev[level] = 0;

--- a/frontend/src/utils/formatChartJSData.js
+++ b/frontend/src/utils/formatChartJSData.js
@@ -6,10 +6,12 @@ export const formatChartData = (reference, stats) => {
       return f.field(stats) || 0;
     }
 
-    return stats[f.field];
+    return stats[f.field] || 0;
   });
   const total = data.datasets[0].data.reduce((a, b) => a + b, 0);
-  data.datasets[0].data = data.datasets[0].data.map((v) => Math.round((v / total) * 100));
+  if (total > 0) {
+    data.datasets[0].data = data.datasets[0].data.map((v) => Math.round((v / total) * 100));
+  }
   data.datasets[0].backgroundColor = reference.map((f) => f.backgroundColor);
   data.datasets[0].borderColor = reference.map((f) => f.borderColor);
   data.labels = reference.map((f) => f.label);


### PR DESCRIPTION
## Summary
- `formatChartData`: treat missing values as 0; skip percentage math when total is 0 (avoids NaN)
- `UseContributorStats`: skip contributors without `mappingLevel`

## Test plan
- [ ] Project statistics → Contributors → "Users by level" doughnut renders when data exists
- [ ] No blank chart / NaN when some levels have zero contributors


Made with [Cursor](https://cursor.com)