### PR TITLE
feat: enrich team join requests CSV with mapper stats and profile links

### DIFF
--- a/backend/api/teams/resources.py
+++ b/backend/api/teams/resources.py
@@ -1,12 +1,14 @@
 import csv
 import io
 from datetime import datetime
+from urllib.parse import quote
 
 from databases import Database
 from fastapi import APIRouter, Body, Depends, Query, Request, Response
 from fastapi.responses import JSONResponse
 from loguru import logger
 
+from backend.config import settings
 from backend.db import get_db
 from backend.models.dtos.team_dto import NewTeamDTO, TeamSearchDTO, UpdateTeamDTO
 from backend.models.dtos.user_dto import AuthUserDTO
@@ -441,6 +443,82 @@ async def create_team(
         return JSONResponse(content={"Error": str(e)}, status_code=400)
 
 
+async def _get_task_stats_by_user(user_ids: list, db: Database) -> dict:
+    """Batches tasks-mapped/validated counts and time spent mapping for a
+    list of user ids into two grouped queries, rather than one query per user."""
+    counts_query = """
+        SELECT
+            user_id,
+            COUNT(DISTINCT (project_id, task_id))
+                FILTER (WHERE action_text = 'MAPPED') AS tasks_mapped,
+            COUNT(DISTINCT (project_id, task_id))
+                FILTER (WHERE action_text = 'VALIDATED') AS tasks_validated
+        FROM task_history
+        WHERE user_id = ANY(:user_ids) AND action_text IN ('MAPPED', 'VALIDATED')
+        GROUP BY user_id
+    """
+    time_query = """
+        SELECT
+            user_id,
+            SUM(
+                EXTRACT(EPOCH FROM to_timestamp(action_text, 'HH24:MI:SS') -
+                    to_timestamp('00:00:00', 'HH24:MI:SS'))
+            ) AS time_spent_mapping
+        FROM task_history
+        WHERE user_id = ANY(:user_ids)
+        AND action IN ('LOCKED_FOR_MAPPING', 'AUTO_UNLOCKED_FOR_MAPPING')
+        GROUP BY user_id
+    """
+    counts_rows = await db.fetch_all(counts_query, values={"user_ids": user_ids})
+    time_rows = await db.fetch_all(time_query, values={"user_ids": user_ids})
+
+    stats = {
+        row["user_id"]: {
+            "tasks_mapped": row["tasks_mapped"],
+            "tasks_validated": row["tasks_validated"],
+        }
+        for row in counts_rows
+    }
+    for row in time_rows:
+        stats.setdefault(row["user_id"], {})["time_spent_mapping"] = int(
+            row["time_spent_mapping"] or 0
+        )
+    return stats
+
+
+async def _get_other_teams_by_user(
+    user_ids: list, current_team_id: int, db: Database
+) -> dict:
+    """Returns, for each user id, a comma-separated list of other teams
+    they are already an active member of."""
+    query = """
+        SELECT
+            tm.user_id AS user_id,
+            STRING_AGG(t.name, ', ' ORDER BY t.name) AS other_teams
+        FROM team_members tm
+        INNER JOIN teams t ON tm.team_id = t.id
+        WHERE tm.user_id = ANY(:user_ids)
+        AND tm.active = TRUE
+        AND tm.team_id != :current_team_id
+        GROUP BY tm.user_id
+    """
+    rows = await db.fetch_all(
+        query, values={"user_ids": user_ids, "current_team_id": current_team_id}
+    )
+    return {row["user_id"]: row["other_teams"] for row in rows}
+
+
+def _username_hyperlink(username: str) -> str:
+    """Renders the username as a spreadsheet HYPERLINK formula pointing at the
+    candidate's TM profile, so the name is clickable straight from the CSV.
+    Quotes in either argument are doubled up, which is how a spreadsheet escapes
+    them inside a string literal, so an unusual username can't break out of the
+    formula."""
+    url = f"{settings.APP_BASE_URL}/users/{quote(username)}/"
+    label = username.replace('"', '""')
+    return f'=HYPERLINK("{url}","{label}")'
+
+
 @router.get("/join_requests/")
 async def get_join_requests(
     request: Request,
@@ -449,7 +527,9 @@ async def get_join_requests(
     user: AuthUserDTO = Depends(login_required),
 ):
     """
-    Downloads join requests for a specific team as a CSV.
+    Downloads join requests for a specific team as a CSV, including each
+    candidate's mapper level, task/time contributions and other team
+    memberships. The username is written as a link to their TM profile.
     ---
     tags:
         - teams
@@ -472,22 +552,27 @@ async def get_join_requests(
             description: Internal server error
     """
     try:
+        team_id = int(team_id)
         query = """
             SELECT
+                u.id AS user_id,
                 u.username AS username,
                 tm.joined_date AS joined_date,
-                t.name AS team_name
+                t.name AS team_name,
+                ml.name AS mapping_level
             FROM
                 team_members tm
             INNER JOIN
                 users u ON tm.user_id = u.id
             INNER JOIN
                 teams t ON tm.team_id = t.id
+            LEFT JOIN
+                mapping_levels ml ON u.mapping_level = ml.id
             WHERE
                 tm.team_id = :team_id
                 AND tm.active = FALSE
         """
-        team_members = await db.fetch_all(query=query, values={"team_id": int(team_id)})
+        team_members = await db.fetch_all(query=query, values={"team_id": team_id})
 
         if not team_members:
             return JSONResponse(
@@ -495,20 +580,42 @@ async def get_join_requests(
                 status_code=200,
             )
 
+        user_ids = [getattr(member, "user_id") for member in team_members]
+        task_stats = await _get_task_stats_by_user(user_ids, db)
+        other_teams = await _get_other_teams_by_user(user_ids, team_id, db)
+
         csv_output = io.StringIO()
         writer = csv.writer(csv_output)
-        writer.writerow(["Username", "Date Joined (UTC)", "Team Name"])
+        writer.writerow(
+            [
+                "Username",
+                "Date Joined (UTC)",
+                "Team Name",
+                "Mapper Level",
+                "Tasks Mapped",
+                "Tasks Validated",
+                "Time Spent Mapping (seconds)",
+                "Other Teams Joined",
+            ]
+        )
 
         for member in team_members:
+            member_user_id = getattr(member, "user_id")
             joined_date = getattr(member, "joined_date")
             joined_date_str = (
                 joined_date.strftime("%Y-%m-%dT%H:%M:%S") if joined_date else "N/A"
             )
+            stats = task_stats.get(member_user_id, {})
             writer.writerow(
                 [
-                    getattr(member, "username"),
+                    _username_hyperlink(getattr(member, "username")),
                     joined_date_str,
                     getattr(member, "team_name"),
+                    getattr(member, "mapping_level") or "N/A",
+                    stats.get("tasks_mapped", 0),
+                    stats.get("tasks_validated", 0),
+                    stats.get("time_spent_mapping", 0),
+                    other_teams.get(member_user_id, ""),
                 ]
             )
 

--- a/tests/api/integration/api/teams/test_resources.py
+++ b/tests/api/integration/api/teams/test_resources.py
@@ -1,17 +1,22 @@
 import base64
+import csv
+import io
 
 import pytest
 from httpx import AsyncClient
 
+from backend.config import settings
 from backend.services.users.authentication_service import AuthenticationService
-from backend.models.postgis.statuses import UserRole
+from backend.models.postgis.statuses import TeamMemberFunctions, UserRole
 
 from tests.api.helpers.test_helpers import (
+    add_user_to_team,
     create_canned_organisation,
-    create_canned_user,
-    return_canned_user,
+    create_canned_project,
     create_canned_team,
+    create_canned_user,
     return_canned_team,
+    return_canned_user,
 )
 
 from tests.api.integration.api.teams.test_actions import (
@@ -255,3 +260,135 @@ class TestTeamsAllAPI:
         resp = await client.get(self.endpoint_url)
         assert resp.status_code == 403
         assert resp.json() == {"detail": "Not authenticated"}
+
+
+@pytest.mark.anyio
+class TestTeamJoinRequestsCSV:
+    @pytest.fixture(autouse=True)
+    async def _setup(self, db_connection_fixture):
+        self.db = db_connection_fixture
+
+        self.test_org = await create_canned_organisation(self.db)
+
+        manager_result = await return_canned_user(
+            self.db, username="team manager", id=222222
+        )
+        self.test_manager = await create_canned_user(self.db, manager_result)
+        raw = AuthenticationService.generate_session_token_for_user(
+            self.test_manager.id
+        )
+        self.manager_token = (
+            f"Token {base64.b64encode(raw.encode('utf-8')).decode('utf-8')}"
+        )
+
+        self.test_team = await create_canned_team(self.db)
+        await add_user_to_team(
+            self.test_team,
+            self.test_manager,
+            TeamMemberFunctions.MANAGER.value,
+            True,
+            self.db,
+        )
+
+        candidate_result = await return_canned_user(
+            self.db, username="join candidate", id=333333
+        )
+        self.candidate = await create_canned_user(self.db, candidate_result)
+        # Mapping level 2 is seeded as INTERMEDIATE by the mapping_levels migration.
+        await self.db.execute(
+            "UPDATE users SET mapping_level = :level WHERE id = :id",
+            {"level": 2, "id": self.candidate.id},
+        )
+        await add_user_to_team(
+            self.test_team,
+            self.candidate,
+            TeamMemberFunctions.MEMBER.value,
+            False,
+            self.db,
+        )
+
+        self.endpoint_url = f"/api/v2/teams/join_requests/?team_id={self.test_team.id}"
+
+    async def test_join_requests_csv_returns_message_when_no_pending_requests(
+        self, client: AsyncClient
+    ):
+        empty_team = await create_canned_team(self.db)
+        resp = await client.get(
+            f"/api/v2/teams/join_requests/?team_id={empty_team.id}",
+            headers={"Authorization": self.manager_token},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "message": "No inactive members found for the specified team"
+        }
+
+    async def test_join_requests_csv_includes_mapper_level_and_stats(
+        self, client: AsyncClient
+    ):
+        other_team = await create_canned_team(
+            self.db, await return_canned_team(self.db, name="Other Team")
+        )
+        await add_user_to_team(
+            other_team, self.candidate, TeamMemberFunctions.MEMBER.value, True, self.db
+        )
+
+        _, _, project_id = await create_canned_project(self.db)
+        for action, action_text in (
+            ("STATE_CHANGE", "MAPPED"),
+            ("STATE_CHANGE", "VALIDATED"),
+            ("LOCKED_FOR_MAPPING", "00:05:00"),
+        ):
+            await self.db.execute(
+                """
+                INSERT INTO task_history
+                    (project_id, task_id, action, action_text, action_date, user_id)
+                VALUES
+                    (:project_id, 1, :action, :action_text, now(), :user_id)
+                """,
+                {
+                    "project_id": project_id,
+                    "action": action,
+                    "action_text": action_text,
+                    "user_id": self.candidate.id,
+                },
+            )
+
+        resp = await client.get(
+            self.endpoint_url, headers={"Authorization": self.manager_token}
+        )
+
+        assert resp.status_code == 200
+        rows = list(csv.reader(io.StringIO(resp.text)))
+        assert rows[0] == [
+            "Username",
+            "Date Joined (UTC)",
+            "Team Name",
+            "Mapper Level",
+            "Tasks Mapped",
+            "Tasks Validated",
+            "Time Spent Mapping (seconds)",
+            "Other Teams Joined",
+        ]
+        data_row = rows[1]
+        assert self.candidate.username in data_row[0]
+        assert data_row[2] == self.test_team.name
+        assert data_row[3] == "INTERMEDIATE"
+        assert data_row[4] == "1"  # tasks mapped
+        assert data_row[5] == "1"  # tasks validated
+        assert data_row[6] == "300"  # time spent mapping, in seconds
+        assert data_row[7] == other_team.name
+
+    async def test_join_requests_csv_links_username_to_profile(
+        self, client: AsyncClient
+    ):
+        resp = await client.get(
+            self.endpoint_url, headers={"Authorization": self.manager_token}
+        )
+        assert resp.status_code == 200
+        rows = list(csv.reader(io.StringIO(resp.text)))
+        # The username cell is a spreadsheet formula so the name is clickable
+        # from the downloaded CSV, with the username percent-encoded in the URL.
+        assert rows[1][0] == (
+            f'=HYPERLINK("{settings.APP_BASE_URL}/users/join%20candidate/",'
+            f'"{self.candidate.username}")'
+        )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #7308
Fixes #7307

## Describe this PR

The Teams → Join requests CSV export only carried Username, Date Joined and Team Name, which isn't enough for a manager to triage a join request without opening each candidate's profile by hand. This PR adds Mapper Level, Tasks Mapped, Tasks Validated, Time Spent Mapping (seconds) and Other Teams Joined, and writes the Username cell as a `=HYPERLINK(...)` formula pointing at `{APP_BASE_URL}/users/{username}/` so the candidate's name is clickable straight from the downloaded sheet.

Per-element counts (buildings / highways / POIs / waterways created, modified, deleted) from #7307 are deliberately **not** included — pulling them means an ohsome stats API call per candidate, which makes the export depend on an external service that can be slow or down. That's the conclusion already reached in the issue thread, and #7308 is the agreed alternative: those numbers are one click away on the user page via the new hyperlink, and the export stays a pure database read.

The two new stat groups are gathered in two batched queries keyed by the full list of candidate user IDs, so the added columns don't introduce a query per candidate. The username is percent-encoded in the URL (TM usernames commonly contain spaces) and quotes in the display name are doubled, so an unusual username can't break out of the formula string.