### PR TITLE
fix: use TAG_OVERRIDE for backend image tag in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - tm-net
 
   tm-backend:
-    image: ghcr.io/hotosm/tasking-manager/backend:main
+    image: ghcr.io/hotosm/tasking-manager/backend:${TAG_OVERRIDE:-main}
     build:
       context: .
       target: ${TARGET_TAG:-debug}
@@ -71,7 +71,7 @@ services:
       - tm-net
 
   tm-migration:
-    image: ghcr.io/hotosm/tasking-manager/backend:main
+    image: ghcr.io/hotosm/tasking-manager/backend:${TAG_OVERRIDE:-main}
     build:
       context: .
       target: ${TARGET_TAG:-debug}
@@ -101,7 +101,7 @@ services:
       - tm-net
 
   tm-cron-jobs:
-    image: ghcr.io/hotosm/tasking-manager/backend:main
+    image: ghcr.io/hotosm/tasking-manager/backend:${TAG_OVERRIDE:-main}
     build:
       context: .
       target: ${TARGET_TAG:-debug}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix
- [x] 🤖 Build or CI

## Related Issue

Fixes `tm-migration` failing at the end of `pytest-unit` / `pytest-integration` CI, on this branch and others.

## Describe this PR

`docker-compose.yml` hardcoded `image: ghcr.io/hotosm/tasking-manager/backend:main` for `tm-backend`, `tm-migration`, `tm-cron-jobs`. CI already builds a fresh image per run and exports its tag as `TAG_OVERRIDE`, but the compose file never referenced it, so CI always pulled the stale, currently-published `:main` image instead.

That `:main` image predates the packages only added in the develop like in current case `pg_nearest_city` dependency  which is not merged to `main` yet from `develop`. Source is bind-mounted fresh, but installed packages aren't, so `alembic upgrade head` crashed with `ModuleNotFoundError: No module named 'pg_nearest_city'` (via `env.py` → `backend/models/postgis/project.py`) before touching the database. Since that traceback is never printed by the CI workflow, it just showed as a generic `tm-migration exit 1`.

## Fix 
reference `${TAG_OVERRIDE:-main}` instead of a hardcoded `main`, so CI actually uses the image it just built. Local `docker compose up` is unaffected still defaults to `:main`.

## Review Guide

1. Check `docker-compose.yml` no longer hardcodes `:main` for the three backend services.
2. Confirm local `docker compose up` with no `TAG_OVERRIDE` set still resolves to `:main`.
3. Re-run CI on a previously-failing branch and confirm `tm-migration` completes successfully.