### PR TITLE
fix: prevent white screen on task selection map

### DIFF
--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -1,4 +1,4 @@
-import { lazy, useState, useEffect, useCallback, Suspense, useRef } from 'react';
+import { lazy, useState, useEffect, useCallback, useMemo, Suspense, useRef } from 'react';
 import { useLocation, useParams, useNavigate } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { useQueryParam, StringParam } from 'use-query-params';
@@ -90,9 +90,10 @@ export function TaskSelection({ project }: Object) {
   });
   const { data: tasksData, refetch: refetchTasks } = useTasksQuery(projectId, {
     useErrorBoundary: true,
-    // Task status on the map were not being updated when coming from the action page,
-    // so added this as a workaround.
-    cacheTime: 0,
+    // Keep the cached grid so the map paints instantly (stale) on remount instead
+    // of showing a white screen. `staleTime: 0` lets invalidateQueries mark it stale
+    // so a background refetch is allowed; a fresh refetch is triggered on mount below.
+    staleTime: 0,
     enabled: false,
   });
   const {
@@ -101,7 +102,10 @@ export function TaskSelection({ project }: Object) {
     isLoadingError: isPriorityAreasLoadingError,
   } = usePriorityAreasQuery(projectId);
 
-  const tasks = tasksData && activities && updateTasksStatus(tasksData, activities);
+  const tasks = useMemo(
+    () => (tasksData && activities ? updateTasksStatus(tasksData, activities) : undefined),
+    [tasksData, activities],
+  );
   const randomTask = activities && [getRandomTaskByAction(activities.activity, taskAction)];
   const isValidationAllowed = user && userTeams && userCanValidate(user, project, userTeams.teams);
 
@@ -109,6 +113,12 @@ export function TaskSelection({ project }: Object) {
     isPriorityAreasLoadingError &&
       toast.error(<FormattedMessage {...messages.priorityAreasLoadingError} />);
   }, [isPriorityAreasLoadingError]);
+
+  // Fetch fresh task geometry on mount. With the cache kept, the stale grid paints
+  // immediately (no white screen) while this refetch silently refreshes it.
+  useEffect(() => {
+    if (token) refetchTasks();
+  }, [token, refetchTasks]);
 
   useEffect(() => {
     const { lastLockedTasksIds, lastLockedProjectId } = location.state || {};

--- a/frontend/src/components/taskSelection/map.js
+++ b/frontend/src/components/taskSelection/map.js
@@ -427,11 +427,22 @@ export const TasksMap = ({
       someResultsReady;
     const mapLayersAlreadyDefined = map !== null && map.getSource('tasks') !== undefined;
 
-    /* set up style/sources for the map, either immediately or on base load */
+    /* set up style/sources for the map, either immediately (style already
+     * parsed) or on the 'style.load' event. We intentionally do NOT wait for
+     * the 'load' event: 'load' only fires after the first visually complete
+     * render, which includes the base raster tiles downloading. On a slow
+     * connection that would keep the task grid hidden until the imagery
+     * appears, so we draw the grid as soon as the style is ready instead. */
     if (mapReadyTasksReady && !mapLayersAlreadyDefined) {
       maplibreLayerDefn();
     } else if (tasksReadyMapLoading && !mapLayersAlreadyDefined) {
-      map.on('load', maplibreLayerDefn);
+      // 'style.load' fires once the style JSON is parsed, before the base
+      // raster tiles finish downloading — unlike 'load', which waits for the
+      // first complete render (tiles included). Using it keeps the task grid
+      // from being blocked behind slow base imagery.
+      map.once('style.load', () => {
+        if (map.getSource('tasks') === undefined) maplibreLayerDefn();
+      });
     } else if (tasksReadyMapLoading || mapReadyTasksReady) {
       console.error('One of the hook dependencies changed and try to redefine the map');
     }

--- a/frontend/src/config/index.js
+++ b/frontend/src/config/index.js
@@ -97,8 +97,15 @@ const fallbackRasterStyle = {
   sources: {
     'raster-tiles': {
       type: 'raster',
-      tiles: ['https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png'],
-      tileSize: 128,
+      // Round-robin across a/b/c subdomains for more concurrent tile requests,
+      // and use the native 256px tile size (128 caused ~4x more requests and
+      // downscaled/blurry tiles), which hammered the single HOT tile host.
+      tiles: [
+        'https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
+        'https://b.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
+        'https://c.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
+      ],
+      tileSize: 256,
       attribution:
         '© <a href="https://www.openstreetmap.org/copyright/">OpenStreetMap</a> contributors',
     },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
Fixes #7280

## Describe this PR
The task selection map often showed a white screen with no task grid most noticeably after submitting a task, and on slower connections the grid wouldn't appear until the background imagery had fully loaded.

Investigating in the running app (throttled to Slow 3G to reproduce reliably), this was three separate issues stacking, not one:

1. **Task data dropped from cache on every remount**. useTasksQuery used cacheTime: 0, so returning from the action page left tasks undefined and the ReactPlaceholder gate replaced the whole map with a loader until the network responded. The updateTasksStatus merge also ran on every render, causing the grid to flicker.
2. **The task grid was gated behind the base imagery.** The grid layers were added inside MapLibre's load event, which only fires after the first visually complete render (base raster tiles included). On a slow connection the grid stayed hidden until the imagery downloaded.
3. **Base tiles fetched inefficiently.** The base map used a single tile host with tileSize: 128. Since the HOT tiles are natively 256px, MapLibre requested ~4× more (downscaled) tiles than needed, all through one host.

## Changes:

`taskSelection/index.js`
 Keep the task cache (staleTime: 0 + refetch on mount) so the grid paints instantly with last-known state and refreshes in the background; memoize the updateTasksStatus result to stop the map effect re-running every render.

`taskSelection/map.js`  
Add the task grid on style.load instead of load, so it renders as soon as the style is parsed, over the still-loading base tiles.

`config/index.js` 
Use tileSize: 256 and round-robin base tiles across the a/b/c subdomains.

