### PR TITLE
Add task hover tooltip and loading/error states to the invalidation heatmap

### DIFF
--- a/frontend/src/components/taskSelection/index.js
+++ b/frontend/src/components/taskSelection/index.js
@@ -104,7 +104,11 @@ export function TaskSelection({ project }: Object) {
     isLoadingError: isPriorityAreasLoadingError,
   } = usePriorityAreasQuery(projectId);
 
-  const { data: invalidatedTasksData } = useInvalidatedTasksQuery(projectId, {
+  const {
+    data: invalidatedTasksData,
+    isInitialLoading: isInvalidatedTasksLoading,
+    isLoadingError: isInvalidatedTasksLoadingError,
+  } = useInvalidatedTasksQuery(projectId, {
     enabled: showChoropleth,
     // No staleTime — data is immediately stale so React Query refetches on
     // every window focus or remount. This ensures if a user invalidates a task
@@ -123,6 +127,11 @@ export function TaskSelection({ project }: Object) {
     isPriorityAreasLoadingError &&
       toast.error(<FormattedMessage {...messages.priorityAreasLoadingError} />);
   }, [isPriorityAreasLoadingError]);
+
+  useEffect(() => {
+    isInvalidatedTasksLoadingError &&
+      toast.error(<FormattedMessage {...messages.invalidatedTasksLoadingError} />);
+  }, [isInvalidatedTasksLoadingError]);
 
   // Fetch fresh task geometry on mount. With the cache kept, the stale grid paints
   // immediately (no white screen) while this refetch silently refreshes it.
@@ -389,6 +398,8 @@ export function TaskSelection({ project }: Object) {
                 animateZoom={false}
                 showChoropleth={showChoropleth}
                 invalidatedTasksData={invalidatedTasksData}
+                isChoroplethLoading={isInvalidatedTasksLoading}
+                showHoverTooltip
                 onToggleChoropleth={() => setShowChoropleth((v) => !v)}
               />
               <TasksMapLegend showChoropleth={showChoropleth} />

--- a/frontend/src/components/taskSelection/map.js
+++ b/frontend/src/components/taskSelection/map.js
@@ -1,11 +1,11 @@
-import { createRef, useLayoutEffect, useState, useRef } from 'react';
+import { createRef, useLayoutEffect, useMemo, useState, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import bbox from '@turf/bbox';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { NineCellsGridIcon } from '../svgIcons';
+import { NineCellsGridIcon, LoadingIcon } from '../svgIcons';
 
 import WebglUnsupported from '../webglUnsupported';
 import isWebglSupported from '../../utils/isWebglSupported';
@@ -37,12 +37,25 @@ export const TasksMap = ({
   selected: selectedOnMap,
   invalidatedTasksData,
   showChoropleth = false,
+  isChoroplethLoading = false,
+  showHoverTooltip = false,
   onToggleChoropleth,
 }) => {
   const intl = useIntl();
   const mapRef = createRef();
   const authDetails = useSelector((state) => state.auth.userDetails);
   const [hoveredTaskId, setHoveredTaskId] = useState(null);
+
+  // taskId -> invalidation count, shared by the choropleth layer and its hover tooltip
+  const invalidationCountMap = useMemo(() => {
+    const countMap = {};
+    (invalidatedTasksData || []).forEach(({ taskId, invalidatedCount }) => {
+      countMap[taskId] = invalidatedCount;
+    });
+    return countMap;
+  }, [invalidatedTasksData]);
+  // Distinguishes "counts haven't loaded yet" from "every task has zero invalidations"
+  const hasInvalidationData = Array.isArray(invalidatedTasksData);
 
   const [map, setMapObj] = useState(null);
   const lastZoomedIdRef = useRef(null);
@@ -349,29 +362,15 @@ export const TasksMap = ({
           'point-tasks-centroid-inner',
         );
       }
-      const popup = new maplibregl.Popup({
-        closeButton: false,
-        closeOnClick: false,
-        offset: {
-          top: [-10, 0],
-          bottom: [0, -10],
-          left: [0, -10],
-          right: [-10, 0],
-        },
-      })
-        .setHTML(`${intl.formatMessage(messages.cantValidateMappedTask)}`)
-        .trackPointer();
-
       map.on('mousemove', 'tasks-fill', function (e) {
         // To now allow validators to select tasks that they mapped
         if (
-          e.features[0].properties.mappedBy === authDetails.id &&
-          e.features[0].properties.taskStatus === 'MAPPED'
+          !(
+            e.features[0].properties.mappedBy === authDetails.id &&
+            e.features[0].properties.taskStatus === 'MAPPED'
+          )
         ) {
-          popup.addTo(map);
-        } else {
           map.getCanvas().style.cursor = 'pointer';
-          popup.isOpen() && popup.remove();
         }
         if (showTaskIds) {
           // when the user hover on a task they are validating, enable the task id dialog
@@ -407,13 +406,6 @@ export const TasksMap = ({
         map.getCanvas().style.cursor = '';
         // disable the task id dialog when the mouse go outside the task grid
         showTaskIds && setHoveredTaskId(null);
-        popup.isOpen() && popup.remove();
-
-        // Cursor style won't change to original state with trackPointer()
-        // https://github.com/mapbox/mapbox-gl-js/issues/12223
-        if (map._canvasContainer) {
-          map._canvasContainer.classList.remove('maplibregl-track-pointer');
-        }
       });
       updateTMZoom();
     };
@@ -515,18 +507,14 @@ export const TasksMap = ({
     const CHOROPLETH_LAYER = 'tasks-invalidation-fill';
 
     const buildChoroplethGeoJSON = () => {
-      if (!mapResults || !invalidatedTasksData) return null;
-      const countMap = {};
-      invalidatedTasksData.forEach(({ taskId, invalidatedCount }) => {
-        countMap[taskId] = invalidatedCount;
-      });
+      if (!mapResults || !hasInvalidationData) return null;
       return {
         type: 'FeatureCollection',
         features: mapResults.features.map((f) => ({
           ...f,
           properties: {
             ...f.properties,
-            invalidatedCount: countMap[f.properties.taskId] || 0,
+            invalidatedCount: invalidationCountMap[f.properties.taskId] || 0,
           },
         })),
       };
@@ -544,7 +532,7 @@ export const TasksMap = ({
       return;
     }
 
-    if (!invalidatedTasksData || !mapResults?.features?.length) return;
+    if (!hasInvalidationData || !mapResults?.features?.length) return;
 
     const geojson = buildChoroplethGeoJSON();
     if (!geojson) return;
@@ -573,11 +561,17 @@ export const TasksMap = ({
           source: CHOROPLETH_SOURCE,
           paint: {
             'fill-color': [
-              'interpolate', ['linear'], ['get', 'invalidatedCount'],
-              0, '#f9fafb',   // never invalidated: near-white
-              1, '#fde68a',   // once: light amber
-              3, '#f97316',   // moderate: orange
-              6, '#b91c1c',   // high: deep red
+              'interpolate',
+              ['linear'],
+              ['get', 'invalidatedCount'],
+              0,
+              '#f9fafb', // never invalidated: near-white
+              1,
+              '#fde68a', // once: light amber
+              3,
+              '#f97316', // moderate: orange
+              6,
+              '#b91c1c', // high: deep red
             ],
             'fill-opacity': 1,
           },
@@ -617,7 +611,139 @@ export const TasksMap = ({
       map.on('idle', onIdle);
       return () => map.off('idle', onIdle);
     }
-  }, [map, showChoropleth, invalidatedTasksData, mapResults]);
+  }, [map, showChoropleth, hasInvalidationData, invalidationCountMap, mapResults]);
+
+  /* ------------------------------------------------------------------
+   * Task hover: outline the hovered task and show a pointer-following
+   * tooltip with its id and status. While the choropleth is on, the
+   * tooltip also carries the task's invalidation count.
+   * ------------------------------------------------------------------ */
+  useLayoutEffect(() => {
+    if (!map || !showHoverTooltip) return;
+
+    const HOVER_LAYER = 'hovered-task-border';
+
+    const popup = new maplibregl.Popup({
+      closeButton: false,
+      closeOnClick: false,
+      offset: {
+        top: [-12, 0],
+        bottom: [0, -12],
+        left: [0, -12],
+        right: [-12, 0],
+      },
+    }).trackPointer();
+
+    let lastTaskId = null;
+
+    const buildPopupHTML = ({ taskId, taskStatus, mappedBy }) => {
+      const lines = [
+        `<div class="fw6">${intl.formatMessage(messages.taskId, { id: taskId })}</div>`,
+      ];
+      const statusMessage = messages[`taskStatus_${taskStatus}`];
+      if (statusMessage) {
+        lines.push(`<div>${intl.formatMessage(statusMessage)}</div>`);
+      }
+      if (showChoropleth && hasInvalidationData) {
+        lines.push(
+          `<div>${intl.formatMessage(messages.invalidationCountTooltip, {
+            count: invalidationCountMap[taskId] || 0,
+          })}</div>`,
+        );
+      }
+      // Validators can't select tasks they mapped themselves, so warn on hover
+      if (mappedBy === authDetails.id && taskStatus === 'MAPPED') {
+        lines.push(`<div class="red">${intl.formatMessage(messages.cantValidateMappedTask)}</div>`);
+      }
+      return `<div class="base-font f6 dark-gray">${lines.join('')}</div>`;
+    };
+
+    const highlightTask = (taskId) => {
+      if (!map.getLayer(HOVER_LAYER)) return;
+      map.setFilter(
+        HOVER_LAYER,
+        taskId === null ? ['in', 'taskId', ''] : ['==', ['get', 'taskId'], taskId],
+      );
+    };
+
+    const onMouseMove = (e) => {
+      const properties = e.features?.[0]?.properties;
+      if (!properties || properties.taskId === undefined || properties.taskId === null) return;
+      // Only rebuild the tooltip and the highlight when the hovered task changes
+      if (properties.taskId !== lastTaskId) {
+        lastTaskId = properties.taskId;
+        popup.setHTML(buildPopupHTML(properties));
+        highlightTask(properties.taskId);
+      }
+      if (!popup.isOpen()) popup.addTo(map);
+    };
+
+    const onMouseLeave = () => {
+      lastTaskId = null;
+      popup.remove();
+      highlightTask(null);
+
+      // Cursor style won't change to original state with trackPointer()
+      // https://github.com/mapbox/mapbox-gl-js/issues/12223
+      if (map._canvasContainer) {
+        map._canvasContainer.classList.remove('maplibregl-track-pointer');
+      }
+    };
+
+    const setup = () => {
+      if (!map.getLayer(HOVER_LAYER)) {
+        map.addLayer({
+          id: HOVER_LAYER,
+          type: 'line',
+          source: 'tasks',
+          paint: {
+            'line-color': '#2c3038',
+            'line-width': 3,
+          },
+          filter: ['in', 'taskId', ''],
+        });
+      }
+      map.on('mousemove', 'tasks-fill', onMouseMove);
+      map.on('mouseleave', 'tasks-fill', onMouseLeave);
+    };
+
+    const teardown = () => {
+      map.off('mousemove', 'tasks-fill', onMouseMove);
+      map.off('mouseleave', 'tasks-fill', onMouseLeave);
+      popup.remove();
+      if (map.getLayer(HOVER_LAYER)) map.removeLayer(HOVER_LAYER);
+    };
+
+    // Wait for the tasks layer to exist before binding, otherwise MapLibre logs
+    // errors when the delegated listener queries a layer that isn't there yet.
+    if (map.getLayer('tasks-fill')) {
+      setup();
+      return teardown;
+    }
+
+    const onIdle = () => {
+      if (!map.getLayer('tasks-fill')) return;
+      map.off('idle', onIdle);
+      setup();
+    };
+    map.on('idle', onIdle);
+    return () => {
+      map.off('idle', onIdle);
+      teardown();
+    };
+  }, [
+    map,
+    showHoverTooltip,
+    showChoropleth,
+    hasInvalidationData,
+    invalidationCountMap,
+    authDetails.id,
+    intl,
+  ]);
+
+  let choroplethToggleMessage = messages.invalidationChoroplethToggle;
+  if (showChoropleth) choroplethToggleMessage = messages.invalidationChoroplethToggleOff;
+  if (isChoroplethLoading) choroplethToggleMessage = messages.invalidationChoroplethLoading;
 
   if (!isWebglSupported()) {
     return <WebglUnsupported className={`w-100 h-100 fr ${className || ''}`} />;
@@ -635,10 +761,11 @@ export const TasksMap = ({
           <button
             id="invalidation-choropleth-toggle"
             onClick={onToggleChoropleth}
-            title={showChoropleth ? 'Hide invalidation heatmap' : 'Show invalidation heatmap'}
+            title={intl.formatMessage(choroplethToggleMessage)}
+            aria-busy={isChoroplethLoading}
             style={{
               position: 'absolute',
-              top: 103,   // 10px margin + 58px zoom cluster + 29px compass + 6px gap
+              top: 103, // 10px margin + 58px zoom cluster + 29px compass + 6px gap
               right: 10,
               zIndex: 5,
               width: 29,
@@ -656,14 +783,18 @@ export const TasksMap = ({
               transition: 'background 0.15s',
             }}
           >
-            <NineCellsGridIcon
-              style={{
-                width: 15,
-                height: 15,
-                fill: showChoropleth ? '#d73f3f' : '#404040',
-                transition: 'fill 0.15s',
-              }}
-            />
+            {isChoroplethLoading ? (
+              <LoadingIcon className="red h1 w1" style={{ animation: 'spin 1s linear infinite' }} />
+            ) : (
+              <NineCellsGridIcon
+                style={{
+                  width: 15,
+                  height: 15,
+                  fill: showChoropleth ? '#d73f3f' : '#404040',
+                  transition: 'fill 0.15s',
+                }}
+              />
+            )}
           </button>
         )}
 

--- a/frontend/src/components/taskSelection/messages.js
+++ b/frontend/src/components/taskSelection/messages.js
@@ -934,6 +934,18 @@ export default defineMessages({
     id: 'project.tasks.map.invalidationChoropleth.toggle',
     defaultMessage: 'Show invalidation heatmap',
   },
+  invalidationChoroplethToggleOff: {
+    id: 'project.tasks.map.invalidationChoropleth.toggle.off',
+    defaultMessage: 'Hide invalidation heatmap',
+  },
+  invalidationChoroplethLoading: {
+    id: 'project.tasks.map.invalidationChoropleth.loading',
+    defaultMessage: 'Loading invalidation data...',
+  },
+  invalidatedTasksLoadingError: {
+    id: 'project.tasks.map.invalidationChoropleth.loading.error',
+    defaultMessage: 'An error occured while loading the invalidation counts for the project',
+  },
   invalidationChoroplethLegendTitle: {
     id: 'project.tasks.map.invalidationChoropleth.legend.title',
     defaultMessage: 'Invalidation count',
@@ -953,6 +965,11 @@ export default defineMessages({
   invalidationChoroplethHigh: {
     id: 'project.tasks.map.invalidationChoropleth.legend.high',
     defaultMessage: '6+ times',
+  },
+  invalidationCountTooltip: {
+    id: 'project.tasks.map.invalidationChoropleth.tooltip.count',
+    defaultMessage:
+      '{count, plural, =0 {Never invalidated} one {Invalidated # time} other {Invalidated # times}}',
   },
   invalidationChoroplethRampHint: {
     id: 'project.tasks.map.invalidationChoropleth.legend.rampHint',

--- a/frontend/src/components/taskSelection/tests/map.test.js
+++ b/frontend/src/components/taskSelection/tests/map.test.js
@@ -1,26 +1,113 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
 import { ReduxIntlProviders } from '../../../utils/testWithIntl';
+import maplibregl from 'maplibre-gl';
+
 import { TasksMap } from '../map';
+import isWebglSupported from '../../../utils/isWebglSupported';
 
-jest.mock('maplibre-gl/dist/maplibre-gl', () => ({
-  supported: jest.fn(),
-  Map: jest.fn(() => ({
-    addControl: jest.fn(),
+jest.mock('../../../utils/isWebglSupported');
+
+// setupTests.js already mocks the module `maplibre-gl` resolves to, and imports it
+// before this file runs, so its instance is cached. Augment that shared object with
+// the extra surface map.js needs rather than re-registering a competing mock. The
+// assignments have to run per-test because CRA's jest preset sets `resetMocks: true`,
+// which strips the implementations between tests.
+const createMapMock = () => {
+  const map = {
+    addControl: jest.fn(() => map),
     on: jest.fn(),
+    off: jest.fn(),
+    once: jest.fn(),
     remove: jest.fn(),
-  })),
-}));
+    addLayer: jest.fn(),
+    addSource: jest.fn(),
+    getLayer: jest.fn(),
+    getSource: jest.fn(),
+    setFilter: jest.fn(),
+    setPaintProperty: jest.fn(),
+    setLayoutProperty: jest.fn(),
+    isStyleLoaded: jest.fn(() => false),
+    getCanvas: jest.fn(() => ({ style: {} })),
+    fitBounds: jest.fn(),
+    scrollZoom: { enable: jest.fn(), disable: jest.fn() },
+  };
+  return map;
+};
 
-test('displays WebGL not supported message', () => {
+beforeEach(() => {
+  maplibregl.Map = jest.fn(() => createMapMock());
+  maplibregl.AttributionControl = jest.fn();
+  maplibregl.NavigationControl = jest.fn();
+  maplibregl.setRTLTextPlugin = jest.fn();
+  maplibregl.Popup = jest.fn(() => ({
+    trackPointer: jest.fn().mockReturnThis(),
+    setHTML: jest.fn().mockReturnThis(),
+    addTo: jest.fn().mockReturnThis(),
+    remove: jest.fn(),
+    isOpen: jest.fn(() => false),
+  }));
+});
+
+const renderMap = (props = {}) =>
   render(
     <ReduxIntlProviders>
-      <TasksMap state={{ mapResults: null }} />
+      <TasksMap mapResults={null} onToggleChoropleth={jest.fn()} {...props} />
     </ReduxIntlProviders>,
   );
-  expect(
-    screen.getByRole('heading', {
-      name: 'WebGL Context Not Found',
-    }),
-  ).toBeInTheDocument();
+
+describe('TasksMap', () => {
+  it('displays WebGL not supported message', () => {
+    isWebglSupported.mockReturnValue(false);
+    render(
+      <ReduxIntlProviders>
+        <TasksMap state={{ mapResults: null }} />
+      </ReduxIntlProviders>,
+    );
+    expect(
+      screen.getByRole('heading', {
+        name: 'WebGL Context Not Found',
+      }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('TasksMap invalidation choropleth toggle', () => {
+  beforeEach(() => {
+    isWebglSupported.mockReturnValue(true);
+  });
+
+  it('is not rendered when no toggle handler is supplied', () => {
+    renderMap({ onToggleChoropleth: undefined });
+    expect(screen.queryByTitle('Show invalidation heatmap')).not.toBeInTheDocument();
+  });
+
+  it('offers to show the heatmap while it is hidden', () => {
+    renderMap({ showChoropleth: false });
+    const toggle = screen.getByTitle('Show invalidation heatmap');
+    expect(toggle).toHaveAttribute('aria-busy', 'false');
+  });
+
+  it('offers to hide the heatmap while it is shown', () => {
+    renderMap({ showChoropleth: true });
+    expect(screen.getByTitle('Hide invalidation heatmap')).toBeInTheDocument();
+    expect(screen.queryByTitle('Show invalidation heatmap')).not.toBeInTheDocument();
+  });
+
+  it('reports the loading state while the counts are being fetched', () => {
+    renderMap({ showChoropleth: true, isChoroplethLoading: true });
+    const toggle = screen.getByTitle('Loading invalidation data...');
+    expect(toggle).toHaveAttribute('aria-busy', 'true');
+    expect(screen.queryByTitle('Hide invalidation heatmap')).not.toBeInTheDocument();
+  });
+
+  it('calls the toggle handler when clicked', async () => {
+    const user = userEvent.setup();
+    const onToggleChoropleth = jest.fn();
+    renderMap({ onToggleChoropleth });
+    await user.click(screen.getByTitle('Show invalidation heatmap'));
+    expect(onToggleChoropleth).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Follow-up to #7112.

## Describe this PR

This PR adds a hover tooltip to the task selection map showing the task id, its status, and,  when the heatmap is on  its invalidation count. The hovered task also gets an outline so it's clear which one the tooltip refers to. 

On the loading side, the toggle button now shows a spinner with `aria-busy` while the counts are being fetched, and a failed fetch raises a toast instead of failing silently. The button's tooltip text was a hardcoded English string; it now goes through react-intl like everything else.

The tooltip is opt-in via a new `showHoverTooltip` prop and only the task selection map passes it, so the other four `TasksMap` call sites are unchanged.

## Screenshots
[Screencast from 2026-08-19 16-51-51.webm](https://github.com/user-attachments/assets/e68a70ee-180c-4869-b611-9db3046190dc)
