### PR TITLE
fix: recover polygon area from GeometryCollection intersections in grid trim

### DIFF
--- a/backend/services/grid/grid_service.py
+++ b/backend/services/grid/grid_service.py
@@ -46,11 +46,23 @@ class GridService:
                 intersecting_features.append(feature)
             else:
                 intersection = aoi_multi_polygon.intersection(tile)
-                if intersection.is_empty or intersection.geom_type not in [
-                    "Polygon",
-                    "MultiPolygon",
-                ]:
-                    continue  # this intersections which are not polygons or which are completely outside aoi
+                if intersection.is_empty:
+                    continue  # tile is completely outside aoi
+                if intersection.geom_type == "GeometryCollection":
+                    # A tile touching the AOI boundary can intersect into a mix of
+                    # geometry types (e.g. a real polygon slice plus stray points/
+                    # lines from the boundary touch). Recover the polygon area
+                    # instead of discarding the whole tile.
+                    polygonal_parts = [
+                        geom
+                        for geom in intersection.geoms
+                        if geom.geom_type in ("Polygon", "MultiPolygon")
+                    ]
+                    if not polygonal_parts:
+                        continue  # no actual area in the intersection, nothing to keep
+                    intersection = unary_union(polygonal_parts)
+                elif intersection.geom_type not in ["Polygon", "MultiPolygon"]:
+                    continue  # intersection is a bare LineString/Point, no area
                 # tile is partially intersecting the aoi
                 clipped_feature = GridService._update_feature(
                     clip_to_aoi, feature, intersection


### PR DESCRIPTION
## Summary

Fixes #6638.

`GridService.trim_grid_to_aoi()` (`backend/services/grid/grid_service.py`) drops a partially-overlapping tile entirely whenever its intersection with the AOI comes back as anything other than a bare `Polygon`/`MultiPolygon`. A tile touching the AOI boundary can intersect into a `GeometryCollection` containing a real polygon slice *plus* stray `Point`/`LineString` artifacts from the boundary touch — the old code discarded the whole tile in that case, losing real area and leaving gaps in task coverage, matching exactly what's reported in the issue.

@prabinoid already diagnosed this in the issue thread — this PR implements the fix they identified: for a `GeometryCollection` result, filter `.geoms` for just the `Polygon`/`MultiPolygon` members and `unary_union` them back into a single shape to keep using. If none of the sub-geometries carry any area (a pure boundary touch), the tile is still correctly skipped, same as before.

## Test plan

- [x] Constructed a real reproduction with Shapely: two AOI polygons (one overlapping the tile's interior, one only touching its edge) unioned together actually produce a `GeometryCollection([Polygon, LineString])` intersection with the tile — confirmed the **old** logic drops the tile despite 1.0 unit of real overlap area, and the **new** logic recovers it correctly.
- [x] Verified the "no polygon in the collection" (pure boundary touch, e.g. a bare `LineString`) and "genuinely no overlap" (`is_empty`) paths still correctly skip the tile, unchanged from before.
- [ ] Couldn't run the existing `tests/backend/unit/services/grid/test_grid_service.py` suite locally — importing the `backend` package pulls in its full dependency tree (mail clients etc.) well beyond what this module needs, and `BaseTestCase` additionally requires a live Postgres instance, neither available in my environment. The verification above exercises the exact Shapely operations this change makes; deferring the full suite to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)