### PR TITLE
fix: return 404 instead of 500 when a mapping level is missing

### DIFF
--- a/backend/services/mapping_levels.py
+++ b/backend/services/mapping_levels.py
@@ -23,10 +23,10 @@ class MappingLevelService:
 
     @staticmethod
     async def _single_record(
-        mapping_level: MappingLevel, db: Database
+        mapping_level: MappingLevel, db: Database, **not_found_details
     ) -> MappingLevelDTO:
         if mapping_level is None:
-            raise NotFound(sub_code="MAPPING_LEVEL_NOT_FOUND", mapping_level_id=id)
+            raise NotFound(sub_code="MAPPING_LEVEL_NOT_FOUND", **not_found_details)
 
         dto = mapping_level.as_dto()
         dto.required_badges = await MappingLevelService.get_associated_badges(
@@ -39,7 +39,9 @@ class MappingLevelService:
     async def get_by_id(id: int, db: Database) -> MappingLevelDTO:
         mapping_level = await MappingLevel.get_by_id(id, db)
 
-        return await MappingLevelService._single_record(mapping_level, db)
+        return await MappingLevelService._single_record(
+            mapping_level, db, mapping_level_id=id
+        )
 
     @staticmethod
     async def get_associated_badges(id: int, db: Database) -> List[MappingBadgeDTO]:
@@ -51,7 +53,9 @@ class MappingLevelService:
     async def get_by_name(name: str, db: Database) -> MappingLevel:
         mapping_level = await MappingLevel.get_by_name(name, db)
 
-        return await MappingLevelService._single_record(mapping_level, db)
+        return await MappingLevelService._single_record(
+            mapping_level, db, mapping_level_name=name
+        )
 
     @staticmethod
     async def create(data: MappingLevelCreateDTO, db: Database) -> MappingLevelDTO:

--- a/tests/api/unit/services/mapping_levels/test_mapping_level_service.py
+++ b/tests/api/unit/services/mapping_levels/test_mapping_level_service.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from backend.exceptions import Conflict
@@ -69,6 +71,28 @@ class TestMappingLevelService:
         assert levels.levels[0].name == "BEGINNER"
         assert levels.levels[1].name == "INTERMEDIATE"
         assert levels.levels[2].name == "ADVANCED"
+
+    async def test_get_by_id_not_found_reports_the_requested_id(self):
+        # Act
+        with pytest.raises(NotFound) as e:
+            await MappingLevelService.get_by_id(999999, self.db)
+
+        # Assert
+        assert e.value.detail["error"]["details"] == {"mapping_level_id": 999999}
+        # the exception handler serializes detail to JSON, so an unserializable
+        # value here turns the 404 into a 500
+        json.dumps(e.value.detail)
+
+    async def test_get_by_name_not_found_reports_the_requested_name(self):
+        # Act
+        with pytest.raises(NotFound) as e:
+            await MappingLevelService.get_by_name("NO SUCH LEVEL", self.db)
+
+        # Assert
+        assert e.value.detail["error"]["details"] == {
+            "mapping_level_name": "NO SUCH LEVEL"
+        }
+        json.dumps(e.value.detail)
 
     async def test_create_requires_badges(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

None found — spotted while reading `backend/services/mapping_levels.py`.

## Describe this PR

`MappingLevelService._single_record` raises

```python
raise NotFound(sub_code="MAPPING_LEVEL_NOT_FOUND", mapping_level_id=id)
```

but `_single_record(mapping_level, db)` has no `id` parameter, so `id` resolves to
the Python builtin. The 404's `details` payload ends up holding a function object,
and `JSONResponse` cannot serialize it — so the failure happens *inside* the
`HTTPException` handler and the request ends as a 500 with a raw traceback body
instead of a 404.

Both callers are affected: `get_by_id` and `get_by_name`.

Before, against a level id that doesn't exist:

```
GET /api/v2/levels/999999/ -> 500
body: Traceback (most recent call last): ... TypeError: Object of type
builtin_function_or_method is not JSON serializable
```

After:

```
GET /api/v2/levels/999999/ -> 404
{"error":{"code":404,"sub_code":"MAPPING_LEVEL_NOT_FOUND","message":"MAPPING_LEVEL_NOT_FOUND","details":{"mapping_level_id":999999}}}
```

The fix passes the identifier that was actually looked up down from the callers,
matching the `<thing>_id=` / `permalink=` convention used elsewhere
(`partner.py`, `licenses.py`, `project.py`).

## Screenshots

N/A — backend only.

## Alternative Approaches Considered

Dropping the kwarg entirely would also stop the 500, but it throws away the
identifier the caller asked for; the rest of the codebase includes it.

## Review Guide

Two regression tests added to
`tests/api/unit/services/mapping_levels/test_mapping_level_service.py`. They
assert the actual value in `details` and also `json.dumps` the payload, so the
serialization failure is caught rather than only the exception type. The existing
`pytest.raises(NotFound)` assertions pass on the broken code, which is why this
went unnoticed.

`pytest tests/api/unit/` — 175 passed before, 177 after. `flake8` and
`black --check` clean.

## AI Disclosure

- [x] This PR was created with significant help from AI tools (e.g., Claude, Copilot, ChatGPT)

AI assisted with locating the bug, writing the fix and the two regression tests,
and running the suite and linters locally.
