### PR TITLE
fix(build-ci): bump build workflow version to 3.6.0

### DIFF
--- a/.github/workflows/build_ci_img.yml
+++ b/.github/workflows/build_ci_img.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   backend-ci-build:
-    uses: hotosm/gh-workflows/.github/workflows/image_build.yml@3.2.0
+    uses: hotosm/gh-workflows/.github/workflows/image_build.yml@3.6.0
     with:
       context: .
       build_target: ci


### PR DESCRIPTION
## What type of PR is this? (check all applicable)


- [x] 🤖 Build or CI

## Related Issue
- image build failed due to depreciation and removal of `aquasecurity/trivy-action@0.28.0` on [this action run](https://github.com/hotosm/tasking-manager/actions/runs/33476897850/job/99758382829?pr=7325)

## Describe this PR
- our build workflow already replaced `aquasecurity/trivy-action` with `anchore/scan-action`, so using one of those ob build workflow to fix this issue.
