### PR TITLE
feat: accept closed LineStrings as AOI outlines on import

### DIFF
--- a/backend/services/grid/grid_service.py
+++ b/backend/services/grid/grid_service.py
@@ -179,12 +179,20 @@ class GridService:
         :param feature: geojson.feature to be adapted
         :return: feature with geometry adapted
         """
-        if isinstance(
-            feature.geometry, (geojson.geometry.Polygon, geojson.geometry.MultiPolygon)
-        ):
+        geometry = feature.geometry
+        if isinstance(geometry, geojson.geometry.LineString):
+            # A closed LineString (first/last coordinate match, at least 4
+            # points) is unambiguously a polygon outline. Tools like
+            # geojson.io convert a closed .osm way to a LineString rather
+            # than a Polygon, which otherwise gets rejected outright.
+            coordinates = geometry["coordinates"]
+            if len(coordinates) >= 4 and coordinates[0] == coordinates[-1]:
+                geometry = geojson.geometry.Polygon([coordinates])
+
+        if isinstance(geometry, (geojson.geometry.Polygon, geojson.geometry.MultiPolygon)):
             # adapt the geometry for use as a shapely geometry
             # http://toblerity.org/shapely/manual.html#shapely.geometry.asShape
-            feature.geometry = shapely.geometry.shape(feature.geometry)
+            feature.geometry = shapely.geometry.shape(geometry)
             return feature
         else:
             return None

--- a/backend/services/grid/grid_service.py
+++ b/backend/services/grid/grid_service.py
@@ -189,7 +189,9 @@ class GridService:
             if len(coordinates) >= 4 and coordinates[0] == coordinates[-1]:
                 geometry = geojson.geometry.Polygon([coordinates])
 
-        if isinstance(geometry, (geojson.geometry.Polygon, geojson.geometry.MultiPolygon)):
+        if isinstance(
+            geometry, (geojson.geometry.Polygon, geojson.geometry.MultiPolygon)
+        ):
             # adapt the geometry for use as a shapely geometry
             # http://toblerity.org/shapely/manual.html#shapely.geometry.asShape
             feature.geometry = shapely.geometry.shape(geometry)


### PR DESCRIPTION
## Summary

Fixes #2285.

`GridService._adapt_feature_geometry()` (`backend/services/grid/grid_service.py`) only accepted `Polygon`/`MultiPolygon` geometries, silently dropping (returning `None`) anything else — including `LineString`s. This meant a closed area imported as a `LineString` (exactly what tools like geojson.io produce when converting a closed `.osm` way to GeoJSON) got rejected outright with `"The AOI contains geometries which are not polygons or multipolygons"`, even though it's unambiguously a valid area outline.

Now, a `LineString` whose first and last coordinates match (a closed ring) and has at least 4 points is converted into a `Polygon` using the same coordinates before the existing `Polygon`/`MultiPolygon` check runs. An open `LineString` (a real path, not a boundary) is still rejected, same as before — only genuinely closed rings get converted.

## Test plan

- [x] Verified against 4 cases directly: closed `LineString` → now converted and accepted as a `Polygon`; open `LineString` → still correctly rejected; existing `Polygon` input → unchanged; a degenerate 3-point "closed" ring (below the 4-point minimum) → still correctly rejected.
- [ ] Couldn't import `GridService` in isolation to run it against the real class — importing the `backend` package pulls in its full dependency tree beyond what this static method needs, same situation noted in #7319. The verification above exercises the exact logic added; deferring to CI for the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)