### PR TITLE
fix: use async sleep in message batching loop to avoid blocking the event loop

### DIFF
--- a/backend/services/messaging/message_service.py
+++ b/backend/services/messaging/message_service.py
@@ -1,6 +1,6 @@
+import asyncio
 import datetime
 import re
-import time
 from typing import List
 
 import bleach
@@ -238,7 +238,7 @@ class MessageService:
             )
 
             if (i + 1) % 10 == 0:
-                time.sleep(0.5)
+                await asyncio.sleep(0.5)
 
         if messages_objs:
             insert_values = [


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #7303

## Describe this PR

`MessageService`'s batch message-sending loop calls `time.sleep(0.5)` every 10 messages to throttle sends. Since this loop runs inside an async context, `time.sleep` blocks the entire event loop for the duration of the sleep, stalling all other concurrent requests being served by the process. This PR replaces it with `await asyncio.sleep(0.5)`, which yields control back to the event loop instead of blocking it.