### PR TITLE
Clarify signup name field as public Display Name (#5208)

### DIFF
--- a/frontend/src/components/header/messages.js
+++ b/frontend/src/components/header/messages.js
@@ -1,186 +1,381 @@
 import { defineMessages } from 'react-intl';
+
 /**
+
  * Internationalized messages for use on header.
+
  */
+
 export default defineMessages({
+
   exploreProjects: {
+
     id: 'header.nav.projects',
+
     defaultMessage: 'Explore projects',
+
   },
+
   learn: {
+
     id: 'header.nav.learn',
+
     defaultMessage: 'Learn',
+
   },
+
   about: {
+
     id: 'header.nav.aboutLink',
+
     defaultMessage: 'About',
+
   },
+
   support: {
+
     id: 'header.nav.support',
+
     defaultMessage: 'Support',
+
   },
+
   myContributions: {
+
     id: 'header.nav.my_contributions',
+
     defaultMessage: 'My contributions',
+
   },
+
   manage: {
+
     id: 'header.nav.manage',
+
     defaultMessage: 'Manage',
+
   },
+
   logIn: {
+
     id: 'header.buttons.logIn',
+
     defaultMessage: 'Log in',
+
   },
+
   partners: {
+
     id: 'header.nav.partners',
+
     defaultMessage: 'Partners',
+
   },
+
   signUp: {
+
     id: 'header.buttons.signUp',
+
     defaultMessage: 'Sign up',
+
   },
+
   createAccount: {
+
     id: 'header.buttons.createAccount',
+
     defaultMessage: 'Create an account',
+
   },
+
   authorize: {
+
     id: 'header.buttons.authorize',
+
     defaultMessage: 'Log in',
+
   },
+
   AuthorizeTitle: {
+
     id: 'signUp.modal.authorize',
+
     defaultMessage: 'Have you finished the registration on OpenStreetMap?',
+
   },
+
   AuthorizeMessage: {
+
     id: 'signUp.authorize.message',
+
     defaultMessage:
+
       'Start mapping now! Just login to the Tasking Manager with your new OpenStreetMap account.',
+
   },
+
   osmRegisterCheck: {
+
     id: 'signUp.authorize.check',
+
     defaultMessage: 'Do you still need an OpenStreetMap account?',
+
   },
+
   signUpTitle: {
+
     id: 'signUp.modal.title',
+
     defaultMessage: 'Sign up',
+
   },
+
   signupLabelEmail: {
+
     id: 'signUp.modal.form_email',
+
     defaultMessage: 'Email',
+
   },
+
   signupLabelName: {
+
     id: 'signUp.modal.form_name',
-    defaultMessage: 'Name',
+
+    defaultMessage: 'Display Name',
+
   },
+
+  signupNameHelp: {
+
+    id: 'signUp.modal.form_name_help',
+
+    defaultMessage:
+
+      'This name is publicly visible on the Tasking Manager and can be changed later in your preferences.',
+
+  },
+
   proceedOSMTitle: {
+
     id: 'signUp.proceed_osm.osm_title',
+
     defaultMessage: 'Do you have an OpenStreetMap account?',
+
   },
+
   proceedOSMPart1: {
+
     id: 'signup.proceed_osm.text1',
+
     defaultMessage:
+
       'The Tasking Manager works with OpenStreetMap, a collaborative, open-source map of the world. Everything you map on the Tasking Manager is going to be available on OpenStreetMap.',
+
   },
+
   proceedOSMPart2: {
+
     id: 'signup.proceed_osm.text2',
+
     defaultMessage: "First, you'll need an account on OpenStreetMap.org in order to get started.",
+
   },
+
   proceedOSMLogin: {
+
     id: 'signup.proceed_osm.login',
+
     defaultMessage: 'I already have an OpenStreetMap account',
+
   },
+
   emailPlaceholder: {
+
     id: 'input.placeholder.email_address',
+
     defaultMessage: 'Your email address',
+
   },
+
   invalidEmail: {
+
     id: 'input.errors.email_address',
+
     defaultMessage: 'Invalid email address',
+
   },
+
   invalidName: {
+
     id: 'input.errors.name',
+
     defaultMessage: 'Invalid name',
+
   },
+
   namePlaceHolder: {
+
     id: 'input.placeholder.Name',
-    defaultMessage: 'Your Name',
+
+    defaultMessage: 'Your publicly visible name',
+
   },
+
   slogan: {
+
     id: 'header.topBar.slogan',
+
     defaultMessage: 'Mapping our world together',
+
   },
+
   settings: {
+
     id: 'header.nav.settings',
+
     defaultMessage: 'Settings',
+
   },
+
   myTeams: {
+
     id: 'header.nav.my_teams',
+
     defaultMessage: 'My teams',
+
   },
+
   logout: {
+
     id: 'header.nav.logout',
+
     defaultMessage: 'Logout',
+
   },
+
   email: {
+
     id: 'signup.modal.email',
+
     defaultMessage: 'Email',
+
   },
+
   submitProceed: {
+
     id: 'signup.button.submit',
+
     defaultMessage: 'Next',
+
   },
+
   submitProceedOSM: {
+
     id: 'signup.button.submit_osm',
+
     defaultMessage: 'Create OpenStreetMap account',
+
   },
+
   signUpQuestion: {
+
     id: 'signup.modal.question',
+
     defaultMessage: 'Please provide your name and email address:',
+
   },
+
   emailUpdateButton: {
+
     id: 'emailUpdate.modal.button',
+
     defaultMessage: 'Update',
+
   },
+
   emailUpdateSuccess: {
+
     id: 'emailUpdate.modal.success_message',
+
     defaultMessage: 'Email updated successfully',
+
   },
+
   emailUpdateTitle: {
+
     id: 'emailUpdate.modal.title',
+
     defaultMessage: 'Update your email',
+
   },
+
   emailUpdateTextPart1: {
+
     id: 'emailUpdate.modal.text1',
+
     defaultMessage: 'Before you begin mapping, please add your email address.',
+
   },
+
   emailUpdateTextPart2: {
+
     id: 'emailUpdate.modal.text2',
+
     defaultMessage:
+
       'We are mapping together! Providing your email address is necessary for mapping feedback and direct messages to reach you.',
+
   },
+
   privacyPolicy: {
+
     id: 'emailUpdate.modal.privacy_policy',
+
     defaultMessage:
+
       "Read our Privacy Policy for more information on how we protect users' personal data.",
+
   },
+
   newVersionAvailable: {
+
     id: 'serviceWorker.dialog.newVersion',
+
     defaultMessage: 'Tasking Manager has been updated.',
+
   },
+
   newVersionAvailableLineTwo: {
+
     id: 'serviceWorker.dialog.newVersionAvailableLineTwo',
+
     defaultMessage: 'Click the button to refresh and ensure the page is displayed correctly.',
+
   },
+
   update: {
+
     id: 'serviceWorker.dialog.update',
+
     defaultMessage: 'Refresh',
+
   },
+
   remindMeLater: {
+
     id: 'serviceWorker.dialog.remindMeLater',
+
     defaultMessage: 'Remind me later',
+
   },
+
   sandbox: {
+
     id: 'project.detail.sandbox',
+
     defaultMessage: 'Sandbox Mode',
+
   },
+
 });

--- a/frontend/src/components/header/signUp.js
+++ b/frontend/src/components/header/signUp.js
@@ -1,227 +1,459 @@
 import { useState } from 'react';
+
 import { FormattedMessage } from 'react-intl';
 
+
+
 import messages from './messages';
+
 import { Button } from '../button';
+
 import { CloseIcon } from '../svgIcons';
+
 import { registerUser } from '../../store/actions/user';
+
 import { store } from '../../store';
+
 import { osmLoginRedirect } from '../../utils/login';
+
 import { ORG_PRIVACY_POLICY_URL, OSM_REGISTER_URL } from '../../config';
+
 import { setItem } from '../../utils/safe_storage';
 
+
+
 export const LoginModal = ({ step, login }) => {
+
   return (
+
     <div>
+
       <h1 className="pb2 ma0 barlow-condensed blue-dark">
+
         <span className="mr2">{step.number}.</span>
+
         <FormattedMessage {...messages.AuthorizeTitle} />
+
       </h1>
+
       <div>
+
         <p className="blue-dark lh-copy">
+
           <FormattedMessage {...messages.AuthorizeMessage} />
+
         </p>
+
       </div>
+
       <div className="mt4 tr">
+
         <Button className="bg-red white" onClick={() => login()}>
+
           <FormattedMessage {...messages.authorize} />
+
         </Button>
+
         <p className="mb0 f6 tr">
+
           <a
+
             className="link pointer red fw5"
+
             target="_blank"
+
             rel="noopener noreferrer"
+
             href={OSM_REGISTER_URL}
+
           >
+
             <FormattedMessage {...messages.osmRegisterCheck} />
+
           </a>
+
         </p>
+
       </div>
+
     </div>
+
   );
+
 };
+
+
 
 export const ProceedOSM = ({ data, step, setStep, login }) => {
+
   const NextStep = (setStep) => {
+
     window.open(OSM_REGISTER_URL, '_blank');
+
     setStep((s) => {
+
       return { ...s, number: 3 };
+
     });
+
   };
+
+
 
   const handleLogin = () => {
+
     login();
+
     setItem('email_address', data.email);
+
     setItem('name', data.name);
+
   };
 
+
+
   return (
+
     <div>
+
       <h1 className="pb2 ma0 barlow-condensed blue-dark">
+
         <span className="mr2">{step.number}.</span>
+
         <FormattedMessage {...messages.proceedOSMTitle} />
+
       </h1>
+
       <div className="mt4">
+
         <p className="blue-dark lh-copy">
+
           <FormattedMessage {...messages.proceedOSMPart1} />
+
         </p>
+
         <p className="blue-dark lh-copy">
+
           <FormattedMessage {...messages.proceedOSMPart2} />
+
         </p>
+
       </div>
+
       <div className="mt5 tr">
+
         <Button className="bg-red white" onClick={() => NextStep(setStep)}>
+
           <FormattedMessage {...messages.submitProceedOSM} />
+
         </Button>
+
         <p className="tr f6 link pointer red fw5" onClick={() => handleLogin()}>
+
           <FormattedMessage {...messages.proceedOSMLogin} />
+
         </p>
+
       </div>
+
     </div>
+
   );
+
 };
+
+
 
 const SignupForm = ({ data, setData, step, setStep }) => {
+
   const onChange = (e) => {
+
     setData({ ...data, [e.target.name]: e.target.value });
+
     if (step.errMessage) setStep({ ...step, errMessage: null });
+
   };
+
+
 
   const checkFields = () => {
+
     const re =
+
       // eslint-disable-next-line no-useless-escape
+
       /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
     if (re.test(data.email) === false) {
+
       setStep({ ...step, errMessage: <FormattedMessage {...messages.invalidEmail} /> });
+
       return;
+
     }
+
+
 
     const formData = {
+
       email: data.email,
+
     };
 
+
+
     const registerPromise = store.dispatch(registerUser(formData));
+
     registerPromise.then((res) => {
+
       if (res.success === true) {
+
         setItem('email_address', data.email);
+
         setItem('name', data.name);
+
         setStep({ number: 2, errMessage: null });
+
       } else {
+
         setStep({ number: 1, errMessage: res.details });
+
       }
+
     });
+
   };
 
+
+
   return (
+
     <div>
+
       <h1 className="pb2 ma0 barlow-condensed blue-dark">
+
         <span className="mr2">{step.number}.</span>
+
         <FormattedMessage {...messages.signUpTitle} />
+
       </h1>
+
       <p className="blue-dark lh-copy">
+
         <FormattedMessage {...messages.signUpQuestion} />
+
       </p>
+
       <div>
+
         <div>
+
           <p className="b f6">
+
             <FormattedMessage {...messages.signupLabelName} />
+
           </p>
+
           <FormattedMessage {...messages.namePlaceHolder}>
+
             {(msg) => {
+
               return (
+
                 <input
+
                   className="pa2 w-60-l w-100 f6"
+
                   type="text"
+
                   name="name"
+
                   placeholder={msg}
+
                   autoComplete="email"
+
                   onChange={onChange}
+
                   value={data.name}
+
                 />
+
               );
+
             }}
+
           </FormattedMessage>
-        </div>
-        <div>
-          <p className="b f6">
-            <FormattedMessage {...messages.signupLabelEmail} />
+
+          <p className="mt1 mb0 f6 blue-dark lh-copy">
+
+            <FormattedMessage {...messages.signupNameHelp} />
+
           </p>
-          <FormattedMessage {...messages.emailPlaceholder}>
-            {(msg) => {
-              return (
-                <input
-                  className="pa2 w-60-l w-100 f6"
-                  type="email"
-                  name="email"
-                  placeholder={msg}
-                  autoComplete="email"
-                  onChange={onChange}
-                  value={data.email}
-                />
-              );
-            }}
-          </FormattedMessage>
+
         </div>
+
+        <div>
+
+          <p className="b f6">
+
+            <FormattedMessage {...messages.signupLabelEmail} />
+
+          </p>
+
+          <FormattedMessage {...messages.emailPlaceholder}>
+
+            {(msg) => {
+
+              return (
+
+                <input
+
+                  className="pa2 w-60-l w-100 f6"
+
+                  type="email"
+
+                  name="email"
+
+                  placeholder={msg}
+
+                  autoComplete="email"
+
+                  onChange={onChange}
+
+                  value={data.email}
+
+                />
+
+              );
+
+            }}
+
+          </FormattedMessage>
+
+        </div>
+
         <p className={`h2 white f6 pa2 tc ${step.errMessage !== null ? 'bg-red' : null}`}>
+
           {step.errMessage}
+
         </p>
+
       </div>
+
       {ORG_PRIVACY_POLICY_URL && (
+
         <p className="mb0 f6">
+
           <a
+
             className="link pointer red fw5"
+
             target="_blank"
+
             rel="noopener noreferrer"
+
             href={`${ORG_PRIVACY_POLICY_URL}`}
+
           >
+
             <FormattedMessage {...messages.privacyPolicy} />
+
           </a>
+
         </p>
+
       )}
+
       <div className="mt3 tr">
+
         <Button
+
           className="bg-red white"
+
           onClick={() => checkFields()}
+
           disabled={step.errMessage !== null || !data.name || !data.email}
+
         >
+
           <FormattedMessage {...messages.submitProceed} />
+
         </Button>
+
       </div>
+
     </div>
+
   );
+
 };
 
+
+
 export const SignUp = ({ closeModal }) => {
+
   const [data, setData] = useState({ name: '', email: '' });
+
   const [step, setStep] = useState({ number: 1, errMessage: null });
 
+
+
   const login = () => {
+
     let redirect = '/welcome';
+
     if (window.location.pathname.startsWith('/projects')) {
+
       redirect = window.location.pathname;
+
     }
+
+
 
     closeModal();
+
     osmLoginRedirect(redirect);
+
   };
+
+
 
   const getStep = (step) => {
+
     switch (step.number) {
+
       case 2:
+
         return <ProceedOSM data={data} step={step} setStep={setStep} login={login} />;
+
       case 3:
+
         return <LoginModal step={step} login={login} />;
+
       default:
+
         return <SignupForm data={data} setData={setData} step={step} setStep={setStep} />;
+
     }
+
   };
 
+
+
   return (
+
     <div className="tl pa4 bg-white">
+
       <span className="fr relative blue-light pt1 link pointer" onClick={() => closeModal()}>
+
         <CloseIcon aria-label="Close popup" style={{ height: '18px', width: '18px' }} />
+
       </span>
+
       {getStep(step)}
+
     </div>
+
   );
+
 };


### PR DESCRIPTION
Users were confused that the signup 'Name' becomes their public username. This change mirrors the clearer OSM-style wording:
- Renames the field label 'Name' -> 'Display Name'
- Updates the placeholder to 'Your publicly visible name'
- Adds i18n help text explaining the name is publicly visible and can be changed later in preferences.

Scoped to i18n message strings (messages.js) and one help-text element in signUp.js, following the existing FormattedMessage pattern. No logic or backend changes.

Fixes #5208

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Example: Fixes #123

## Describe this PR

A brief description of how this solves the issue.

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Tasking Manager Contributing Guide: <https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.

## [optional] What gif best describes this PR or how it makes you feel?
