### PR TITLE
fix: force right-hand-rule winding on AOI geometry

### DIFF
--- a/backend/models/postgis/project.py
+++ b/backend/models/postgis/project.py
@@ -300,8 +300,10 @@ class Project(Base):
 
         query = """
         SELECT ST_AsEWKT(
-            ST_SetSRID(
-                ST_GeomFromGeoJSON(:geojson), 4326
+            ST_ForceRHR(
+                ST_SetSRID(
+                    ST_GeomFromGeoJSON(:geojson), 4326
+                )
             )
         ) AS geometry_wkt;
         """


### PR DESCRIPTION
Related to #4225.
Assisted-by: Claude

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Related to #4225

## Describe this PR

I investigated this issue in Jupyter Notebook trying to reproduce the results given in Shapely. From the gist linked to the issue, I tested it out in Shapely to see if it still worked. What I discovered was it parses fine in Shapely (is_valid: True), but the exterior ring is still wound clockwise instead of counter-clockwise. This is in violation of the right hand rule convention which states the ring around a polygon must be viewed counter-clockwise and a ring (such as a lake) inside the polygon should go clockwise. 

What I cannot confirm, without access to the original Sentry logs, is exactly which part of the processing chain triggers the actual reported error ('Polygon' object does not support indexing). What I can confirm directly was the winding-order anomaly @spwoodcock flagged was real and still present in this data. I applied ST_ForceRHR() which is a low risk normalization that removes said anomaly regardless if that is the cause of the original crash.

Following the fix @spwoodcock proposed which was to wrap the geometry with ST_ForceRHR() before it is actually stored, forcing the correct winding order. The code has been refactored since his original sketch with parameterized SQL instead of SQLAlchemy function objects. This means that no wrapper function is needed in utils.py, I just added it directly to the existing query.
Testing : I could not run the actual ST_ForceRHR PostGIS function directly because I have no live database available to me. What I did try was DuckDB's spatial extension first since I already had that locally installed in Jupyter. Turns out that did not work because DuckDB does not implement ST_ForceRHR. My next step was to try it in shapely.geometry.polygon.orient and confirmed it flips the geometry's exterior ring from clockwise to counter-clockwise, which matches what ST_ForceRHR does in PostGIS. Here is my screenshot of what I produced in Jupyter Notebook:

## Screenshots

<img width="930" height="752" alt="Screenshot 2026-08-22 at 11 54 02 PM" src="https://github.com/user-attachments/assets/cf6a8ad1-1b97-4bcc-a3e8-b2dea91cbfad" />

<img width="935" height="654" alt="Screenshot 2026-08-22 at 11 55 19 PM" src="https://github.com/user-attachments/assets/802f63d6-7956-45c9-8051-24d976fc7c08" />

<img width="942" height="177" alt="Screenshot 2026-08-22 at 11 55 38 PM" src="https://github.com/user-attachments/assets/a458ad27-2da8-403b-927e-a73cca15f106" />


## Alternative Approaches Considered

Tried DuckDB's spatial extension first, since I had it available locally. I confirmed it doesn't implement ST_ForceRHR (real error, not an assumption — see screenshot 2). Fell back to Shapely's orient() as a proxy verification of the winding-order fix, since I don't have a live PostGIS instance to test the actual function directly.

## Review Guide

No live database available to me to test ST_ForceRHR() directly against real PostGIS. The change itself is a single added SQL function wrapper — reviewer testing against a real DB with the failing geometry from the linked gist would be the strongest confirmation.

## AI Disclosure

- [x] This PR was created with significant help from AI tools (e.g., Claude, Copilot, ChatGPT)

If checked, briefly describe what AI assisted with (e.g., code generation, refactoring, tests, documentation) and confirm you have reviewed and understood the changes.

Claude helped me understand the right-hand-rule concept, scope the fix, and draft this description for me to edit. All testing — the Shapely reproduction, the DuckDB attempt, and the orient() verification — I ran myself in my own Jupyter notebook (screenshots attached). I've read through the change and understand what it does.

## Checklist before requesting a review

- 📖 Read the Tasking Manager Contributing Guide: <https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.

## [optional] What gif best describes this PR or how it makes you feel?
