### PR TITLE
feat: add AI disclosure section to pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,12 @@ Did you attempt any other approaches that are not documented in code?
 
 Notes for the reviewer. How to test this change?
 
+## AI Disclosure
+
+- [ ] This PR was created with significant help from AI tools (e.g., Claude, Copilot, ChatGPT)
+
+If checked, briefly describe what AI assisted with (e.g., code generation, refactoring, tests, documentation) and confirm you have reviewed and understood the changes.
+
 ## Checklist before requesting a review
 
 - 📖 Read the Tasking Manager Contributing Guide: <https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing.md>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

N/A

## Describe this PR

Adds an "AI Disclosure" section to the PR template so contributors can flag when a PR was created with significant help from AI tools (e.g., Claude, Copilot, ChatGPT), and briefly describe what the AI assisted with. This gives reviewers useful context up front without blocking or gating the PR process.

## Screenshots

N/A (template change only)

## Alternative Approaches Considered

Considered folding this into the existing "Checklist before requesting a review" section, but gave it its own section instead since it's a disclosure rather than a task to complete, and needed room for an optional free-text description.

## Review Guide

Review the updated `.github/pull_request_template.md`. To see it in context, open a new PR against this repo and confirm the new "AI Disclosure" section renders correctly between "Review Guide" and "Checklist before requesting a review".
